### PR TITLE
fix(ci): ensure needs-regression-test label exists before adding

### DIFF
--- a/.github/workflows/ci-self-heal.yml
+++ b/.github/workflows/ci-self-heal.yml
@@ -360,6 +360,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
+          # Ensure label exists (--force is idempotent — no error if already created)
+          gh label create "needs-regression-test" --color "e11d48" --description "Autofix applied; regression test needed" --force 2>/dev/null || true
           gh pr edit "$PR_NUMBER" --add-label "needs-regression-test" 2>&1 || {
             echo "::warning::Failed to add needs-regression-test label"
           }

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2403,9 +2403,21 @@ test_ci_autofix_comment_regression_note() {
     fi
 }
 
+# Test 106: ci-self-heal ensures label exists before adding it (gh label create --force)
+test_ci_autofix_ensures_label_exists() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
+
+    if grep -q 'gh label create.*needs-regression-test.*--force' "$WORKFLOW"; then
+        pass "ci-self-heal.yml ensures needs-regression-test label exists before adding"
+    else
+        fail "ci-self-heal.yml should use 'gh label create --force' to ensure label exists"
+    fi
+}
+
 test_ci_autofix_regression_label
 test_ci_autofix_has_issues_permission
 test_ci_autofix_comment_regression_note
+test_ci_autofix_ensures_label_exists
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- `gh pr edit --add-label` silently fails if the label doesn't exist in the repo
- PR #79's regression test signal feature would never actually work without this
- Adds `gh label create --force` (idempotent) before the add step
- Caught by CI reviewer as "suggestion" but was actually a critical bug

## Test plan
- [x] Test 106 verifies `gh label create --force` is in workflow
- [x] 110 workflow trigger tests pass
- [x] YAML validation passes
- [ ] CI validates