### PR TITLE
fix(ci): fresh ci-self-heal.yml to restore workflow_run trigger

### DIFF
--- a/.github/workflows/ci-self-heal.yml
+++ b/.github/workflows/ci-self-heal.yml
@@ -1,0 +1,355 @@
+name: CI Auto-Fix
+# Self-healing loop: CI/Review fails -> Claude fixes -> re-triggers -> validates
+
+on:
+  workflow_run:
+    workflows: ["CI", "PR Code Review"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+  workflows: write
+
+env:
+  MAX_AUTOFIX_RETRIES: 3
+  AUTOFIX_LEVEL: criticals
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    # Only run on PR branches (never main), only on failure or review findings
+    if: |
+      github.event.workflow_run.head_branch != 'main' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      (
+        (github.event.workflow_run.name == 'CI' && github.event.workflow_run.conclusion == 'failure') ||
+        (github.event.workflow_run.name == 'PR Code Review' && github.event.workflow_run.conclusion == 'success')
+      )
+
+    steps:
+      - name: Determine trigger source
+        id: source
+        run: |
+          echo "workflow_name=${{ github.event.workflow_run.name }}" >> $GITHUB_OUTPUT
+          echo "conclusion=${{ github.event.workflow_run.conclusion }}" >> $GITHUB_OUTPUT
+          echo "head_branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          echo "head_sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+          echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.event.workflow_run.name }}" = "CI" ]; then
+            echo "mode=ci-failure" >> $GITHUB_OUTPUT
+            echo "Triggered by CI failure on branch ${{ github.event.workflow_run.head_branch }}"
+          else
+            echo "mode=review-findings" >> $GITHUB_OUTPUT
+            echo "Triggered by PR Code Review on branch ${{ github.event.workflow_run.head_branch }}"
+          fi
+
+      # Get the PR number from the triggering workflow run
+      - name: Get PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find PR for this branch
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ steps.source.outputs.head_branch }}&state=open" \
+            --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch ${{ steps.source.outputs.head_branch }}, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Found PR #$PR_NUMBER"
+
+      # Check retry count from git history
+      - name: Check retry count
+        if: steps.pr.outputs.skip != 'true'
+        id: retries
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.source.outputs.head_branch }}
+          fetch-depth: 0
+
+      - name: Count previous autofix attempts
+        if: steps.pr.outputs.skip != 'true'
+        id: count
+        run: |
+          AUTOFIX_COUNT=$(git log origin/main..HEAD --oneline --grep='\[autofix' | wc -l | tr -d ' ')
+          echo "count=$AUTOFIX_COUNT" >> $GITHUB_OUTPUT
+          echo "Previous autofix attempts: $AUTOFIX_COUNT / $MAX_AUTOFIX_RETRIES"
+
+          if [ "$AUTOFIX_COUNT" -ge "$MAX_AUTOFIX_RETRIES" ]; then
+            echo "exceeded=true" >> $GITHUB_OUTPUT
+            echo "Max retries ($MAX_AUTOFIX_RETRIES) reached, will not attempt fix"
+          else
+            echo "exceeded=false" >> $GITHUB_OUTPUT
+            ATTEMPT=$((AUTOFIX_COUNT + 1))
+            echo "attempt=$ATTEMPT" >> $GITHUB_OUTPUT
+          fi
+
+      # Post max-retries comment and stop
+      - name: Post max retries comment
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.pr_number }}
+          header: ci-autofix
+          message: |
+            ## CI Auto-Fix: Max Retries Reached
+
+            Auto-fix has been attempted **${{ steps.count.outputs.count }}/${{ env.MAX_AUTOFIX_RETRIES }}** times without resolving all issues.
+
+            **Manual intervention required.** Please review the failures and fix them manually.
+
+            | Detail | Value |
+            |--------|-------|
+            | Source | ${{ steps.source.outputs.workflow_name }} |
+            | Branch | `${{ steps.source.outputs.head_branch }}` |
+            | Last Run | ${{ steps.source.outputs.run_id }} |
+
+      # === CI FAILURE MODE ===
+      - name: Download CI failure logs
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true' &&
+          steps.source.outputs.mode == 'ci-failure'
+        id: ci-logs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Downloading failure logs from CI run ${{ steps.source.outputs.run_id }}..."
+          gh run view ${{ steps.source.outputs.run_id }} --log-failed > /tmp/ci-failure-logs.txt 2>&1 || true
+
+          # Truncate to last 200 lines to stay within prompt limits
+          tail -200 /tmp/ci-failure-logs.txt > /tmp/ci-failure-context.txt
+          echo "Captured $(wc -l < /tmp/ci-failure-context.txt) lines of failure context"
+
+      # === REVIEW FINDINGS MODE ===
+      - name: Fetch review findings
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true' &&
+          steps.source.outputs.mode == 'review-findings'
+        id: review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ steps.pr.outputs.pr_number }}"
+
+          # Fetch the claude-review sticky comment
+          REVIEW_BODY=$(gh api "repos/${{ github.repository }}/issues/$PR_NUM/comments" \
+            --jq '[.[] | select(.body | contains("claude-review") or contains("## PR Code Review"))] | last | .body // ""' 2>/dev/null || echo "")
+
+          if [ -z "$REVIEW_BODY" ]; then
+            echo "No review comment found, skipping"
+            echo "has_findings=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # AUTOFIX_LEVEL=ci-only skips all review findings regardless of verdict
+          if [ "$AUTOFIX_LEVEL" = "ci-only" ]; then
+            echo "AUTOFIX_LEVEL=ci-only: skipping all review findings"
+            echo "has_findings=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Parse review for findings
+          HAS_CRITICALS=false
+          HAS_SUGGESTIONS=false
+
+          if echo "$REVIEW_BODY" | grep -q "Critical (must fix)"; then
+            if ! echo "$REVIEW_BODY" | grep -A 1 "Critical (must fix)" | grep -q "None\|No critical\|N/A"; then
+              HAS_CRITICALS=true
+            fi
+          fi
+
+          if echo "$REVIEW_BODY" | grep -q "Suggestions (nice to have)"; then
+            if ! echo "$REVIEW_BODY" | grep -A 1 "Suggestions (nice to have)" | grep -q "None\|No suggestions\|N/A"; then
+              HAS_SUGGESTIONS=true
+            fi
+          fi
+
+          # Determine what to act on based on AUTOFIX_LEVEL
+          SKIP=false
+          case "$AUTOFIX_LEVEL" in
+            criticals)
+              if [ "$HAS_CRITICALS" = false ]; then
+                SKIP=true
+              fi
+              ;;
+            all-findings)
+              if [ "$HAS_CRITICALS" = false ] && [ "$HAS_SUGGESTIONS" = false ]; then
+                SKIP=true
+              fi
+              ;;
+            *)
+              echo "WARNING: Unknown AUTOFIX_LEVEL='$AUTOFIX_LEVEL' (valid: ci-only, criticals, all-findings), defaulting to criticals"
+              if [ "$HAS_CRITICALS" = false ]; then
+                SKIP=true
+              fi
+              ;;
+          esac
+
+          if [ "$SKIP" = true ]; then
+            echo "No findings to address at level=$AUTOFIX_LEVEL (criticals=$HAS_CRITICALS, suggestions=$HAS_SUGGESTIONS)"
+            echo "has_findings=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Review has findings: criticals=$HAS_CRITICALS, suggestions=$HAS_SUGGESTIONS (level=$AUTOFIX_LEVEL)"
+
+          # Has findings that need fixing
+          echo "has_findings=true" >> $GITHUB_OUTPUT
+          printf '%s' "$REVIEW_BODY" > /tmp/review-findings.md
+          echo "Review findings saved ($(wc -c < /tmp/review-findings.md) bytes)"
+
+      # === CLAUDE FIX (both modes) ===
+      - name: Run Claude to fix issues
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true' &&
+          (
+            steps.source.outputs.mode == 'ci-failure' ||
+            (steps.source.outputs.mode == 'review-findings' && steps.review.outputs.has_findings == 'true')
+          )
+        id: fix
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --max-turns 30
+            --allowedTools "Read,Edit,Write,Bash(./tests/*),Bash(python3 *),Glob,Grep"
+          prompt: |
+            You are fixing issues found by CI or code review.
+            This is autofix attempt ${{ steps.count.outputs.attempt }}/${{ env.MAX_AUTOFIX_RETRIES }}.
+            Trigger mode: ${{ steps.source.outputs.mode }}
+
+            IMPORTANT RULES:
+            - Do NOT modify .github/workflows/ci-self-heal.yml
+            - Do NOT use EnterPlanMode or ExitPlanMode
+            - Use the Read tool to read files (NOT Bash with cat/find/ls)
+            - You do NOT have access to gh or git CLI
+            - Focus only on fixing the reported issues
+            - Keep changes minimal and focused
+
+            ## What to fix
+
+            If trigger mode is "ci-failure":
+            - Use the Read tool to read /tmp/ci-failure-context.txt
+            - Diagnose the root cause and fix the code
+
+            If trigger mode is "review-findings":
+            - Use the Read tool to read /tmp/review-findings.md
+            - Address all findings - criticals first, then suggestions
+            - Summarize: Critical fixes: [list], Suggestion fixes: [list]
+
+            After fixing, run relevant test scripts to verify your fixes.
+
+      # === COMMIT AND PUSH ===
+      - name: Detect token approach
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true' &&
+          (
+            steps.source.outputs.mode == 'ci-failure' ||
+            (steps.source.outputs.mode == 'review-findings' && steps.review.outputs.has_findings == 'true')
+          )
+        id: token
+        run: |
+          if [ -n "${{ secrets.CI_AUTOFIX_APP_ID }}" ] && [ -n "${{ secrets.CI_AUTOFIX_PRIVATE_KEY }}" ]; then
+            echo "approach=app" >> $GITHUB_OUTPUT
+            echo "Using GitHub App token approach"
+          else
+            echo "approach=pat" >> $GITHUB_OUTPUT
+            echo "Using GITHUB_TOKEN + workflow dispatch approach"
+          fi
+
+      - name: Generate GitHub App token
+        if: |
+          steps.token.outputs.approach == 'app' &&
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.CI_AUTOFIX_PRIVATE_KEY }}
+
+      - name: Commit and push fixes
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true' &&
+          (
+            steps.source.outputs.mode == 'ci-failure' ||
+            (steps.source.outputs.mode == 'review-findings' && steps.review.outputs.has_findings == 'true')
+          )
+        env:
+          GIT_TOKEN: ${{ steps.token.outputs.approach == 'app' && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          ATTEMPT="${{ steps.count.outputs.attempt }}"
+
+          # Check if there are actual changes to commit
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to commit, Claude may not have found a fix"
+            echo "committed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage and commit
+          git add -A
+          git commit -m "[autofix ${ATTEMPT}/${MAX_AUTOFIX_RETRIES}] fix: auto-fix from ${{ steps.source.outputs.mode }}"
+
+          # Push using token
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:${{ steps.source.outputs.head_branch }}
+
+          echo "committed=true" >> $GITHUB_OUTPUT
+          echo "Pushed autofix commit ${ATTEMPT}/${MAX_AUTOFIX_RETRIES}"
+
+      # Re-trigger CI if using GITHUB_TOKEN (app token push triggers naturally)
+      - name: Re-trigger CI via workflow dispatch
+        if: |
+          steps.token.outputs.approach == 'pat' &&
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Re-triggering CI via workflow_dispatch..."
+          gh workflow run ci.yml --ref ${{ steps.source.outputs.head_branch }} || true
+
+      # === STATUS COMMENT ===
+      - name: Post autofix status comment
+        if: |
+          steps.pr.outputs.skip != 'true' &&
+          steps.count.outputs.exceeded != 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.pr_number }}
+          header: ci-autofix
+          message: |
+            ## CI Auto-Fix: Attempt ${{ steps.count.outputs.attempt }}/${{ env.MAX_AUTOFIX_RETRIES }}
+
+            | Detail | Value |
+            |--------|-------|
+            | Source | ${{ steps.source.outputs.workflow_name }} (${{ steps.source.outputs.mode }}) |
+            | Branch | `${{ steps.source.outputs.head_branch }}` |
+            | Trigger Run | ${{ steps.source.outputs.run_id }} |
+            | Status | Fix pushed, CI re-triggered |
+
+            Waiting for CI to re-run. If all checks pass and review approves, this loop is complete.
+
+            ---
+            _Auto-fix powered by Claude Code. Max ${{ env.MAX_AUTOFIX_RETRIES }} attempts._

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -385,26 +385,26 @@ test_ci_allowed_tools_task_tracking() {
 # ============================================
 # CI Auto-Fix Workflow Tests
 # ============================================
-# These tests ensure the autofix.yml workflow
+# These tests ensure the ci-self-heal.yml workflow
 # is properly configured for the automated fix loop.
 
-# Test 22: autofix.yml file exists
+# Test 22: ci-self-heal.yml file exists
 test_ci_autofix_exists() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ -f "$WORKFLOW" ]; then
