### PR TITLE
chore: disable scheduled workflow triggers

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,8 +1,8 @@
 name: Daily Claude Code Update Check
 
 on:
-  schedule:
-    - cron: '0 9 * * *'  # 9 AM UTC daily
+  # schedule:
+  #   - cron: '0 9 * * *'  # 9 AM UTC daily — DISABLED to save API tokens
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/monthly-research.yml
+++ b/.github/workflows/monthly-research.yml
@@ -1,8 +1,8 @@
 name: Monthly Research Deep Dive
 
 on:
-  schedule:
-    - cron: '0 11 1 * *'  # 11 AM UTC on the 1st of each month
+  # schedule:
+  #   - cron: '0 11 1 * *'  # 11 AM UTC on 1st of month — DISABLED to save API tokens
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/weekly-community.yml
+++ b/.github/workflows/weekly-community.yml
@@ -1,8 +1,8 @@
 name: Weekly Community Scan
 
 on:
-  schedule:
-    - cron: '0 10 * * 1'  # 10 AM UTC every Monday
+  # schedule:
+  #   - cron: '0 10 * * 1'  # 10 AM UTC every Monday — DISABLED to save API tokens
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Commented out `schedule` cron triggers on all 3 auto-update workflows
- `workflow_dispatch` preserved — can still run manually anytime
- No code/logic changes, just disabling automatic runs to save API tokens

## Workflows affected
| Workflow | Was | Now |
|----------|-----|-----|
| daily-update.yml | Every day 9 AM UTC | Manual only |
| weekly-community.yml | Every Monday 10 AM UTC | Manual only |
| monthly-research.yml | 1st of month 11 AM UTC | Manual only |