### PR TITLE
fix(ci): add missing origin remote to Tier 2 git init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -936,8 +936,11 @@ jobs:
       - name: Initialize workspace git directory (Tier 2)
         run: |
           # actions/checkout with path: leaves workspace root as non-git.
-          # claude-code-action@v1 configureGitAuth runs git config here and crashes without this.
+          # claude-code-action@v1 needs a git repo with origin remote for:
+          #   1. configureGitAuth: git remote set-url origin <auth-url>
+          #   2. Trusted file restore: git fetch origin main --depth=1
           git init .
+          git remote add origin https://github.com/${{ github.repository }}.git
 
       - name: Record baseline simulation start time (Tier 2)
         if: steps.check-baseline.outputs.has_baseline == 'true'

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -3406,8 +3406,23 @@ test_selfheal_friction_defaults_before_template
 test_readme_setup_not_proven
 test_weekly_fetches_friction_issues
 test_readme_setup_scopes_generated_assets
+# Test 171: Tier 2 (e2e-full-evaluation) git init includes origin remote
+# Without origin, claude-code-action@v1 fails on "git fetch origin main" trust check.
+test_tier2_git_init_has_origin() {
+    local CI_FILE="$REPO_ROOT/.github/workflows/ci.yml"
+    if [ ! -f "$CI_FILE" ]; then fail "ci.yml not found"; return; fi
+
+    # The Tier 2 git init block must add origin remote (same as Tier 1 quick check)
+    if grep -A 10 "Initialize workspace git directory (Tier 2)" "$CI_FILE" | grep -q 'git remote add origin'; then
+        pass "Tier 2 git init includes origin remote"
+    else
+        fail "Tier 2 git init missing 'git remote add origin' — claude-code-action will fail on trust check"
+    fi
+}
+
 test_competitive_audit_says_weekly
 test_cicd_weekly_mentions_watchlist
+test_tier2_git_init_has_origin
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- Fixes `e2e-full-evaluation` (Tier 2) failure: workspace git init was missing `git remote add origin`, causing `claude-code-action@v1` to fail on `git fetch origin main` trust boundary check
- Tier 1 (quick check) already had this fix — Tier 2 was missed
- Adds regression test (test 171) to prevent recurrence
- **Labeled `merge-ready` to verify the fix by running the full Tier 2 pipeline**

## Test plan
- [x] 171/171 workflow trigger tests pass locally
- [x] YAML validation passes
- [ ] `e2e-full-evaluation` job runs successfully (this is the live-fire proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)