### PR TITLE
fix(eval): address PR #8 code review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         id: select-scenario
         run: |
           source pr-branch/tests/e2e/lib/scenario-selector.sh
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_NUMBER=$(echo "${{ github.event.pull_request.number }}" | grep -E '^[0-9]+$' || echo "0")
           SCENARIO_PATH=$(select_scenario "pr-branch/tests/e2e/scenarios" "${PR_NUMBER:-0}")
           SCENARIO_NAME=$(basename "$SCENARIO_PATH" .md)
           echo "scenario=tests/e2e/scenarios/${SCENARIO_NAME}.md" >> $GITHUB_OUTPUT
@@ -748,7 +748,7 @@ jobs:
         id: select-scenario
         run: |
           source pr-branch/tests/e2e/lib/scenario-selector.sh
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_NUMBER=$(echo "${{ github.event.pull_request.number }}" | grep -E '^[0-9]+$' || echo "0")
           SCENARIO_PATH=$(select_scenario "pr-branch/tests/e2e/scenarios" "${PR_NUMBER:-0}")
           SCENARIO_NAME=$(basename "$SCENARIO_PATH" .md)
           echo "scenario=tests/e2e/scenarios/${SCENARIO_NAME}.md" >> $GITHUB_OUTPUT

--- a/tests/e2e/evaluate.sh
+++ b/tests/e2e/evaluate.sh
@@ -233,7 +233,10 @@ if ! is_valid_json "$EVAL_RESULT"; then
     fi
 fi
 
-# Merge deterministic + LLM scores into final result
+# Merge deterministic scores (task_tracking, confidence, tdd_red) into LLM-scored
+# criteria, recalculate total score, and determine pass threshold (7/10).
+# Deterministic criteria are grep-based (free, reproducible); LLM scores subjective
+# criteria only (plan_mode, tdd_green, self_review, clean_code, design_system).
 EVAL_RESULT=$(echo "$EVAL_RESULT" | jq \
     --argjson det "$DETERMINISTIC_RESULT" \
     '

--- a/tests/e2e/lib/deterministic-checks.sh
+++ b/tests/e2e/lib/deterministic-checks.sh
@@ -64,6 +64,8 @@ check_tdd_red() {
     while IFS= read -r filepath; do
         line_num=$((line_num + 1))
         # Check if this is a test file
+        # Matches: *.test.ext, *.spec.ext (JS/TS/Python/Ruby/Java/Go/Rust)
+        # Also matches directories: tests/, test/, spec/, __tests__/
         if echo "$filepath" | grep -qE '(test|spec)\.(js|ts|jsx|tsx|py|rb|java|go|rs)$|tests/|test/|spec/|__tests__/'; then
             if [ -z "$first_test_line" ]; then
                 first_test_line="$line_num"

--- a/tests/e2e/lib/scenario-selector.sh
+++ b/tests/e2e/lib/scenario-selector.sh
@@ -38,10 +38,9 @@ select_scenario() {
     fi
 
     # For empty PR number (push events), use day-of-year for rotation
-    # Strip leading zeros to avoid octal interpretation
+    # Force base-10 interpretation to avoid octal issues (e.g., day 008/009)
     if [ -z "$pr_number" ]; then
-        pr_number=$(date +%j | sed 's/^0*//' )
-        pr_number=${pr_number:-0}
+        pr_number=$((10#$(date +%j)))
     fi
 
     # Round-robin: PR number mod scenario count


### PR DESCRIPTION
## Summary
- Octal-safe day-of-year conversion using `$((10#...))` instead of fragile `sed` strip
- PR_NUMBER numeric validation in CI to prevent shell injection
- Documented jq score-merge strategy in evaluate.sh (deterministic + LLM merge)
- Documented test file detection regex patterns in deterministic-checks.sh

## Context
Addresses suggestions #1, #3, #5, #6 from PR #8 code review.

## Test plan
- [x] 8/8 scenario rotation tests pass
- [x] 20/20 deterministic pre-check tests pass
- [x] YAML syntax validated
- [ ] CI passes on this PR