### PR TITLE
chore: CI efficiency audit — wire orphaned test + coverage guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Run eval prompt regression tests
         run: ./tests/e2e/test-eval-prompt-regression.sh
 
+      - name: Run external benchmark tests
+        run: ./tests/test-external-benchmark.sh
+
       - name: Run self-update mechanism tests
         run: ./tests/test-self-update.sh
 

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2639,6 +2639,47 @@ test_gitignore_exists
 test_gitignore_node_modules
 test_gitignore_e2e_cache
 
+# ============================================
+# CI Coverage Tests
+# ============================================
+# Every test-*.sh script should be wired into ci.yml validate job.
+# Catches orphaned test scripts that run locally but not in CI.
+
+# Test 121: All test-*.sh scripts are referenced in ci.yml validate job
+test_no_orphaned_test_scripts() {
+    local CI="$REPO_ROOT/.github/workflows/ci.yml"
+    if [ ! -f "$CI" ]; then
+        fail "ci.yml not found"
+        return
+    fi
+
+    local orphans=""
+    # Check tests/ (top-level test scripts)
+    for script in "$REPO_ROOT"/tests/test-*.sh; do
+        local name
+        name=$(basename "$script")
+        if ! grep -q "tests/$name" "$CI"; then
+            orphans="$orphans $name"
+        fi
+    done
+    # Check tests/e2e/ (e2e test scripts)
+    for script in "$REPO_ROOT"/tests/e2e/test-*.sh; do
+        local name
+        name=$(basename "$script")
+        if ! grep -q "tests/e2e/$name" "$CI"; then
+            orphans="$orphans $name"
+        fi
+    done
+
+    if [ -z "$orphans" ]; then
+        pass "All test-*.sh scripts are wired into ci.yml"
+    else
+        fail "Orphaned test scripts not in ci.yml:$orphans"
+    fi
+}
+
+test_no_orphaned_test_scripts
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary
- Wire `test-external-benchmark.sh` into ci.yml validate job (15 tests were running locally but not in CI)
- Add structural test 121 that catches orphaned `test-*.sh` scripts not referenced in ci.yml — prevents future orphans
- Full audit found CI is already lean: 22s validate, ~5min E2E (API-bound). No parallelization, caching, or skip wins

## Test plan
- [x] TDD RED: test 121 fails (detects orphan)
- [x] TDD GREEN: wire script into ci.yml, test 121 passes
- [x] Full suite: 357 tests across all scripts, 0 failures
- [ ] CI passes