### PR TITLE
feat(workflows): enable monthly-research.yml schedule + fix permission (Item 23 Phase 3)

### DIFF
--- a/.github/workflows/monthly-research.yml
+++ b/.github/workflows/monthly-research.yml
@@ -1,10 +1,13 @@
 name: Monthly Research Deep Dive
 
 on:
-  workflow_dispatch:  # Auto-schedule disabled until roadmap items 15-22 complete
+  schedule:
+    - cron: '0 11 1 * *'  # 11 AM UTC on the 1st of each month
+  workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
   issues: write
   id-token: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,12 @@ All notable changes to the SDLC Wizard.
 - `error_max_turns` on hard scenarios — bumped from 45 to 55
 - Autofix can't push workflow files — added `workflows: write` permission
 - `git push` silent error swallowing in `weekly-community.yml` — removed `|| echo` fallback
+- Missing `pull-requests: write` permission in `monthly-research.yml` — e2e-test job creates PRs but permission wasn't declared
 - Workflow input validation audit — removed `prompt_file`, `direct_prompt`, `model` invalid inputs across all 3 auto-update workflows
 - `outputs.response` doesn't exist — read from execution output file instead
 
 ### Changed
+- `monthly-research.yml` schedule enabled (1st of month, 11 AM UTC) — Item 23 Phase 3
 - `weekly-community.yml` schedule enabled (Mondays 10 AM UTC) — Item 23 Phase 2
 - `daily-update.yml` schedule re-enabled (9 AM UTC) — Item 23 Phase 1
 - All auto-update workflows create PRs (removed "LOW → direct commit" path)

--- a/CI_CD.md
+++ b/CI_CD.md
@@ -7,7 +7,7 @@
 | `ci.yml` | PR, push to main | Validation, tests, E2E evaluation |
 | `daily-update.yml` | Daily (9 AM UTC) + manual | Check for Claude Code updates |
 | `weekly-community.yml` | Weekly (Mondays 10 AM UTC) + manual | Scan community for patterns |
-| `monthly-research.yml` | Manual only (schedule paused) | Deep research and trends |
+| `monthly-research.yml` | Monthly (1st, 11 AM UTC) + manual | Deep research and trends |
 | `ci-autofix.yml` | CI fail / review findings | Auto-fix loop |
 | `pr-review.yml` | PR opened/ready/labeled | AI code review |
 
@@ -177,8 +177,8 @@ Both use Tier 1 (quick) + Tier 2 (full statistical) evaluation.
 - E2E tests research-suggested improvements (Tier 2)
 
 ### Runs On
-- Manual trigger only (workflow_dispatch)
-- Schedule paused until roadmap items 15-22 complete
+- Monthly schedule: 11 AM UTC on the 1st (`cron: '0 11 1 * *'`)
+- Manual trigger also available (workflow_dispatch)
 
 ## CI Auto-Fix Workflow (`ci-autofix.yml`)
 

--- a/plans/AUTO_SELF_UPDATE.md
+++ b/plans/AUTO_SELF_UPDATE.md
@@ -64,7 +64,7 @@ Detect something new → Suggest changes → Test with E2E → Create PR with re
 - **E2E Testing:** Baseline vs with-changes comparison (Tier 2)
 
 ### Monthly Research Deep Dive (`.github/workflows/monthly-research.yml`)
-- **Trigger:** Manual dispatch only (schedule paused until roadmap items 15-22 complete)
+- **Trigger:** Monthly schedule (1st, 11 AM UTC) + manual dispatch
 - **Checks:** Academic papers, major announcements, deep community analysis
 - **Action:** Creates issue with trend report and recommendations
 - **E2E Testing:** Baseline vs with-changes comparison (Tier 2)
@@ -85,7 +85,7 @@ Detect something new → Suggest changes → Test with E2E → Create PR with re
 |---------|----------|--------------|
 | Daily (9 AM UTC) | daily-update.yml | Check releases → Always PR |
 | Weekly (Mondays 10 AM UTC) | weekly-community.yml | Scan community → Issue |