-        pass "autofix.yml file exists"
+        pass "ci-self-heal.yml file exists"
     else
-        fail "autofix.yml file not found"
+        fail "ci-self-heal.yml file not found"
     fi
 }
 
 # Test 23: ci-autofix triggers on workflow_run
 test_ci_autofix_workflow_run_trigger() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for trigger test)"
+        fail "ci-self-heal.yml file not found (needed for trigger test)"
         return
     fi
 
@@ -417,10 +417,10 @@ test_ci_autofix_workflow_run_trigger() {
 
 # Test 24: ci-autofix watches both CI and PR Code Review workflows
 test_ci_autofix_watches_both_workflows() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for workflows test)"
+        fail "ci-self-heal.yml file not found (needed for workflows test)"
         return
     fi
 
@@ -433,10 +433,10 @@ test_ci_autofix_watches_both_workflows() {
 
 # Test 25: ci-autofix has MAX_AUTOFIX_RETRIES config
 test_ci_autofix_max_retries() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for retries test)"
+        fail "ci-self-heal.yml file not found (needed for retries test)"
         return
     fi
 
@@ -449,10 +449,10 @@ test_ci_autofix_max_retries() {
 
 # Test 26: ci-autofix excludes main branch
 test_ci_autofix_excludes_main() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for branch exclusion test)"
