### PR TITLE
fix(update): fetch all intermediate releases, not just latest

### DIFF
--- a/.github/prompts/analyze-release.md
+++ b/.github/prompts/analyze-release.md
@@ -1,6 +1,6 @@
 # Claude Code Release Analysis Prompt
 
-You are analyzing a Claude Code release to determine if it's relevant to the SDLC Wizard.
+You are analyzing one or more Claude Code releases to determine if they're relevant to the SDLC Wizard. If multiple releases are provided, produce a single unified analysis covering all of them. The `version` field in your JSON response should be the newest version.
 
 ## Wizard Context
 

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -41,35 +41,61 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Last checked version: $VERSION"
 
-      - name: Fetch latest Claude Code release
+      - name: Fetch Claude Code releases
         id: latest-release
         env:
           GH_TOKEN: ${{ github.token }}
+          LAST_VERSION: ${{ steps.last-version.outputs.version }}
         run: |
-          # W4: Fail loudly on API failure instead of silent fallback to v0.0.0
-          RELEASE_JSON=$(gh api repos/anthropics/claude-code/releases/latest 2>/dev/null) || {
-            echo "::error::Failed to fetch latest Claude Code release from GitHub API"
+          # Fetch recent releases (one API call, covers any realistic weekly gap)
+          RELEASES_JSON=$(gh api "repos/anthropics/claude-code/releases?per_page=100" 2>/dev/null) || {
+            echo "::error::Failed to fetch Claude Code releases from GitHub API"
             exit 1
           }
 
-          LATEST_VERSION=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+          # Extract latest version (first entry = most recent)
+          LATEST_VERSION=$(echo "$RELEASES_JSON" | jq -r '.[0].tag_name')
           if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
-            echo "::error::Could not parse tag_name from release JSON"
+            echo "::error::Could not parse tag_name from releases JSON"
             exit 1
           fi
 
-          RELEASE_DATE=$(echo "$RELEASE_JSON" | jq -r '.published_at // "unknown"')
-          RELEASE_URL=$(echo "$RELEASE_JSON" | jq -r '.html_url // ""')
+          RELEASE_DATE=$(echo "$RELEASES_JSON" | jq -r '.[0].published_at // "unknown"')
+          RELEASE_URL=$(echo "$RELEASES_JSON" | jq -r '.[0].html_url // ""')
 
           echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
           echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
 
-          # Save release body to file (safer than shell variable)
-          echo "$RELEASE_JSON" | jq -r '.body' > /tmp/release_body.md
+          # Filter to releases newer than last-checked-version (jq semver comparison)
+          echo "$RELEASES_JSON" | jq --arg last "$LAST_VERSION" '
+            [.[] | select(.tag_name != $last) | select(
+              (.tag_name | ltrimstr("v") | split(".") | map(tonumber)) as $ver |
+              ($last | ltrimstr("v") | split(".") | map(tonumber)) as $chk |
+              ($ver[0] > $chk[0]) or
+              ($ver[0] == $chk[0] and $ver[1] > $chk[1]) or
+              ($ver[0] == $chk[0] and $ver[1] == $chk[1] and $ver[2] > $chk[2])
+            )] | reverse
+          ' > /tmp/new_releases.json
 
-          echo "Latest version: $LATEST_VERSION"
-          echo "Release date: $RELEASE_DATE"
+          RELEASE_COUNT=$(jq 'length' /tmp/new_releases.json)
+          echo "release_count=$RELEASE_COUNT" >> $GITHUB_OUTPUT
+          echo "Found $RELEASE_COUNT new release(s) since $LAST_VERSION"
+          echo "Latest version: $LATEST_VERSION ($RELEASE_DATE)"
+
+          # Build combined release body for analysis
+          if [ "$RELEASE_COUNT" -eq 0 ]; then
+            echo "" > /tmp/release_body.md
+          elif [ "$RELEASE_COUNT" -eq 1 ]; then
+            # Single release: plain body (backward compatible)
+            jq -r '.[0].body // ""' /tmp/new_releases.json > /tmp/release_body.md
+          else
+            # Multiple releases: numbered sections, oldest-first
+            jq -r '
+              to_entries | .[] |
+              "## Release \(.key + 1): \(.value.tag_name) (\(.value.published_at // "unknown"))\n\(.value.body // "(no release notes)")\n\n---\n"
+            ' /tmp/new_releases.json > /tmp/release_body.md
+          fi
 
       - name: Check if update needed
         id: check-update
@@ -105,13 +131,18 @@ jobs:
         id: build-prompt
         run: |
           # Assemble analysis prompt from template + release context
+          RELEASE_COUNT="${{ steps.latest-release.outputs.release_count }}"
           {
             cat .github/prompts/analyze-release.md
             echo ""
-            echo "## Release to Analyze"
+            echo "## Release(s) to Analyze"
             echo ""
-            echo "**Version:** ${{ steps.latest-release.outputs.latest_version }}"
-            echo "**Date:** ${{ steps.latest-release.outputs.release_date }}"
+            if [ "$RELEASE_COUNT" -gt 1 ]; then
+              echo "**Versions:** $RELEASE_COUNT releases from ${{ steps.last-version.outputs.version }} to ${{ steps.latest-release.outputs.latest_version }}"
+            else
+              echo "**Version:** ${{ steps.latest-release.outputs.latest_version }}"
+            fi
+            echo "**Latest Date:** ${{ steps.latest-release.outputs.release_date }}"
             echo "**URL:** ${{ steps.latest-release.outputs.release_url }}"
             echo ""
             echo "**Release Notes:**"

--- a/tests/test-version-logic.sh
+++ b/tests/test-version-logic.sh
@@ -124,6 +124,133 @@ test_branch_name() {
     fi
 }
 
+# --- Intermediate release detection tests (jq semver filtering) ---
+
+# The jq filter used in weekly-update.yml to find releases newer than last-checked
+JQ_SEMVER_FILTER='[.[] | select(.tag_name != $last) | select(
+  (.tag_name | ltrimstr("v") | split(".") | map(tonumber)) as $ver |
+  ($last | ltrimstr("v") | split(".") | map(tonumber)) as $chk |
+  ($ver[0] > $chk[0]) or
+  ($ver[0] == $chk[0] and $ver[1] > $chk[1]) or
+  ($ver[0] == $chk[0] and $ver[1] == $chk[1] and $ver[2] > $chk[2])
+)] | reverse'
+
+# Test 7: Semver filter — 3 releases newer than v2.1.80
+test_semver_filter_basic() {
+    local RELEASES='[
+      {"tag_name":"v2.1.83","body":"release 83","published_at":"2026-03-25"},
+      {"tag_name":"v2.1.82","body":"release 82","published_at":"2026-03-22"},
+      {"tag_name":"v2.1.81","body":"release 81","published_at":"2026-03-20"},
+      {"tag_name":"v2.1.80","body":"release 80","published_at":"2026-03-18"}
+    ]'
+
+    local COUNT
+    COUNT=$(echo "$RELEASES" | jq --arg last "v2.1.80" "$JQ_SEMVER_FILTER | length")
+
+    if [ "$COUNT" = "3" ]; then
+        pass "Semver filter: 3 releases newer than v2.1.80"
+    else
+        fail "Semver filter: expected 3, got $COUNT"
+    fi
+}
+
+# Test 8: Semver filter — same version yields 0 new releases
+test_semver_filter_same_version() {
+    local RELEASES='[{"tag_name":"v2.1.81","body":"release 81","published_at":"2026-03-20"}]'
+
+    local COUNT
+    COUNT=$(echo "$RELEASES" | jq --arg last "v2.1.81" "$JQ_SEMVER_FILTER | length")
+
+    if [ "$COUNT" = "0" ]; then
+        pass "Semver filter: same version yields 0 new releases"
+    else
+        fail "Semver filter: expected 0, got $COUNT"
+    fi
+}
+
+# Test 9: Semver filter — major version jump
+test_semver_filter_major_jump() {
+    local RELEASES='[
+      {"tag_name":"v3.0.0","body":"major","published_at":"2026-04-01"},
+      {"tag_name":"v2.1.82","body":"patch","published_at":"2026-03-22"},
+      {"tag_name":"v2.1.81","body":"current","published_at":"2026-03-20"}
+    ]'
+
+    local COUNT
+    COUNT=$(echo "$RELEASES" | jq --arg last "v2.1.81" "$JQ_SEMVER_FILTER | length")
+
+    if [ "$COUNT" = "2" ]; then
+        pass "Semver filter: major version jump counted correctly"
+    else
+        fail "Semver filter: expected 2 (v2.1.82 + v3.0.0), got $COUNT"
+    fi
+}
+
+# Test 10: Combined release body — single release (backward compatible)
+test_combined_body_single() {
+    local RELEASES='[{"tag_name":"v2.1.82","body":"Fixed a bug","published_at":"2026-03-22"}]'
+
+    local BODY
+    BODY=$(echo "$RELEASES" | jq -r '.[0].body // ""')
+
+    if [ "$BODY" = "Fixed a bug" ]; then
+        pass "Single release body: plain text (backward compatible)"
+    else
+        fail "Single release body format wrong: '$BODY'"
+    fi
+}
+
+# Test 11: Combined release body — multiple releases have numbered sections
+test_combined_body_multi() {
+    local RELEASES='[
+      {"tag_name":"v2.1.82","body":"Fixed bug A","published_at":"2026-03-22"},
+      {"tag_name":"v2.1.83","body":"Added feature B","published_at":"2026-03-25"}
+    ]'
+
+    local BODY
+    BODY=$(echo "$RELEASES" | jq -r '
+      to_entries | .[] |
+      "## Release \(.key + 1): \(.value.tag_name) (\(.value.published_at // "unknown"))\n\(.value.body // "(no release notes)")\n\n---\n"
+    ')
+
+    if echo "$BODY" | grep -q "## Release 1:" && echo "$BODY" | grep -q "## Release 2:"; then
+        pass "Multi-release body: numbered sections with separators"
+    else
+        fail "Multi-release body format wrong"
+    fi
+}
+
+# Test 12: Null/empty release body handled gracefully
+test_empty_release_body() {
+    local RELEASES='[{"tag_name":"v2.1.82","body":null,"published_at":"2026-03-22"}]'
+
+    local BODY
+    BODY=$(echo "$RELEASES" | jq -r '.[0].body // ""')
+
+    if [ "$BODY" = "" ]; then
+        pass "Null release body defaults to empty string"
+    else
+        fail "Null release body should be empty, got: '$BODY'"
+    fi
+}
+
+# Test 13: Initial state (v0.0.0) catches all releases
+test_semver_filter_initial_state() {
+    local RELEASES='[
+      {"tag_name":"v2.1.83","body":"latest","published_at":"2026-03-25"},
+      {"tag_name":"v2.1.82","body":"previous","published_at":"2026-03-22"}
+    ]'
+
+    local COUNT
+    COUNT=$(echo "$RELEASES" | jq --arg last "v0.0.0" "$JQ_SEMVER_FILTER | length")
+
+    if [ "$COUNT" = "2" ]; then
+        pass "Initial state (v0.0.0): all releases caught"
+    else
+        fail "Initial state: expected 2, got $COUNT"
+    fi
+}
+
 # Run all tests
 test_same_version
 test_different_version
