### PR TITLE
perf(ci): add --bare to non-E2E workflow steps

### DIFF
--- a/.github/workflows/ci-self-heal.yml
+++ b/.github/workflows/ci-self-heal.yml
@@ -237,6 +237,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
+            --bare
             --max-turns 30
             --allowedTools "Read,Edit,Write,Bash(./tests/*),Bash(python3 *),Glob,Grep"
           prompt: |

--- a/.github/workflows/monthly-research.yml
+++ b/.github/workflows/monthly-research.yml
@@ -129,6 +129,7 @@ jobs:
             - If nothing notable found, set nothing_notable: true
             - Prioritize actionable insights over interesting-but-not-useful
           claude_args: |
+            --bare
             --allowedTools "WebSearch,WebFetch"
 
       - name: Save research result to file
@@ -364,6 +365,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--bare"
           prompt: |
             Based on this month's research findings, apply minimal targeted
             improvements to SDLC.md.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -259,6 +259,7 @@ jobs:
             Reference specific files and lines like `src/foo.ts:42` for easy navigation.
 
           claude_args: |
+            --bare
             --allowedTools "mcp__github__get_pull_request_diff,Read,Grep,Glob"
 
       # Extract review from Claude's output

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -164,6 +164,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
+          claude_args: "--bare"
 
       - name: Extract analysis from execution output
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
@@ -509,6 +510,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--bare"
           prompt: |
             Analyze the changelog for Claude Code ${{ needs.check-updates.outputs.latest_version }}
             and suggest minimal, targeted improvements to SDLC.md that would help
@@ -742,6 +744,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
           claude_args: |
+            --bare
             --allowedTools "WebSearch,WebFetch"
 
       - name: Save scan result to file
@@ -982,6 +985,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--bare"
           prompt: |
             Based on the community findings from this week's scan, apply minimal
             targeted improvements to SDLC.md.

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2419,6 +2419,94 @@ test_ci_autofix_has_issues_permission
 test_ci_autofix_comment_regression_note
 test_ci_autofix_ensures_label_exists
 
+# --- --bare flag tests (non-E2E steps should use --bare, E2E simulations should NOT) ---
+
+# Test 107: pr-review.yml uses --bare in claude_args
+test_bare_pr_review() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/pr-review.yml"
+
+    if grep -A2 'claude_args:' "$WORKFLOW" | grep -q '\-\-bare'; then
+        pass "pr-review.yml uses --bare in claude_args"
+    else
+        fail "pr-review.yml should use --bare (non-E2E analysis step)"
+    fi
+}
+
+# Test 108: ci-self-heal.yml uses --bare in claude_args
+test_bare_ci_self_heal() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci-self-heal.yml"
+
+    if grep -A3 'claude_args:' "$WORKFLOW" | grep -q '\-\-bare'; then
+        pass "ci-self-heal.yml uses --bare in claude_args"
+    else
+        fail "ci-self-heal.yml should use --bare (non-E2E fix step)"
+    fi
+}
+
+# Test 109: weekly-update.yml analysis step uses --bare
+test_bare_weekly_update_analysis() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+
+    # The "Analyze release with Claude" step should have --bare
+    # Check that the step's claude-code-action invocation includes --bare
+    if sed -n '/name: Analyze release with Claude/,/name:/p' "$WORKFLOW" | grep -q '\-\-bare'; then
+        pass "weekly-update.yml analysis step uses --bare"
+    else
+        fail "weekly-update.yml 'Analyze release with Claude' should use --bare"
+    fi
+}
+
+# Test 110: monthly-research.yml deep research step uses --bare
+test_bare_monthly_research() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/monthly-research.yml"
+
+    if sed -n '/name: Run deep research with Claude/,/name:/p' "$WORKFLOW" | grep -q '\-\-bare'; then
+        pass "monthly-research.yml deep research step uses --bare"
+    else
+        fail "monthly-research.yml 'Run deep research with Claude' should use --bare"
+    fi
+}
+
+# Test 111: ci.yml E2E simulation steps do NOT use --bare (negative test)
+test_no_bare_ci_simulations() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+    # ci.yml has ONLY E2E simulation steps — none should have --bare
+    if grep -A3 'claude_args:' "$WORKFLOW" | grep -q '\-\-bare'; then
+        fail "ci.yml should NOT use --bare (all steps are E2E simulations)"
+    else
+        pass "ci.yml correctly does NOT use --bare in any step"
+    fi
+}
+
+# Test 112: weekly-update.yml simulation steps do NOT use --bare (negative test)
+test_no_bare_weekly_simulations() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+
+    # Simulation steps have claude_args with --allowedTools but should NOT have --bare
+    # Check that simulation step names don't have --bare in their claude_args blocks
+    local bare_in_sim=false
+    for sim_name in "Run scenario simulation with Claude" "Run baseline simulation with Claude" "Run candidate simulation with Claude"; do
+        if sed -n "/name: ${sim_name}/,/name:/p" "$WORKFLOW" | grep -q '\-\-bare'; then
+            bare_in_sim=true
+            break
+        fi
+    done
+
+    if [ "$bare_in_sim" = "false" ]; then
+        pass "weekly-update.yml simulation steps correctly do NOT use --bare"
+    else
+        fail "weekly-update.yml simulation steps should NOT use --bare"
+    fi
+}
+
+test_bare_pr_review
+test_bare_ci_self_heal
+test_bare_weekly_update_analysis
+test_bare_monthly_research
+test_no_bare_ci_simulations
+test_no_bare_weekly_simulations
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- Add `--bare` flag to 8 non-E2E `claude-code-action` steps across 4 workflows (pr-review, ci-self-heal, weekly-update, monthly-research)
- Skips hooks/LSP/plugins/skills loading for analysis, review, and editing tasks that don't need them
- E2E simulation steps (12 across ci.yml, weekly-update, monthly-research) are deliberately unchanged — they test the wizard's hooks/skills

## Steps modified
| Workflow | Step | Change |
|----------|------|--------|
| pr-review.yml | Run Claude Code Review | Append `--bare` |
| ci-self-heal.yml | Run Claude to fix issues | Append `--bare` |
| weekly-update.yml | Analyze release with Claude | Add `claude_args: "--bare"` |
| weekly-update.yml | Apply changelog suggestions | Add `claude_args: "--bare"` |
| weekly-update.yml | Scan community with Claude | Append `--bare` |
| weekly-update.yml | Apply community suggestions | Add `claude_args: "--bare"` |
| monthly-research.yml | Run deep research with Claude | Append `--bare` |
| monthly-research.yml | Apply research recommendations | Add `claude_args: "--bare"` |

## Test plan
- [x] Tests 107-110: Verify `--bare` present in non-E2E steps
- [x] Tests 111-112: Verify `--bare` absent from E2E simulation steps (negative tests)
- [x] All 116 workflow trigger tests pass
- [x] All ~299 tests across 23 test scripts pass