### PR TITLE
feat(ci): add needs-regression-test signal to self-heal autofix

### DIFF
--- a/.github/workflows/ci-self-heal.yml
+++ b/.github/workflows/ci-self-heal.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   actions: write
   id-token: write
+  issues: write
 
 env:
   MAX_AUTOFIX_RETRIES: 3
@@ -352,6 +353,17 @@ jobs:
           echo "Re-triggering CI via workflow_dispatch..."
           gh workflow run ci.yml --ref ${{ steps.source.outputs.head_branch }} || true
 
+      # === REGRESSION TEST SIGNAL ===
+      - name: Add needs-regression-test label
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "needs-regression-test" 2>&1 || {
+            echo "::warning::Failed to add needs-regression-test label"
+          }
+
       # === STATUS COMMENT ===
       - name: Build autofix status comment
         if: |
@@ -399,6 +411,10 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
+            if [ "$COMMITTED" = "true" ]; then
+              echo ""
+              echo "> **Regression test needed:** This autofix addresses the symptom. A regression test should be added to prevent recurrence."
+            fi
             echo "---"
             echo "_Auto-fix by Claude Code. Max ${MAX_RETRIES} attempts._"
           } > /tmp/autofix-comment.md

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2370,6 +2370,43 @@ test_analyze_release_handles_multi() {
 test_weekly_update_multi_release_fetch
 test_analyze_release_handles_multi
 
+# Test 103: ci-self-heal adds needs-regression-test label after autofix
+test_ci_autofix_regression_label() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
+
+    if grep -q 'needs-regression-test' "$WORKFLOW"; then
+        pass "ci-self-heal.yml adds needs-regression-test label after autofix"
+    else
+        fail "ci-self-heal.yml should add needs-regression-test label when autofix commits"
+    fi
+}
+
+# Test 104: ci-self-heal has issues: write permission (needed for label management)
+test_ci_autofix_has_issues_permission() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
+
+    if grep -q 'issues: write' "$WORKFLOW"; then
+        pass "ci-self-heal.yml has issues: write permission"
+    else
+        fail "ci-self-heal.yml needs issues: write permission for label management"
+    fi
+}
+
+# Test 105: ci-self-heal sticky comment mentions regression test when fix is committed
+test_ci_autofix_comment_regression_note() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
+
+    if grep -qi 'regression.*test\|regression-test' "$WORKFLOW"; then
+        pass "ci-self-heal.yml mentions regression test in autofix flow"
+    else
+        fail "ci-self-heal.yml should mention regression test needed after autofix"
+    fi
+}
+
+test_ci_autofix_regression_label
+test_ci_autofix_has_issues_permission
+test_ci_autofix_comment_regression_note
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- When ci-self-heal commits an autofix, it now adds `needs-regression-test` label to the PR
- Sticky comment includes a regression test reminder note
- Added `issues: write` permission (needed for `gh pr edit --add-label`)
- Ensures autofix bugs get proper TDD follow-up instead of being forgotten

## Test plan
- [x] 3 new tests in `test-workflow-triggers.sh` (109 total, all pass)
- [x] YAML validation passes
- [ ] CI validates + E2E quick check