### PR TITLE
fix(daily-update): read .result/.output from execution output

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -141,33 +141,35 @@ jobs:
             exit 0
           fi
 
-          # Extract the last assistant text message which contains the JSON analysis
-          # The execution output is a JSON array of conversation messages
-          LAST_TEXT=$(jq -r '[.[] | select(.type == "text")] | last | .text // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
+          # Extract Claude's text response from the execution output
+          # Format is a direct object with .result or .output field (same as pr-review.yml)
+          RESPONSE_TEXT=$(jq -r '.result // .output // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
 
-          if [ -z "$LAST_TEXT" ]; then
-            # Try alternate format: array of role/content messages
-            LAST_TEXT=$(jq -r '[.[] | select(.role == "assistant")] | last | .content | if type == "array" then [.[] | select(.type == "text") | .text] | join("") else . end // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
-          fi
-
-          if [ -z "$LAST_TEXT" ]; then
+          if [ -z "$RESPONSE_TEXT" ]; then
             echo "::warning::Could not extract text from execution output"
+            echo "Keys found: $(jq -r 'keys | join(", ")' "$OUTPUT_FILE" 2>/dev/null || echo "unknown")"
             echo '{"relevance":"LOW","summary":"Analysis extraction failed"}' > /tmp/analysis.json
             exit 0
           fi
 
-          # Extract JSON from the text (may be wrapped in markdown code blocks)
-          echo "$LAST_TEXT" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/analysis.json 2>/dev/null
+          # The response text contains JSON (possibly wrapped in markdown code blocks)
+          # Try extracting from ```json ... ``` block first
+          echo "$RESPONSE_TEXT" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/analysis.json 2>/dev/null
 
           # If no code block found, try the raw text as JSON
           if [ ! -s /tmp/analysis.json ]; then
-            echo "$LAST_TEXT" > /tmp/analysis.json
+            echo "$RESPONSE_TEXT" > /tmp/analysis.json
           fi
 
           # Validate it's parseable JSON
           if ! jq empty /tmp/analysis.json 2>/dev/null; then
-            echo "::warning::Analysis output is not valid JSON"
-            echo '{"relevance":"LOW","summary":"Analysis produced non-JSON output"}' > /tmp/analysis.json
+            echo "::warning::Analysis output is not valid JSON, trying to extract JSON object"
+            # Last resort: grep out a JSON object from the text
+            echo "$RESPONSE_TEXT" | grep -o '{.*}' | tail -1 > /tmp/analysis.json 2>/dev/null
+            if ! jq empty /tmp/analysis.json 2>/dev/null; then
+              echo "::warning::Could not find valid JSON in analysis response"
+              echo '{"relevance":"LOW","summary":"Analysis produced non-JSON output"}' > /tmp/analysis.json
+            fi
           fi
 
           echo "Analysis extracted successfully"


### PR DESCRIPTION
## Summary
- **Fix analysis extraction**: Read `.result // .output` from execution output (not conversation array selectors)
- **Root cause**: Execution output is a direct object `{result, output, duration, ...}` not a message array

## What happened
PR #26 added extraction from `claude-execution-output.json` but used array selectors (`.[] | select(.type == "text")`) which don't match the actual file format. The file is a direct object — same format as pr-review.yml already parses with `.result // .output`.

## Test plan
- [x] All 54 tests pass
- [x] YAML validates
- [ ] After merge: re-trigger `gh workflow run daily-update.yml`, verify populated summary