+        fail "ci-self-heal.yml file not found (needed for branch exclusion test)"
         return
     fi
 
@@ -465,10 +465,10 @@ test_ci_autofix_excludes_main() {
 
 # Test 27: ci-autofix uses claude-code-action
 test_ci_autofix_uses_claude() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for claude action test)"
+        fail "ci-self-heal.yml file not found (needed for claude action test)"
         return
     fi
 
@@ -481,10 +481,10 @@ test_ci_autofix_uses_claude() {
 
 # Test 28: ci-autofix uses [autofix] commit tag pattern
 test_ci_autofix_commit_tag() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for commit tag test)"
+        fail "ci-self-heal.yml file not found (needed for commit tag test)"
         return
     fi
 
@@ -497,10 +497,10 @@ test_ci_autofix_commit_tag() {
 
 # Test 29: ci-autofix posts sticky PR comment
 test_ci_autofix_sticky_comment() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for sticky comment test)"
+        fail "ci-self-heal.yml file not found (needed for sticky comment test)"
         return
     fi
 
@@ -529,10 +529,10 @@ test_ci_workflow_dispatch() {
 
 # Test 31: ci-autofix reads review comment for findings
 test_ci_autofix_reads_review() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for review reading test)"
+        fail "ci-self-heal.yml file not found (needed for review reading test)"
         return
     fi
 
