### PR TITLE
test: validate trivial detection and needs-review bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+<!-- Test: Validating needs-review label bypass - this is a trivial docs change -->
+
 ## [1.4.0] - 2026-01-26
 
 ### Added


### PR DESCRIPTION
## Purpose

Test PR to validate:

1. **Trivial detection works** - This PR only changes docs (CHANGELOG.md), so it should be detected as trivial and skip full Claude review

2. **needs-review label bypass works** - When we add the `needs-review` label, it should:
   - Force full Claude review (not skip)
   - Use `track_progress: false` for labeled events (fix from PR #3)
   - Auto-remove the label after review

## Expected Behavior

| Step | Expected |
|------|----------|
| PR opens | Sticky comment: "Skipped (trivial changes)" |
| Add `needs-review` label | Full Claude review runs |
| After review | `needs-review` label removed |
| Workflow | No errors (track_progress disabled for labeled events) |

## Test PR - Will Delete After Validation