### PR TITLE
fix(e2e): fix 3 evaluator bugs causing flaky E2E scores

### DIFF
--- a/tests/e2e/evaluate.sh
+++ b/tests/e2e/evaluate.sh
@@ -89,9 +89,8 @@ DET_TOTAL=$(echo "$DETERMINISTIC_RESULT" | jq -r '.total')
 echo "Deterministic scores: task=$DET_TASK confidence=$DET_CONFIDENCE tdd_red=$DET_TDD_RED total=$DET_TOTAL/4" >&2
 
 # Detect scenario type (standard vs UI) for criterion selection
-SCENARIO_TYPE="standard"
-if echo "$SCENARIO_CONTENT" | grep -qiE 'UI|styling|CSS|component|color|font|visual'; then
-    SCENARIO_TYPE="ui"
+SCENARIO_TYPE=$(detect_scenario_type "$SCENARIO_CONTENT")
+if [ "$SCENARIO_TYPE" = "ui" ]; then
     echo "Detected UI scenario — including design_system criterion" >&2
 fi
 
@@ -163,11 +162,17 @@ for criterion in $LLM_CRITERIA; do
     # Extract JSON from response
     CRITERION_JSON=$(extract_json "$RAW_RESULT")
 
-    # Validate and fix if needed
+    # Validate and fix if needed — retry once on invalid JSON
     if ! is_valid_json "$CRITERION_JSON"; then
-        echo "  Warning: Invalid JSON for $criterion, using 0 score" >&2
-        CRITERION_JSON='{"met": false, "evidence": "Invalid JSON response"}'
-        FAILED_CRITERIA="$FAILED_CRITERIA $criterion"
+        echo "  Warning: Invalid JSON for $criterion, retrying..." >&2
+        sleep 2
+        RAW_RESULT=$(call_criterion_api "$CRITERION_PROMPT")
+        CRITERION_JSON=$(extract_json "$RAW_RESULT")
+        if ! is_valid_json "$CRITERION_JSON"; then
+            echo "  Warning: Still invalid JSON for $criterion after retry, using 0 score" >&2
+            CRITERION_JSON='{"met": false, "evidence": "Invalid JSON response after retry"}'
+            FAILED_CRITERIA="$FAILED_CRITERIA $criterion"
+        fi
     fi
 
     # Ensure required fields exist (binary format: met + evidence)

--- a/tests/e2e/lib/eval-criteria.sh
+++ b/tests/e2e/lib/eval-criteria.sh
@@ -23,6 +23,19 @@
 # Usage: source this file in evaluate.sh
 #   source "$(dirname "$0")/lib/eval-criteria.sh"
 
+# Detect scenario type based on content keywords
+# Uses word boundaries to avoid false positives (e.g., "requires" matching "UI")
+# Args: $1 = scenario content
+# Returns: "standard" or "ui"
+detect_scenario_type() {
+    local content="$1"
+    if echo "$content" | grep -qiE '\bUI\b|styling|CSS|\bcomponent\b|\bcolor\b|\bfont\b|\bvisual\b'; then
+        echo "ui"
+    else
+        echo "standard"
+    fi
+}
+
 # Get list of LLM-scored criteria for a scenario type
 # Each criterion is a binary (YES/NO) sub-question worth 1 point.
 # Multi-point criteria are split: plan_mode (2pt) → plan_mode_outline + plan_mode_tool
@@ -126,10 +139,11 @@ Q
             ;;
         plan_mode_tool)
             cat << 'Q'
-Did the agent create a plan file or use a planning tool (e.g., EnterPlanMode, plan file, TodoWrite with plan)?
+Did the agent use a structured tool to plan or track work before coding?
 
-Look for: explicit plan mode usage, a plan file being written, or a structured
-planning tool invocation. Simply describing steps verbally does NOT count. YES/NO.
+Look for: TodoWrite or TaskCreate usage (creating a task list IS structured planning),
+EnterPlanMode, or writing a plan file. Any of these count as YES.
+Simply describing steps verbally without using any tool does NOT count. YES/NO.
 Q
             ;;
         tdd_green_ran)

--- a/tests/e2e/test-eval-validation.sh
+++ b/tests/e2e/test-eval-validation.sh
@@ -640,6 +640,111 @@ test_malformed_clamped_then_valid
 test_valid_full_result
 test_invalid_full_result
 
