### PR TITLE
fix(daily-update): extract analysis from execution output file

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -128,18 +128,50 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: |
-            --output-format json
-            --json-schema '{"type":"object","properties":{"version":{"type":"string"},"relevance":{"type":"string","enum":["HIGH","MEDIUM","LOW"]},"summary":{"type":"string"},"wizard_impact":{"type":"array","items":{"type":"object","properties":{"area":{"type":"string"},"description":{"type":"string"},"suggested_action":{"type":"string"},"files_affected":{"type":"array","items":{"type":"string"}}}}},"plugin_check":{"type":"object","properties":{"new_official_plugins":{"type":"array","items":{"type":"string"}},"replaces_custom":{"type":"array","items":{"type":"string"}}}},"reasoning":{"type":"string"}},"required":["version","relevance","summary","reasoning"]}'
 
-      - name: Save analysis to file
+      - name: Extract analysis from execution output
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        env:
-          # Use env to safely pass potentially malicious content
-          ANALYSIS_OUTPUT: ${{ steps.analyze.outputs.structured_output }}
         run: |
-          # Write to file via env var (safe from injection)
-          printf '%s' "$ANALYSIS_OUTPUT" > /tmp/analysis.json
+          # claude-code-action saves Claude's response to this file
+          OUTPUT_FILE="${RUNNER_TEMP:-/tmp}/claude-execution-output.json"
+
+          if [ ! -f "$OUTPUT_FILE" ]; then
+            echo "::warning::No execution output file found"
+            echo '{"relevance":"LOW","summary":"Analysis unavailable"}' > /tmp/analysis.json
+            exit 0
+          fi
+
+          # Extract the last assistant text message which contains the JSON analysis
+          # The execution output is a JSON array of conversation messages
+          LAST_TEXT=$(jq -r '[.[] | select(.type == "text")] | last | .text // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TEXT" ]; then
+            # Try alternate format: array of role/content messages
+            LAST_TEXT=$(jq -r '[.[] | select(.role == "assistant")] | last | .content | if type == "array" then [.[] | select(.type == "text") | .text] | join("") else . end // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$LAST_TEXT" ]; then
+            echo "::warning::Could not extract text from execution output"
+            echo '{"relevance":"LOW","summary":"Analysis extraction failed"}' > /tmp/analysis.json
+            exit 0
+          fi
+
+          # Extract JSON from the text (may be wrapped in markdown code blocks)
+          echo "$LAST_TEXT" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/analysis.json 2>/dev/null
+
+          # If no code block found, try the raw text as JSON
+          if [ ! -s /tmp/analysis.json ]; then
+            echo "$LAST_TEXT" > /tmp/analysis.json
+          fi
+
+          # Validate it's parseable JSON
+          if ! jq empty /tmp/analysis.json 2>/dev/null; then
+            echo "::warning::Analysis output is not valid JSON"
+            echo '{"relevance":"LOW","summary":"Analysis produced non-JSON output"}' > /tmp/analysis.json
+          fi
+
+          echo "Analysis extracted successfully"
+          jq -r '.relevance // "unknown"' /tmp/analysis.json
 
       - name: Parse analysis result
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- **Fix empty analysis (take 2)**: Read Claude's response from the execution output file instead of non-existent action outputs
- **Root cause**: `claude-code-action@v1` doesn't expose `outputs.response` or `outputs.structured_output` in agent mode. The `--json-schema` approach crashed the SDK (exit code 1).

## What failed in the previous fix (PR #25)
PR #25 tried `outputs.structured_output` with `--json-schema` in `claude_args`. However:
1. `--json-schema` + `--output-format json` caused the Claude Code SDK to crash with exit code 1
2. Even if it worked, the action may not populate `structured_output` in workflow_dispatch mode

## New approach
Read the analysis from `claude-execution-output.json` — the file that `claude-code-action` always writes. This is the same pattern CI uses for reading simulation results.

The extraction step:
1. Reads the execution output JSON array
2. Extracts the last assistant text message  
3. Strips markdown code blocks if present
4. Validates the result is parseable JSON
5. Falls back gracefully if extraction fails

## Test plan
- [x] Test 54 updated to verify execution output file extraction
- [x] All 54 workflow trigger tests pass
- [x] YAML validates cleanly
- [ ] After merge: re-trigger `gh workflow run daily-update.yml`, verify PR has populated relevance/summary