@@ -552,10 +552,10 @@ test_ci_autofix_reads_review() {
 
 # Test 32: ci-autofix prompt references /tmp/ci-failure-context.txt
 test_ci_autofix_prompt_failure_file() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for prompt file test)"
+        fail "ci-self-heal.yml file not found (needed for prompt file test)"
         return
     fi
 
@@ -568,10 +568,10 @@ test_ci_autofix_prompt_failure_file() {
 
 # Test 33: ci-autofix prompt references /tmp/review-findings.md
 test_ci_autofix_prompt_review_file() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for prompt file test)"
+        fail "ci-self-heal.yml file not found (needed for prompt file test)"
         return
     fi
 
@@ -653,10 +653,10 @@ test_ci_max_turns_sufficient
 
 # Test 37: ci-autofix checks for suggestions (not just criticals)
 test_ci_autofix_checks_suggestions() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for suggestions test)"
+        fail "ci-self-heal.yml file not found (needed for suggestions test)"
         return
     fi
 
@@ -669,10 +669,10 @@ test_ci_autofix_checks_suggestions() {
 
 # Test 38: ci-autofix prompt addresses all findings
 test_ci_autofix_prompt_all_findings() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for prompt test)"
+        fail "ci-self-heal.yml file not found (needed for prompt test)"
         return
     fi
 
@@ -685,10 +685,10 @@ test_ci_autofix_prompt_all_findings() {
 
 # Test 39: ci-autofix prompt tells Claude to use Read tool (not Bash) for context files
 test_ci_autofix_prompt_read_tool() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for Read tool test)"
+        fail "ci-self-heal.yml file not found (needed for Read tool test)"
         return
     fi
 
@@ -709,18 +709,18 @@ test_ci_autofix_prompt_read_tool
 
 # Test 40: ci-autofix --max-turns >= 30
 test_ci_autofix_max_turns() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for max-turns test)"
+        fail "ci-self-heal.yml file not found (needed for max-turns test)"
         return
     fi
 
-    # Extract --max-turns value from autofix.yml
+    # Extract --max-turns value from ci-self-heal.yml
     TURNS=$(grep -oE '\-\-max-turns [0-9]+' "$WORKFLOW" | grep -oE '[0-9]+')
 
     if [ -z "$TURNS" ]; then
-        fail "autofix.yml missing --max-turns flag"
+        fail "ci-self-heal.yml missing --max-turns flag"
         return
     fi
 