-| Manual only (schedule paused) | monthly-research.yml | Deep research → Issue |
+| Monthly (1st, 11 AM UTC) | monthly-research.yml | Deep research → Issue |
 | On PR | ci.yml | Run tests + E2E eval |
 | On PR | pr-review.yml | AI code review |
 | On CI fail / review findings | ci-autofix.yml | Auto-fix loop |
@@ -783,9 +783,9 @@ CI runs ──► FAIL ──► ci-autofix ──► Claude fixes ──► com
 | 19 | Real-world scenarios | MED | Extract from public repos like SWE-bench for realistic E2E testing | DONE |
 | 20 | Observability/tracing | LOW | Structured logging for debugging score changes across runs | DONE |
 | 22 | Color-coded PR comments | LOW | Add visual indicators to E2E scoring PR comments - green/red/yellow emoji or status badges for PASS/WARN/FAIL per criterion. Makes it easier to scan results at a glance instead of reading raw numbers. | DONE — emoji indicators in ci.yml |
-| 23 | Phased workflow re-enablement | HIGH | Re-enable daily → weekly → monthly schedules. Phase 1: daily (PR #35, merged). Phase 2: weekly. Phase 3: monthly. All schedules enabled before Tier 2 audit so audit covers full system. | IN PROGRESS — Phases 1+2 DONE (daily + weekly), Phase 3 next |
+| 23 | Phased workflow re-enablement | HIGH | Re-enable daily → weekly → monthly schedules. Phase 1: daily (PR #35). Phase 2: weekly (PR #37). Phase 3: monthly (PR #38). All schedules enabled before Tier 2 audit so audit covers full system. | DONE — all 3 schedules enabled |
 | 24 | Tier 2 E2E full suite audit | HIGH | Run full Tier 2 evaluation (`merge-ready` label) end-to-end. Verify 5-trial statistical evaluation, 95% CI, pairwise tiebreaker, CUSUM, SDP, score history persistence, and PR comment formatting all work correctly in CI. This is the final validation gate before mutation testing. | PLANNED |
-| 25 | Full system audit | HIGH | Comprehensive audit of all workflows, tests, scripts, and docs after Tier 2 passes. Verify every feature works as documented. Catch any remaining silent failures or stale assumptions. Establish as recurring practice — audit on every PR going forward (lightweight version via PR review workflow, thorough version periodically). | PLANNED |
+| 25 | Full system audit | HIGH | Comprehensive audit of all workflows, tests, scripts, and docs after Tier 2 passes. Verify every feature works as documented. Catch any remaining silent failures or stale assumptions. Known bug: E2E "apply" step in daily/weekly/monthly doesn't propagate changes to test fixture — baseline vs candidate always tests same code, verdict always STABLE (useless comparison). Fix in this audit. | PLANNED |
 | 21 | Mutation testing | MED | Two tracks: (a) Wizard recommendation - detect stack and offer mutation testing setup (Stryker for JS/TS, mutmut for Python, pitest for Java, cargo-mutants for Rust). (b) Our own CI - explore "SDLC document mutation testing": mutate wizard doc sections, run E2E, verify score drops to prove which sections are load-bearing. Gate: Items 24-25 must pass first. | PLANNED — last in execution order, after 24-25 |
 
 ### Item 15: Eval Framework Improvements (Targeted, Not Framework Adoption)
@@ -1008,6 +1008,6 @@ _Updated: 2026-02-15_
 
 **Summary:** 6/8 items DONE, 1 SKIPPED (by design), 1 PLANNED (last in order).
 
-**Item 23 decision (updated 2026-02-16):** Phase 1 (daily) merged in PR #35. Phase 2 (weekly) in PR. Phase 3 (monthly) next — enable all schedules before auditing so the audit covers the fully-live system.
+**Item 23 decision (updated 2026-02-16):** All 3 schedules enabled — daily (PR #35), weekly (PR #37), monthly (PR #38). System is fully live. Ready for audit.
 
-**Execution order (updated 2026-02-16):** Item 23 Phase 2+3 (weekly + monthly schedules) → Item 24 (Tier 2 full suite audit) → Item 25 (full system audit) → Item 21 (mutation testing, last). Rationale: audit after all schedules are live so nothing is missed.
+**Execution order (updated 2026-02-16):** Item 23 DONE → Item 24 (Tier 2 full suite audit) → Item 25 (full system audit) → Item 21 (mutation testing, last). Rationale: audit after all schedules are live so nothing is missed.

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -96,14 +96,14 @@ test_weekly_has_schedule() {
     fi
 }
 
-# Test 36: Monthly workflow does NOT have active schedule trigger
-test_monthly_no_schedule() {
+# Test 36: Monthly workflow has active schedule trigger (Item 23 Phase 3)
+test_monthly_has_schedule() {
     WORKFLOW="$REPO_ROOT/.github/workflows/monthly-research.yml"
 
-    if grep -q "schedule:" "$WORKFLOW"; then
-        fail "Monthly workflow has active schedule trigger (should be paused)"
+    if grep -q "schedule:" "$WORKFLOW" && grep -q "cron:" "$WORKFLOW"; then
+        pass "Monthly workflow has active schedule with cron trigger"
     else
-        pass "Monthly workflow schedule is paused (manual dispatch only)"
+        fail "Monthly workflow missing schedule trigger (should have cron for Item 23)"
     fi
 }
 
@@ -613,7 +613,7 @@ test_weekly_dispatch
 test_monthly_dispatch
 test_daily_has_schedule
 test_weekly_has_schedule
-test_monthly_no_schedule
+test_monthly_has_schedule
 test_state_file_path
 test_state_file_roundtrip
 test_workflow_permissions
@@ -1745,6 +1745,29 @@ test_tier1_regression_threshold() {
     fi
 }
 
+# ============================================
+# Monthly-Research Permission Tests
+# ============================================
+# Ensure monthly-research has the permissions its
+# e2e-test job needs (creates PRs via peter-evans/create-pull-request).
+
+# Test 77: monthly-research has pull-requests: write permission
+test_monthly_has_pr_write_permission() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/monthly-research.yml"
+
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "monthly-research.yml not found"
+        return
+    fi
+
+    if grep -q 'pull-requests: write' "$WORKFLOW"; then
+        pass "monthly-research has pull-requests: write permission"
+    else
+        fail "monthly-research missing pull-requests: write permission (e2e-test creates PRs)"
+    fi
+}
+
+test_monthly_has_pr_write_permission
 test_tier1_regression_threshold
 test_ci_no_dead_token_extraction
 test_ci_score_history_committed


### PR DESCRIPTION
## Summary
- Enable cron schedule on `monthly-research.yml`: 1st of month, 11 AM UTC (`0 11 1 * *`)
- **BUG FIX**: Add missing `pull-requests: write` permission (e2e-test job creates PRs via `peter-evans/create-pull-request@v7` but permission wasn't declared — would silently fail)
- Flip test 36 to assert monthly workflow HAS schedule trigger
- Add test 77: regression test for `pull-requests: write` permission
- Mark Item 23 DONE in roadmap (all 3 schedules now enabled)
- Document known E2E fixture propagation bug in Item 25 description

## Bug Fix
**Missing `pull-requests: write` permission** — The `e2e-test` job in `monthly-research.yml` uses `peter-evans/create-pull-request@v7` to create PRs with research-suggested improvements, but the workflow only declared `contents: write`, `issues: write`, and `id-token: write`. Without `pull-requests: write`, the PR creation step would silently fail.

## Note
This PR will have a minor merge conflict with PR #37 (weekly schedule) in `CHANGELOG.md`, `CI_CD.md`, `AUTO_SELF_UPDATE.md`, and `test-workflow-triggers.sh`. Both PRs modify adjacent lines. Resolve by keeping both changes.

## Test plan
- [x] `./tests/test-workflow-triggers.sh` — 77/77 passing (test 36 flipped + test 77 added)
- [x] YAML validation passes
- [x] `grep 'pull-requests: write'` confirms permission present
- [ ] CI validates on PR