### PR TITLE
fix(daily-update): use structured_output + json-schema for analysis

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -128,15 +128,18 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
+          claude_args: |
+            --output-format json
+            --json-schema '{"type":"object","properties":{"version":{"type":"string"},"relevance":{"type":"string","enum":["HIGH","MEDIUM","LOW"]},"summary":{"type":"string"},"wizard_impact":{"type":"array","items":{"type":"object","properties":{"area":{"type":"string"},"description":{"type":"string"},"suggested_action":{"type":"string"},"files_affected":{"type":"array","items":{"type":"string"}}}}},"plugin_check":{"type":"object","properties":{"new_official_plugins":{"type":"array","items":{"type":"string"}},"replaces_custom":{"type":"array","items":{"type":"string"}}}},"reasoning":{"type":"string"}},"required":["version","relevance","summary","reasoning"]}'
 
       - name: Save analysis to file
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
         env:
           # Use env to safely pass potentially malicious content
-          ANALYSIS_RESPONSE: ${{ steps.analyze.outputs.response }}
+          ANALYSIS_OUTPUT: ${{ steps.analyze.outputs.structured_output }}
         run: |
           # Write to file via env var (safe from injection)
-          printf '%s' "$ANALYSIS_RESPONSE" > /tmp/analysis.json
+          printf '%s' "$ANALYSIS_OUTPUT" > /tmp/analysis.json
 
       - name: Parse analysis result
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- **Fix empty analysis**: `claude-code-action@v1` doesn't expose `outputs.response` — use `outputs.structured_output` with `--json-schema` instead
- **Root cause**: Analysis step ran Claude successfully but result was never captured, producing `[]` titles and blank relevance/summary in auto-update PRs

## What was broken
The `Analyze release with Claude` step successfully ran Claude and got a response, but:
1. `steps.analyze.outputs.response` doesn't exist in claude-code-action@v1
2. The action requires `--json-schema` in `claude_args` to populate `outputs.structured_output`
3. Without both, the analysis result is silently lost

## Fix
- Add `--output-format json` and `--json-schema` to the analysis step's `claude_args`
- Replace `outputs.response` with `outputs.structured_output`
- Schema matches the format defined in `analyze-release.md` prompt

## Test plan
- [x] 2 new tests (53-54) — validate correct output field and json-schema presence
- [x] All 54 workflow trigger tests pass
- [x] All other test suites pass
- [x] YAML validates cleanly
- [ ] After merge: re-trigger `gh workflow run daily-update.yml`, verify PR has populated relevance/summary