@@ -131,6 +258,13 @@ test_initial_state
 test_version_file_read
 test_missing_version_file
 test_branch_name
+test_semver_filter_basic
+test_semver_filter_same_version
+test_semver_filter_major_jump
+test_combined_body_single
+test_combined_body_multi
+test_empty_release_body
+test_semver_filter_initial_state
 
 echo ""
 echo "=== Results ==="

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2345,6 +2345,31 @@ test_quick_check_accepts_workflow_dispatch
 test_cleanup_accepts_workflow_dispatch
 test_required_checks_run_on_dispatch
 
+# Test 101: weekly-update fetches release list (not just /releases/latest)
+test_weekly_update_multi_release_fetch() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+
+    if grep -q 'releases?per_page=' "$WORKFLOW"; then
+        pass "weekly-update.yml fetches release list (not just /releases/latest)"
+    else
+        fail "weekly-update.yml should use releases?per_page= instead of releases/latest"
+    fi
+}
+
+# Test 102: analyze-release.md handles multiple releases
+test_analyze_release_handles_multi() {
+    local PROMPT="$REPO_ROOT/.github/prompts/analyze-release.md"
+
+    if grep -qi "one or more.*release\|multiple release\|releases are provided" "$PROMPT"; then
+        pass "analyze-release.md handles multiple releases"
+    else
+        fail "analyze-release.md should mention handling multiple releases"
+    fi
+}
+
+test_weekly_update_multi_release_fetch
+test_analyze_release_handles_multi
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- weekly-update.yml used `/releases/latest` which only returns the single newest release
- If multiple CC versions ship between checks, intermediate releases were silently skipped (we're 3 behind right now: v2.1.81 → v2.1.84)
- Now fetches up to 100 recent releases and filters to those newer than `last-checked-version.txt` using jq semver comparison
- Single-release path produces identical output (backward compatible)
- Analysis prompt updated to handle one or more releases

## Test plan
- [x] 7 new jq semver filter tests in `test-version-logic.sh` (13 total, all pass)
- [x] 2 new structural tests in `test-workflow-triggers.sh` (106 total, all pass)
- [x] All 12 test scripts pass (~281 tests)
- [x] YAML validation passes
- [ ] CI validates + E2E quick check
- [ ] After merge: manually trigger weekly-update to catch up v2.1.82-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)