### PR TITLE
fix(ci): non-blocking cosmetic steps + flaky test guidance

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -119,6 +119,15 @@ During self-review, critique tests HARDER than app code:
 
 **Tests are the foundation.** Bad tests = false confidence = production bugs.
 
+## Flaky Test Recovery
+
+When a test fails intermittently:
+1. **Don't dismiss it** — "flaky" means "bug we haven't found yet"
+2. **Identify the layer** — test code? app code? environment?
+3. **Stress-test** — run the suspect test N times to reproduce reliably
+4. **Fix root cause** — don't just retry-and-pray
+5. **If CI infrastructure** — make cosmetic steps non-blocking, keep quality gates strict
+
 ## Scope Guard (Stay in Your Lane)
 
 **Only make changes directly related to the task.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,7 @@ jobs:
 
       - name: Build quick check comment message
         id: build-quick-message
+        continue-on-error: true   # Comment is cosmetic — don't fail the job
         run: |
           IS_BOOTSTRAPPING="${{ steps.compare.outputs.is_bootstrapping }}"
           BASELINE="${{ steps.compare.outputs.baseline }}"
@@ -725,6 +726,7 @@ jobs:
           fi
 
       - name: Comment quick check results on PR
+        continue-on-error: true   # Comment is cosmetic — don't fail the job
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: e2e-quick-check

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1658,6 +1658,36 @@ If tests fail:
 
 Debug it. Find root cause. Fix it properly. Tests ARE code.
 
+## Flaky Test Prevention
+
+**Flaky tests are bugs. Period.** They erode trust in the test suite, slow down teams, and mask real regressions.
+
+### Principles
+
+1. **Treat test code like app code** — same code review standards, same quality bar. Tests are first-class citizens, not afterthoughts.
+
+2. **Investigate every flaky failure** — never ignore a flaky test. It's a bug somewhere in one of three layers:
+   - **Test code** — shared state, not parallel-safe, timing assumptions, missing cleanup
+   - **App code** — race condition, unhandled edge case, non-deterministic behavior
+   - **Environment/infra** — CI runner flakiness, resource contention, external service instability
+
+3. **Stress-test new tests** — run new or modified tests N times before merge to sniff out flakiness early. A test that passes 1x but fails on run 50 has a bug.
+
+4. **Isolate testing environments** — sanitize state between tests. Don't share databases. Clean up properly. Each test should be independently runnable.
+
+5. **Address flakiness immediately** — momentum matters. The longer a flaky test lives, the more trust erodes and the harder root cause becomes to find.
+
+6. **Quarantine only if actively fixing** — quarantine is a temporary holding pen, not a permanent ignore. If a test is quarantined for more than a sprint, it needs attention or deletion.
+
+7. **Track flaky rates** — you can't fix what you don't measure. Know which tests are flaky and how often.
+
+### When the Bug Is in CI Infrastructure
+
+Sometimes the flakiness is genuinely in CI infrastructure (runner environment, GitHub Actions internals, third-party action bugs). When this happens:
+- **Make cosmetic steps non-blocking** — PR comments, notifications, and reports should use `continue-on-error: true`
+- **Keep quality gates strict** — the actual pass/fail decision must NOT have `continue-on-error`
+- **Separate "fail the build" from "nice to have"** — a missing PR comment is not a regression
+
 ## CI Feedback Loop (After Commit)
 
 **The SDLC doesn't end at local tests.** CI must pass too.

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -751,6 +751,67 @@ test_ci_autofix_no_ternary_newlines() {
 test_ci_autofix_max_turns
 test_ci_autofix_no_ternary_newlines
 
+# ============================================
+# CI Cosmetic Step Resilience Tests
+# ============================================
+# These tests ensure cosmetic CI steps (PR comments)
+# don't fail the build, while the real quality gate does.
+
+# Test 42: "Build quick check comment message" has continue-on-error
+test_quick_check_comment_continue_on_error() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "CI workflow file not found (needed for continue-on-error test)"
+        return
+    fi
+
+    # Check that the "Build quick check comment message" step has continue-on-error: true
+    if grep -A 2 "Build quick check comment message" "$WORKFLOW" | grep -q "continue-on-error: true"; then
+        pass "Build quick check comment message has continue-on-error: true"
+    else
+        fail "Build quick check comment message missing continue-on-error: true (cosmetic step can fail the build)"
+    fi
+}
+
+# Test 43: "Comment quick check results on PR" has continue-on-error
+test_quick_check_post_comment_continue_on_error() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "CI workflow file not found (needed for continue-on-error test)"
+        return
+    fi
+
+    # Check that the "Comment quick check results on PR" step has continue-on-error: true
+    if grep -A 2 "Comment quick check results on PR" "$WORKFLOW" | grep -q "continue-on-error: true"; then
+        pass "Comment quick check results on PR has continue-on-error: true"
+    else
+        fail "Comment quick check results on PR missing continue-on-error: true (cosmetic step can fail the build)"
+    fi
+}
+
+# Test 44: "Fail on regression" does NOT have continue-on-error
+test_fail_on_regression_no_continue_on_error() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "CI workflow file not found (needed for quality gate test)"
+        return
+    fi
+
+    # The quality gate must NOT have continue-on-error
+    if grep -A 2 "Fail on regression" "$WORKFLOW" | grep -q "continue-on-error"; then
+        fail "Fail on regression has continue-on-error (quality gate would be bypassed!)"
+    else
+        pass "Fail on regression does NOT have continue-on-error (quality gate intact)"
+    fi
+}
+
+test_quick_check_comment_continue_on_error
+test_quick_check_post_comment_continue_on_error
+test_fail_on_regression_no_continue_on_error
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- **Fix flaky CI**: `continue-on-error: true` on "Build quick check comment message" and "Comment quick check results on PR" steps — these are cosmetic (PR comments), not quality gates. The intermittent `npm ENOENT` error from runner environment pollution no longer blocks the build.
- **Quality gate preserved**: "Fail on regression" step has NO `continue-on-error` — it remains the actual gatekeeper based on `steps.compare.outputs.pass`.
- **Flaky test guidance**: Added "Flaky Test Prevention" section to wizard and skill — 7 principles (investigate every failure, stress-test new tests, quarantine only if actively fixing, track rates, etc.)
- **3 new tests (42-44)**: Verify continue-on-error configuration is correct on cosmetic steps and absent on the quality gate.

## Test plan
- [x] `./tests/test-workflow-triggers.sh` — 44/44 pass (including 3 new tests)
- [x] `./tests/test-analysis-schema.sh` — 8/8 pass
- [x] `./tests/test-version-logic.sh` — 6/6 pass
- [ ] CI validates workflow YAML and runs e2e-quick-check
- [ ] If flaky npm ENOENT occurs, verify it no longer fails the job