@@ -733,10 +733,10 @@ test_ci_autofix_max_turns() {
 
 # Test 41: ci-autofix prompt has no literal \n ternary pattern
 test_ci_autofix_no_ternary_newlines() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml file not found (needed for ternary test)"
+        fail "ci-self-heal.yml file not found (needed for ternary test)"
         return
     fi
 
@@ -1552,17 +1552,17 @@ test_ci_score_history_committed() {
 
 # Test 69: ci-autofix has no show_full_output input
 test_ci_autofix_no_show_full_output() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml not found"
+        fail "ci-self-heal.yml not found"
         return
     fi
 
     if grep -q 'show_full_output' "$WORKFLOW"; then
-        fail "autofix.yml still has invalid 'show_full_output' input"
+        fail "ci-self-heal.yml still has invalid 'show_full_output' input"
     else
-        pass "autofix.yml has no invalid 'show_full_output' input"
+        pass "ci-self-heal.yml has no invalid 'show_full_output' input"
     fi
 }
 
@@ -1656,9 +1656,9 @@ test_ci_score_history_push_explicit_ref() {
     fi
 }
 
-# Test 73: autofix.yml has workflows: write permission (needed to push workflow file changes)
+# Test 73: ci-self-heal.yml has workflows: write permission (needed to push workflow file changes)
 test_ci_autofix_has_workflows_write() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
         fail "ci-autofix workflow file not found"
@@ -1668,9 +1668,9 @@ test_ci_autofix_has_workflows_write() {
     # Without workflows: write, autofix can't push fixes to .github/workflows/ files.
     # Git rejects with: "refusing to allow a GitHub App to create or update workflow without workflows permission"
     if grep -q 'workflows: write' "$WORKFLOW"; then
-        pass "autofix.yml has workflows: write permission (can push workflow file fixes)"
+        pass "ci-self-heal.yml has workflows: write permission (can push workflow file fixes)"
     else
-        fail "autofix.yml missing workflows: write permission (can't push workflow file fixes)"
+        fail "ci-self-heal.yml missing workflows: write permission (can't push workflow file fixes)"
     fi
 }
 
@@ -1767,12 +1767,12 @@ test_monthly_has_pr_write_permission() {
     fi
 }
 
-# Test 78: autofix.yml has name: field (required for workflow_run registry)
+# Test 78: ci-self-heal.yml has name: field (required for workflow_run registry)
 test_ci_autofix_has_name_field() {
-    WORKFLOW="$REPO_ROOT/.github/workflows/autofix.yml"
+    WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
 
     if [ ! -f "$WORKFLOW" ]; then
-        fail "autofix.yml not found"
+        fail "ci-self-heal.yml not found"
         return
     fi
 
@@ -1787,11 +1787,11 @@ print(wf.get('name', ''))
 ")
 
     if [ "$YAML_NAME" = "CI Auto-Fix" ]; then
-        pass "autofix.yml has correct name: field ('CI Auto-Fix')"
+        pass "ci-self-heal.yml has correct name: field ('CI Auto-Fix')"
     elif [ -n "$YAML_NAME" ]; then
-        fail "autofix.yml name: field is '$YAML_NAME' (expected 'CI Auto-Fix')"
+        fail "ci-self-heal.yml name: field is '$YAML_NAME' (expected 'CI Auto-Fix')"
     else
-        fail "autofix.yml missing name: field (workflow_run registry will use file path instead)"
+        fail "ci-self-heal.yml missing name: field (workflow_run registry will use file path instead)"
     fi
 }
 


### PR DESCRIPTION
## Summary
GitHub permanently corrupted the workflow registry for both `ci-autofix.yml` (ID 232420762) and `autofix.yml` (ID 235121432). Neither could receive `workflow_run` events.

**Diagnostic proof:** A fresh `test-workflow-run.yml` received `workflow_run` events correctly (PR #42). The issue is specific to files that were renamed/modified from the original corrupted entry.

**Fix:** Delete `autofix.yml` and create `ci-self-heal.yml` at a brand new path. This guarantees a fresh workflow ID with no corrupted registry metadata. Also removed non-ASCII characters (Unicode arrows/em dashes) that may have contributed to GitHub's parser silently failing.

## IMPORTANT: Use rebase merge (not squash)
The delete (commit 1) and create (commit 2) must be separate commits.

## Changes
- Delete `.github/workflows/autofix.yml` (corrupted)
- Create `.github/workflows/ci-self-heal.yml` (identical logic, ASCII-only, new identity)
- Update all 78 tests to reference new filename

## Test plan
- [x] 78/78 workflow trigger tests pass
- [x] No non-ASCII characters in workflow file
- [ ] After merge: new workflow ID in registry with `name: "CI Auto-Fix"`
- [ ] After merge: `workflow_run` event fires when CI completes