### PR TITLE
fix(ci): fix 3 weekly-update workflow bugs

### DIFF
--- a/.github/workflows/monthly-research.yml
+++ b/.github/workflows/monthly-research.yml
@@ -312,9 +312,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation.
@@ -404,9 +404,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation with research improvements applied.

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -413,9 +413,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation.
@@ -557,9 +557,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation with the improved SDLC docs.
@@ -884,7 +884,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/last-community-scan.txt
           git diff --staged --quiet || git commit -m "chore: update last-community-scan to ${{ steps.current-date.outputs.current_date }}"
-          git push
+          git push || true  # Non-blocking: branch protection may reject direct push to main
 
       - name: Log if nothing notable
         if: steps.parse.outputs.nothing_notable == 'true' || steps.parse.outputs.findings_count == '0'
@@ -932,9 +932,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation.
@@ -1010,9 +1010,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation with community improvements applied.
@@ -1151,9 +1151,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation.
@@ -1238,9 +1238,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: tests/e2e/fixtures/test-repo
+
           claude_args: |
-            --max-turns 30
+            --max-turns 55
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *)"
           prompt: |
             Run an E2E SDLC simulation without custom SDLC hooks (testing native behavior).

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2507,6 +2507,91 @@ test_bare_monthly_research
 test_no_bare_ci_simulations
 test_no_bare_weekly_simulations
 
+# --- Bug fix tests (weekly-update/monthly-research workflow issues) ---
+
+# Test 113: scan-community push to main is non-blocking (|| true)
+test_scan_community_push_nonblocking() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+
+    if grep -q 'git push.*|| true' "$WORKFLOW"; then
+        pass "scan-community git push is non-blocking (|| true)"
+    else
+        fail "scan-community git push should be non-blocking (protected branch blocks direct push)"
+    fi
+}
+
+# Test 114: No working_directory input in weekly-update (not a valid claude-code-action input)
+test_no_working_directory_weekly() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+
+    if grep -q 'working_directory:' "$WORKFLOW"; then
+        fail "weekly-update.yml should not use working_directory (invalid claude-code-action input)"
+    else
+        pass "weekly-update.yml has no invalid working_directory input"
+    fi
+}
+
+# Test 115: No working_directory input in monthly-research
+test_no_working_directory_monthly() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/monthly-research.yml"
+
+    if grep -q 'working_directory:' "$WORKFLOW"; then
+        fail "monthly-research.yml should not use working_directory (invalid claude-code-action input)"
+    else
+        pass "monthly-research.yml has no invalid working_directory input"
+    fi
+}
+
+# Test 116: Simulation max-turns >= 35 in weekly-update (was 30, ci.yml uses 55)
+test_weekly_sim_max_turns() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    local min_turns=35
+    local all_ok=true
+
+    while IFS= read -r line; do
+        local turns
+        turns=$(echo "$line" | grep -oE '[0-9]+')
+        if [ -n "$turns" ] && [ "$turns" -lt "$min_turns" ]; then
+            all_ok=false
+            break
+        fi
+    done < <(grep 'max-turns' "$WORKFLOW")
+
+    if [ "$all_ok" = "true" ]; then
+        pass "weekly-update.yml simulation --max-turns >= $min_turns"
+    else
+        fail "weekly-update.yml has --max-turns < $min_turns (too low, causes error_max_turns)"
+    fi
+}
+
+# Test 117: Simulation max-turns >= 35 in monthly-research
+test_monthly_sim_max_turns() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/monthly-research.yml"
+    local min_turns=35
+    local all_ok=true
+
+    while IFS= read -r line; do
+        local turns
+        turns=$(echo "$line" | grep -oE '[0-9]+')
+        if [ -n "$turns" ] && [ "$turns" -lt "$min_turns" ]; then
+            all_ok=false
+            break
+        fi
+    done < <(grep 'max-turns' "$WORKFLOW")
+
+    if [ "$all_ok" = "true" ]; then
+        pass "monthly-research.yml simulation --max-turns >= $min_turns"
+    else
+        fail "monthly-research.yml has --max-turns < $min_turns (too low, causes error_max_turns)"
+    fi
+}
+
+test_scan_community_push_nonblocking
+test_no_working_directory_weekly
+test_no_working_directory_monthly
+test_weekly_sim_max_turns
+test_monthly_sim_max_turns
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- **scan-community push blocked**: `git push` to protected main fails with GITHUB_TOKEN. Made non-blocking with `|| true`
- **`working_directory` invalid input**: Not a valid `claude-code-action@v1` input (silently ignored). Removed from weekly-update (7) and monthly-research (2)
- **`--max-turns 30` too low**: Simulations hit `error_max_turns` at 31 turns. Bumped to 55 to match ci.yml

## Test plan
- [x] Tests 113-117: Verify all 3 fixes
- [x] All 121 workflow trigger tests pass
- [x] All 22 test scripts pass (0 failures)