### PR TITLE
feat: formalize cross-model review as first-class SDLC step

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -39,7 +39,7 @@ TodoWrite([
   { content: "Visual consistency check (if UI change)", status: "pending", activeForm: "Checking visual consistency" },
   { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
   { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
-  // Optional: Cross-model review (if configured — see wizard setup)
+  { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
   // CI FEEDBACK LOOP (if CI monitoring enabled in setup - skip if no CI)
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
@@ -109,7 +109,50 @@ PLANNING -> DOCS -> TDD RED -> TDD GREEN -> Tests Pass -> Self-Review
 4. Issues below 80 are likely false positives — skip unless obviously valid
 5. Address issues by going back through the proper SDLC loop
 
-**Optional: Cross-model review.** If configured during wizard setup, run an independent review using a competing AI model (e.g., Codex CLI with the latest GPT model at maximum reasoning effort). Different training = different blind spots. See the wizard's "Cross-Model Review Loop" section for setup.
+## Cross-Model Review (If Configured)
+
+**When to run:** High-stakes changes (auth, payments, data handling), complex refactors, research-heavy work.
+**When to skip:** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
+
+**Prerequisites:** Codex CLI installed (`npm i -g @openai/codex`), OpenAI API key set.
+
+**Steps:**
+1. After self-review passes, write `.reviews/handoff.json`:
+   ```jsonc
+   {
+     "review_id": "feature-xyz-001",
+     "status": "PENDING_REVIEW",
+     "files_changed": ["src/auth.ts", "tests/auth.test.ts"],
+     "review_instructions": "Review for security, edge cases, and correctness",
+     "artifact_path": ".reviews/feature-xyz-001/"
+   }
+   ```
+2. Tell the user to run the independent reviewer:
+   ```bash
+   codex exec \
+     -c 'model_reasoning_effort="xhigh"' \
+     -s danger-full-access \
+     -o .reviews/latest-review.md \
+     "You are an independent code reviewer. Read .reviews/handoff.json, \
+      review the listed files, and write your findings to the artifact_path. \
+      End with CERTIFIED or NOT CERTIFIED."
+   ```
+3. Read `.reviews/latest-review.md` — if CERTIFIED, proceed to CI. If NOT CERTIFIED, fix findings and repeat from step 1.
+
+```
+Self-review passes → write handoff.json → user runs codex exec
+    ^                                              |
+    |                                    CERTIFIED? → YES → CI feedback loop
+    |                                              |
+    |                                              → NO (findings)
+    |                                              |
+    └──────── Fix findings ←───────────────────────┘
+                  (repeat until CERTIFIED, or ask user)
+```
+
+**Tool-agnostic:** The value is adversarial diversity (different model, different blind spots), not the specific tool. Any competing AI reviewer works.
+
+**Full protocol:** See the wizard's "Cross-Model Review Loop (Optional)" section for key flags and reasoning effort guidance.
 
 ## Test Review (Harder Than Implementation)
 

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1645,7 +1645,7 @@ TodoWrite([
   { content: "DRY check: Is logic duplicated elsewhere?", status: "pending", activeForm: "Checking for duplication" },
   { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
   { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
-  // Optional: Cross-model review (if configured — see wizard setup)
+  { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
   // CI FEEDBACK LOOP (After local tests pass)
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
@@ -1715,7 +1715,50 @@ PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Self-Review
 4. Issues below 80 are likely false positives — skip unless obviously valid
 5. Address issues by going back through the proper SDLC loop
 
-**Optional: Cross-model review.** If configured during wizard setup, run an independent review using a competing AI model (e.g., Codex CLI with the latest GPT model at maximum reasoning effort). Different training = different blind spots. See the "Cross-Model Review Loop" section below for setup.
+## Cross-Model Review (If Configured)
+
+**When to run:** High-stakes changes (auth, payments, data handling), complex refactors, research-heavy work.
+**When to skip:** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
+
+**Prerequisites:** Codex CLI installed (`npm i -g @openai/codex`), OpenAI API key set.
+
+**Steps:**
+1. After self-review passes, write `.reviews/handoff.json`:
+   ```jsonc
+   {
+     "review_id": "feature-xyz-001",
+     "status": "PENDING_REVIEW",
+     "files_changed": ["src/auth.ts", "tests/auth.test.ts"],
+     "review_instructions": "Review for security, edge cases, and correctness",
+     "artifact_path": ".reviews/feature-xyz-001/"
+   }
+   ```
+2. Tell the user to run the independent reviewer:
+   ```bash
+   codex exec \
+     -c 'model_reasoning_effort="xhigh"' \
+     -s danger-full-access \
+     -o .reviews/latest-review.md \
+     "You are an independent code reviewer. Read .reviews/handoff.json, \
+      review the listed files, and write your findings to the artifact_path. \
+      End with CERTIFIED or NOT CERTIFIED."
+   ```
+3. Read `.reviews/latest-review.md` — if CERTIFIED, proceed to CI. If NOT CERTIFIED, fix findings and repeat from step 1.
+
+```
+Self-review passes → write handoff.json → user runs codex exec
+    ^                                              |
+    |                                    CERTIFIED? → YES → CI feedback loop
+    |                                              |
+    |                                              → NO (findings)
+    |                                              |
+    └──────── Fix findings ←───────────────────────┘
+                  (repeat until CERTIFIED, or ask user)
+```
+
+**Tool-agnostic:** The value is adversarial diversity (different model, different blind spots), not the specific tool. Any competing AI reviewer works.
+
+**Full protocol:** See the "Cross-Model Review Loop (Optional)" section below for key flags and reasoning effort guidance.
 
 ## Test Review (Harder Than Implementation)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 | 12 | CI efficiency audit | DONE (PR #92) |
 | 13 | Cross-model full repo audit | IN PROGRESS — pass 4 done (3 findings: friction loop closure, setup-path scoping, watchlist cadence). Friction consumer wired, docs narrowed |
 | 13.5 | Live-fire CI job audit | TODO — verify untested CI paths (see details below) |
-| 13.6 | Wire cross-model review into own SDLC | TODO — dogfood codex exec in our local pre-PR loop |
+| 13.6 | Wire cross-model review into own SDLC | DONE — cross-model review is now a first-class SDLC step |
 | 14 | Distribution | TODO — npx CLI or curl one-liner (research done) |
 
 ## Post-Distribution

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -257,24 +257,43 @@ test_cross_model_review_step() {
     fi
 }
 
-# Test 18: SKILL.md references cross-model review
+# Test 18: SKILL.md has a real TodoWrite step for cross-model review (not just a comment)
 test_skill_cross_model_review() {
     local skill_file="$SCRIPT_DIR/../.claude/skills/sdlc/SKILL.md"
-    if grep -qi "cross-model review" "$skill_file"; then
-        pass "SKILL.md references cross-model review"
+    # Exclude // comment lines in the TodoWrite block — we need an actual step
+    if grep -i 'content:.*cross-model review' "$skill_file" | grep -qv '^\s*//'; then
+        pass "SKILL.md has TodoWrite step for cross-model review"
     else
-        fail "SKILL.md should reference cross-model review"
+        fail "SKILL.md should have a TodoWrite step (not a comment) for cross-model review"
     fi
 }
 
-# Test 19: Wizard template SKILL copy references cross-model review
+# Test 19: Wizard embedded SKILL has a real TodoWrite step for cross-model review
 test_wizard_skill_cross_model_review() {
-    # The wizard template contains a copy of the SKILL content in step 6
-    # Check that the wizard's embedded SKILL also references cross-model review
-    if grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -qi "cross-model review"; then
-        pass "Wizard template SKILL copy references cross-model review"
+    # The wizard's embedded SKILL checklist should have the real step, not just a comment
+    if grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -i 'content:.*cross-model review' | grep -qv '^\s*//'; then
+        pass "Wizard embedded SKILL has TodoWrite step for cross-model review"
     else
-        fail "Wizard template SKILL copy should reference cross-model review"
+        fail "Wizard embedded SKILL should have a TodoWrite step (not a comment) for cross-model review"
+    fi
+}
+
+# Test 20: SKILL.md has a dedicated cross-model review instructions section
+test_skill_cross_model_review_instructions() {
+    local skill_file="$SCRIPT_DIR/../.claude/skills/sdlc/SKILL.md"
+    if grep -q "## Cross-Model Review" "$skill_file"; then
+        pass "SKILL.md has dedicated cross-model review section"
+    else
+        fail "SKILL.md should have a '## Cross-Model Review' section with instructions"
+    fi
+}
+
+# Test 21: Wizard embedded SKILL has a dedicated cross-model review section
+test_wizard_skill_cross_model_review_instructions() {
+    if grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -q "## Cross-Model Review"; then
+        pass "Wizard embedded SKILL has cross-model review section"
+    else
+        fail "Wizard embedded SKILL should have a '## Cross-Model Review' section"
     fi
 }
 
@@ -298,6 +317,8 @@ test_cross_model_review_section
 test_cross_model_review_step
 test_skill_cross_model_review
 test_wizard_skill_cross_model_review
+test_skill_cross_model_review_instructions
+test_wizard_skill_cross_model_review_instructions
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- Promotes cross-model review from a JS comment (`// Optional: Cross-model review...`) to a real TodoWrite checklist step in the SDLC skill
- Adds a dedicated `## Cross-Model Review (If Configured)` section with actionable instructions (when to run/skip, handoff.json protocol, codex exec command, loop diagram)
- Mirrors changes in both SKILL.md and the wizard's embedded SKILL copy
- Tightens tests 18-19 to structural checks (verify real step, not just text presence) and adds tests 20-21 for section heading presence
- Marks roadmap item 13.6 as DONE

## Test plan
- [x] TDD RED: tests 18-20 fail before implementation
- [x] TDD GREEN: all 21 self-update tests pass after implementation
- [x] Full 23-script test suite passes with zero failures
- [x] Self-review (/simplify) found no issues beyond minor nits (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)