+# -----------------------------------------------
+# UI detection tests (evaluate.sh scenario type)
+# -----------------------------------------------
+echo ""
+echo "--- UI detection tests ---"
+
+source "$SCRIPT_DIR/lib/eval-criteria.sh"
+
+# Test: "technical-debt-cleanup" must NOT be detected as UI
+test_tech_debt_not_ui() {
+    local scenario_content
+    scenario_content=$(cat "$SCRIPT_DIR/scenarios/technical-debt-cleanup.md")
+
+    local detected
+    detected=$(detect_scenario_type "$scenario_content")
+    if [ "$detected" = "standard" ]; then
+        pass "technical-debt-cleanup correctly detected as non-UI (standard)"
+    else
+        fail "technical-debt-cleanup falsely detected as UI scenario (got: $detected)"
+    fi
+}
+
+# Test: Words like "requires" should NOT trigger UI detection
+test_requires_not_ui() {
+    local content="Medium - requires usage analysis, safe deletion"
+    local detected
+    detected=$(detect_scenario_type "$content")
+    if [ "$detected" = "standard" ]; then
+        pass "'requires' does not trigger UI detection"
+    else
+        fail "'requires' falsely triggers UI detection"
+    fi
+}
+
+# Test: Actual UI content SHOULD trigger UI detection
+test_actual_ui_detected() {
+    local content="This task involves changing the UI styling and color scheme"
+    local detected
+    detected=$(detect_scenario_type "$content")
+    if [ "$detected" = "ui" ]; then
+        pass "Actual UI content correctly detected as UI"
+    else
+        fail "Actual UI content not detected (got: $detected)"
+    fi
+}
+
+# Test: standard criteria do NOT include design_system
+test_standard_no_design_system() {
+    local criteria
+    criteria=$(get_llm_criteria "standard")
+    if echo "$criteria" | grep -q "design_system"; then
+        fail "standard criteria includes design_system"
+    else
+        pass "standard criteria correctly excludes design_system"
+    fi
+}
+
+# Test: UI criteria DO include design_system
+test_ui_has_design_system() {
+    local criteria
+    criteria=$(get_llm_criteria "ui")
+    if echo "$criteria" | grep -q "design_system"; then
+        pass "UI criteria correctly includes design_system"
+    else
+        fail "UI criteria missing design_system"
+    fi
+}
+
+# -----------------------------------------------
+# plan_mode_tool criterion prompt tests
+# -----------------------------------------------
+echo ""
+echo "--- plan_mode_tool criterion tests ---"
+
+# Test: plan_mode_tool prompt must mention TodoWrite as qualifying
+test_plan_mode_tool_accepts_todowrite() {
+    local question
+    question=$(_get_binary_question "plan_mode_tool")
+    if echo "$question" | grep -qi "TodoWrite.*count\|TodoWrite.*IS.*planning\|TaskCreate.*count"; then
+        pass "plan_mode_tool criterion explicitly says TodoWrite/TaskCreate counts as planning"
+    else
+        fail "plan_mode_tool criterion does not clearly say TodoWrite counts as planning"
+    fi
+}
+
+# Test: plan_mode_tool prompt must NOT require EnterPlanMode specifically
+test_plan_mode_tool_not_require_enterplanmode() {
+    local question
+    question=$(_get_binary_question "plan_mode_tool")
+    # Check it doesn't say EnterPlanMode is the ONLY way
+    if echo "$question" | grep -qi "must.*EnterPlanMode"; then
+        fail "plan_mode_tool criterion requires EnterPlanMode specifically"
+    else
+        pass "plan_mode_tool criterion does not require EnterPlanMode specifically"
+    fi
+}
+
+test_tech_debt_not_ui
+test_requires_not_ui
+test_actual_ui_detected
+test_standard_no_design_system
+test_ui_has_design_system
+test_plan_mode_tool_accepts_todowrite
+test_plan_mode_tool_not_require_enterplanmode
+
 echo ""
 echo "=========================================="
 echo "Results: $PASSED passed, $FAILED failed"


### PR DESCRIPTION
## Summary
Fixes 3 bugs in the E2E evaluator that caused consistent false score drops (Baseline 7 vs Candidate 5), blocking PRs with unrelated changes.

## Root Causes

### 1. UI detection false positive (`evaluate.sh:93`)
`grep -iE 'UI|...'` matched "req**ui**res" and "req**ui**red" in `technical-debt-cleanup.md`, falsely triggering `design_system` criterion (0/1) on a non-UI scenario.

**Fix:** Extract `detect_scenario_type()` into `eval-criteria.sh` with word boundaries (`\bUI\b`).

### 2. `plan_mode_tool` contradiction (`eval-criteria.sh:128`)
Simulation prompt says "Do NOT use EnterPlanMode", but evaluator showed EnterPlanMode as the primary qualifying example. LLM judge didn't count TodoWrite as "structured planning."

**Fix:** Rewrite criterion to explicitly say "TodoWrite/TaskCreate IS structured planning."

### 3. `tdd_green_pass` invalid JSON (`evaluate.sh:167`)
LLM sometimes returns malformed JSON. Existing retry only covered empty responses, not parse failures.

**Fix:** Add retry on JSON parse failure (mirrors existing empty-response retry).

## Test plan
- [x] 7 new tests in `test-eval-validation.sh` (UI detection, plan_mode_tool prompt)
- [x] All 199 tests pass across 5 test scripts
- [x] `detect_scenario_type` correctly classifies technical-debt-cleanup as "standard"
- [x] plan_mode_tool prompt explicitly accepts TodoWrite as qualifying

## Impact
These 3 bugs explain ~2 points of systematic score loss on the candidate run. With fixes, the candidate should match baseline on non-UI scenarios, eliminating false regressions on PRs like .gitignore changes.