### PR TITLE
feat: add npx distribution CLI (item 14)

### DIFF
--- a/cli/bin/sdlc-wizard.js
+++ b/cli/bin/sdlc-wizard.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+const { version } = require('../../package.json');
+const { init } = require('../init');
+
+const args = process.argv.slice(2);
+
+const flags = {
+  force: args.includes('--force'),
+  dryRun: args.includes('--dry-run'),
+};
+
+const command = args.find((a) => !a.startsWith('--'));
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log(version);
+  process.exit(0);
+}
+
+if (args.includes('--help') || args.includes('-h') || !command) {
+  console.log(`
+  agentic-sdlc-wizard v${version}
+
+  Usage:
+    sdlc-wizard init [options]    Install SDLC wizard into current directory
+
+  Options:
+    --force       Overwrite existing files
+    --dry-run     Preview changes without writing
+    --version     Show version
+    --help        Show this help
+  `.trim());
+  process.exit(0);
+}
+
+if (command === 'init') {
+  try {
+    init(process.cwd(), flags);
+    process.exit(0);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+} else {
+  console.error(`Unknown command: ${command}`);
+  console.error('Run "sdlc-wizard --help" for usage.');
+  process.exit(1);
+}

--- a/cli/init.js
+++ b/cli/init.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const RESET = '\x1b[0m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+
+const TEMPLATES_DIR = path.join(__dirname, 'templates');
+const WIZARD_DOC = path.join(__dirname, '..', 'CLAUDE_CODE_SDLC_WIZARD.md');
+
+const FILES = [
+  { src: 'settings.json', dest: '.claude/settings.json' },
+  { src: 'hooks/sdlc-prompt-check.sh', dest: '.claude/hooks/sdlc-prompt-check.sh', executable: true },
+  { src: 'hooks/tdd-pretool-check.sh', dest: '.claude/hooks/tdd-pretool-check.sh', executable: true },
+  { src: 'hooks/instructions-loaded-check.sh', dest: '.claude/hooks/instructions-loaded-check.sh', executable: true },
+  { src: 'skills/sdlc/SKILL.md', dest: '.claude/skills/sdlc/SKILL.md' },
+  { src: 'skills/testing/SKILL.md', dest: '.claude/skills/testing/SKILL.md' },
+];
+
+const GITIGNORE_ENTRIES = ['.claude/plans/', '.claude/settings.local.json'];
+
+function planOperations(targetDir, { force }) {
+  const ops = [];
+
+  for (const file of FILES) {
+    const destPath = path.join(targetDir, file.dest);
+    const exists = fs.existsSync(destPath);
+    ops.push({
+      src: path.join(TEMPLATES_DIR, file.src),
+      dest: destPath,
+      relativeDest: file.dest,
+      action: exists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+      executable: file.executable || false,
+    });
+  }
+
+  // Wizard doc
+  const wizardDest = path.join(targetDir, 'CLAUDE_CODE_SDLC_WIZARD.md');
+  const wizardExists = fs.existsSync(wizardDest);
+  ops.push({
+    src: WIZARD_DOC,
+    dest: wizardDest,
+    relativeDest: 'CLAUDE_CODE_SDLC_WIZARD.md',
+    action: wizardExists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+    executable: false,
+  });
+
+  return ops;
+}
+
+function ensureDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function executeOperations(ops) {
+  for (const op of ops) {
+    if (op.action === 'SKIP') continue;
+    ensureDir(op.dest);
+    fs.copyFileSync(op.src, op.dest);
+    if (op.executable) {
+      fs.chmodSync(op.dest, 0o755);
+    }
+  }
+}
+
+function updateGitignore(targetDir, { dryRun }) {
+  const gitignorePath = path.join(targetDir, '.gitignore');
+  let content = '';
+  if (fs.existsSync(gitignorePath)) {
+    content = fs.readFileSync(gitignorePath, 'utf8');
+  }
+
+  const toAdd = GITIGNORE_ENTRIES.filter((entry) => !content.includes(entry));
+  if (toAdd.length === 0) return [];
+
+  if (!dryRun) {
+    const suffix = (content && !content.endsWith('\n') ? '\n' : '') + toAdd.join('\n') + '\n';
+    fs.appendFileSync(gitignorePath, suffix);
+  }
+
+  return toAdd;
+}
+
+function printOps(ops) {
+  for (const op of ops) {
+    const color = op.action === 'CREATE' ? GREEN : op.action === 'SKIP' ? YELLOW : CYAN;
+    console.log(`  ${color}${op.action}${RESET}  ${op.relativeDest}`);
+  }
+}
+
+function init(targetDir, { force = false, dryRun = false } = {}) {
+  const ops = planOperations(targetDir, { force });
+
+  if (dryRun) {
+    console.log('Dry run — no files will be written:\n');
+    printOps(ops);
+    const gitignoreAdds = updateGitignore(targetDir, { dryRun: true });
+    if (gitignoreAdds.length > 0) {
+      console.log(`  ${GREEN}APPEND${RESET}  .gitignore (${gitignoreAdds.join(', ')})`);
+    }
+    return true;
+  }
+
+  console.log('');
+  printOps(ops);
+
+  if (ops.every((o) => o.action === 'SKIP')) {
+    console.log('\nAll files already exist. Use --force to overwrite.');
+    return true;
+  }
+
+  executeOperations(ops);
+
+  const gitignoreAdds = updateGitignore(targetDir, { dryRun: false });
+  if (gitignoreAdds.length > 0) {
+    console.log(`  ${GREEN}APPEND${RESET}  .gitignore (${gitignoreAdds.join(', ')})`);
+  }
+
+  console.log(`
+${GREEN}SDLC Wizard installed successfully!${RESET}
+
+Next steps:
+  1. Start Claude Code in this directory
+  2. Tell Claude: "Run the SDLC wizard setup"
+  3. Claude will scan your project and create CLAUDE.md, SDLC.md, TESTING.md, ARCHITECTURE.md
+
+The wizard doc is at: CLAUDE_CODE_SDLC_WIZARD.md
+  `);
+
+  return true;
+}
+
+module.exports = { init, planOperations, GITIGNORE_ENTRIES };

--- a/cli/templates/hooks/instructions-loaded-check.sh
+++ b/cli/templates/hooks/instructions-loaded-check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# InstructionsLoaded hook - validates SDLC files exist at session start
+# Fires when Claude loads instructions (session start/resume)
+# Available since Claude Code v2.1.69
+# Note: no set -e — this hook must always exit 0 to not block session start
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+MISSING=""
+
+if [ ! -f "$PROJECT_DIR/SDLC.md" ]; then
+    MISSING="${MISSING:+${MISSING}, }SDLC.md"
+fi
+
+if [ ! -f "$PROJECT_DIR/TESTING.md" ]; then
+    MISSING="${MISSING:+${MISSING}, }TESTING.md"
+fi
+
+if [ -n "$MISSING" ]; then
+    echo "WARNING: Missing SDLC wizard files: ${MISSING}"
+    echo "Run the wizard setup to generate them."
+fi
+
+exit 0

--- a/cli/templates/hooks/sdlc-prompt-check.sh
+++ b/cli/templates/hooks/sdlc-prompt-check.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Light SDLC hook - baseline reminder every prompt (~100 tokens)
+# Full guidance in skills: .claude/skills/sdlc/ and .claude/skills/testing/
+
+cat << 'EOF'
+SDLC BASELINE:
+1. TodoWrite FIRST (plan tasks before coding)
+2. STATE CONFIDENCE: HIGH/MEDIUM/LOW
+3. LOW confidence? ASK USER before proceeding
+4. FAILED 2x? STOP and ASK USER
+5. ALL TESTS MUST PASS BEFORE COMMIT - NO EXCEPTIONS
+
+AUTO-INVOKE SKILLS (Claude MUST do this FIRST):
+- implement/fix/refactor/feature/bug/build → Invoke: Skill tool, skill="sdlc"
+- test/TDD/write test (standalone) → Invoke: Skill tool, skill="testing"
+- If BOTH match (e.g., "fix the test") → sdlc takes precedence (includes TDD)
+- DON'T invoke for: questions, explanations, reading/exploring code, simple queries
+- DON'T wait for user to type /sdlc - AUTO-INVOKE based on task type
+
+Workflow phases:
+1. Plan Mode (research) → Present approach + confidence
+2. Transition (update docs) → Request /compact
+3. Implementation (TDD after compact)
+4. SELF-REVIEW (/code-review) → BEFORE presenting to user
+
+Quick refs: SDLC.md | TESTING.md | *_PLAN.md for feature
+EOF

--- a/cli/templates/hooks/tdd-pretool-check.sh
+++ b/cli/templates/hooks/tdd-pretool-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# PreToolUse hook - TDD enforcement before editing source files
+# Fires before Write/Edit/MultiEdit tools
+
+# Read the tool input (JSON with file_path, content, etc.)
+TOOL_INPUT=$(cat)
+
+# Extract the file path being edited (requires jq)
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty')
+
+# CUSTOMIZE: Change this pattern to match YOUR source directory
+# Examples: "/src/", "/app/", "/lib/", "/packages/", "/server/"
+if [[ "$FILE_PATH" == *"/src/"* ]]; then
+  # Output additionalContext that Claude will read
+  cat << 'EOF'
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "TDD CHECK: Are you writing IMPLEMENTATION before a FAILING TEST? If yes, STOP. Write the test first (TDD RED), then implement (TDD GREEN)."}}
+EOF
+fi
+
+# No output = allow the tool to proceed

--- a/cli/templates/settings.json
+++ b/cli/templates/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sdlc-prompt-check.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/tdd-pretool-check.sh"
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/instructions-loaded-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cli/templates/skills/sdlc/SKILL.md
+++ b/cli/templates/skills/sdlc/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: sdlc
+description: Full SDLC workflow for implementing features, fixing bugs, refactoring code, and creating new functionality. Use this skill when implementing, fixing, refactoring, adding features, or building new code.
+argument-hint: [task description]
+effort: high
+---
+# SDLC Skill - Full Development Workflow
+
+## Task
+$ARGUMENTS
+
+## Full SDLC Checklist
+
+Your FIRST action must be TodoWrite with these steps:
+
+```
+TodoWrite([
+  // PLANNING PHASE (Plan Mode for non-trivial tasks)
+  { content: "Find and read relevant documentation", status: "in_progress", activeForm: "Reading docs" },
+  { content: "Assess doc health - flag issues (ask before cleaning)", status: "pending", activeForm: "Checking doc health" },
+  { content: "DRY scan: What patterns exist to reuse?", status: "pending", activeForm: "Scanning for reusable patterns" },
+  { content: "Blast radius: What depends on code I'm changing?", status: "pending", activeForm: "Checking dependencies" },
+  { content: "Design system check (if UI change)", status: "pending", activeForm: "Checking design system" },
+  { content: "Restate task in own words - verify understanding", status: "pending", activeForm: "Verifying understanding" },
+  { content: "Scrutinize test design - right things tested? Follow TESTING.md?", status: "pending", activeForm: "Reviewing test approach" },
+  { content: "Present approach + STATE CONFIDENCE LEVEL", status: "pending", activeForm: "Presenting approach" },
+  { content: "Signal ready - user exits plan mode", status: "pending", activeForm: "Awaiting plan approval" },
+  // TRANSITION PHASE (After plan mode, before compact)
+  { content: "Update feature docs with discovered gotchas", status: "pending", activeForm: "Updating feature docs" },
+  { content: "Request /compact before TDD", status: "pending", activeForm: "Requesting compact" },
+  // IMPLEMENTATION PHASE (After compact)
+  { content: "TDD RED: Write failing test FIRST", status: "pending", activeForm: "Writing failing test" },
+  { content: "TDD GREEN: Implement, verify test passes", status: "pending", activeForm: "Implementing feature" },
+  { content: "Run lint/typecheck", status: "pending", activeForm: "Running lint and typecheck" },
+  { content: "Run ALL tests", status: "pending", activeForm: "Running all tests" },
+  { content: "Production build check", status: "pending", activeForm: "Verifying production build" },
+  // REVIEW PHASE
+  { content: "DRY check: Is logic duplicated elsewhere?", status: "pending", activeForm: "Checking for duplication" },
+  { content: "Visual consistency check (if UI change)", status: "pending", activeForm: "Checking visual consistency" },
+  { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
+  { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
+  { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
+  // CI FEEDBACK LOOP (if CI monitoring enabled in setup - skip if no CI)
+  { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
+  { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
+  { content: "Read CI review - implement valid suggestions, iterate until clean", status: "pending", activeForm: "Addressing CI review feedback" },
+  // FINAL
+  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" }
+])
+```
+
+## New Pattern & Test Design Scrutiny (PLANNING)
+
+**New design patterns require human approval:**
+1. Search first - do similar patterns exist in codebase?
+2. If YES and they're good - use as building block
+3. If YES but they're bad - propose improvement, get approval
+4. If NO (new pattern) - explain why needed, get explicit approval
+
+**Test design scrutiny during planning:**
+- Are we testing the right things?
+- Does test approach follow TESTING.md philosophies?
+- If introducing new test patterns, same scrutiny as code patterns
+
+## Plan Mode Integration
+
+**Use plan mode for:** Multi-file changes, new features, LOW confidence, bugs needing investigation.
+
+**Workflow:**
+1. **Plan Mode** (editing blocked): Research -> Write plan file -> Present approach + confidence
+2. **Transition** (after approval): Update feature docs -> Request /compact
+3. **Implementation** (after compact): TDD RED -> GREEN -> PASS
+
+**Before TDD, MUST ask:** "Docs updated. Run `/compact` before implementation?"
+
+## Confidence Check (REQUIRED)
+
+Before presenting approach, STATE your confidence:
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| HIGH (90%+) | Know exactly what to do | Present approach, proceed after approval |
+| MEDIUM (60-89%) | Solid approach, some uncertainty | Present approach, highlight uncertainties |
+| LOW (<60%) | Not sure | ASK USER before proceeding |
+| FAILED 2x | Something's wrong | STOP. ASK USER immediately |
+| CONFUSED | Can't diagnose why something is failing | STOP. Describe what you tried, ask for help |
+
+## Self-Review Loop (CRITICAL)
+
+```
+PLANNING -> DOCS -> TDD RED -> TDD GREEN -> Tests Pass -> Self-Review
+    ^                                                      |
+    |                                                      v
+    |                                            Issues found?
+    |                                            |-- NO -> Present to user
+    |                                            +-- YES v
+    +------------------------------------------- Ask user: fix in new plan?
+```
+
+**The loop goes back to PLANNING, not TDD RED.** When self-review finds issues:
+1. Ask user: "Found issues. Want to create a plan to fix?"
+2. If yes -> back to PLANNING phase with new plan doc
+3. Then -> docs update -> TDD -> review (proper SDLC loop)
+
+**How to self-review:**
+1. Run `/code-review` to review your changes
+2. It launches parallel agents (CLAUDE.md compliance, bug detection, logic & security)
+3. Issues at confidence >= 80 are real findings — go back to PLANNING to fix
+4. Issues below 80 are likely false positives — skip unless obviously valid
+5. Address issues by going back through the proper SDLC loop
+
+## Cross-Model Review (If Configured)
+
+**When to run:** High-stakes changes (auth, payments, data handling), complex refactors, research-heavy work.
+**When to skip:** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
+
+**Prerequisites:** Codex CLI installed (`npm i -g @openai/codex`), OpenAI API key set.
+
+**Steps:**
+1. After self-review passes, write `.reviews/handoff.json`:
+   ```jsonc
+   {
+     "review_id": "feature-xyz-001",
+     "status": "PENDING_REVIEW",
+     "files_changed": ["src/auth.ts", "tests/auth.test.ts"],
+     "review_instructions": "Review for security, edge cases, and correctness",
+     "artifact_path": ".reviews/feature-xyz-001/"
+   }
+   ```
+2. Tell the user to run the independent reviewer:
+   ```bash
+   codex exec \
+     -c 'model_reasoning_effort="xhigh"' \
+     -s danger-full-access \
+     -o .reviews/latest-review.md \
+     "You are an independent code reviewer. Read .reviews/handoff.json, \
+      review the listed files, and write your findings to the artifact_path. \
+      End with CERTIFIED or NOT CERTIFIED."
+   ```
+3. Read `.reviews/latest-review.md` — if CERTIFIED, proceed to CI. If NOT CERTIFIED, fix findings and repeat from step 1.
+
+```
+Self-review passes → write handoff.json → user runs codex exec
+    ^                                              |
+    |                                    CERTIFIED? → YES → CI feedback loop
+    |                                              |
+    |                                              → NO (findings)
+    |                                              |
+    └──────── Fix findings ←───────────────────────┘
+                  (repeat until CERTIFIED, or ask user)
+```
+
+**Tool-agnostic:** The value is adversarial diversity (different model, different blind spots), not the specific tool. Any competing AI reviewer works.
+
+**Full protocol:** See the wizard's "Cross-Model Review Loop (Optional)" section for key flags and reasoning effort guidance.
+
+## Test Review (Harder Than Implementation)
+
+During self-review, critique tests HARDER than app code:
+1. **Testing the right things?** - Not just that tests pass
+2. **Tests prove correctness?** - Or just verify current behavior?
+3. **Follow our philosophies (TESTING.md)?**
+   - Testing Diamond (integration-heavy)?
+   - Minimal mocking (real DB, mock external APIs only)?
+   - Real fixtures from captured data?
+
+**Tests are the foundation.** Bad tests = false confidence = production bugs.
+
+## Flaky Test Recovery
+
+When a test fails intermittently:
+1. **Don't dismiss it** — "flaky" means "bug we haven't found yet"
+2. **Identify the layer** — test code? app code? environment?
+3. **Stress-test** — run the suspect test N times to reproduce reliably
+4. **Fix root cause** — don't just retry-and-pray
+5. **If CI infrastructure** — make cosmetic steps non-blocking, keep quality gates strict
+
+## Scope Guard (Stay in Your Lane)
+
+**Only make changes directly related to the task.**
+
+If you notice something else that should be fixed:
+- NOTE it in your summary ("I noticed X could be improved")
+- DON'T fix it unless asked
+
+**Why this matters:** AI agents can drift into "helpful" changes that weren't requested. This creates unexpected diffs, breaks unrelated things, and makes code review harder.
+
+## Test Failure Recovery (SDET Philosophy)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  ALL TESTS MUST PASS. NO EXCEPTIONS.                                │
+│                                                                     │
+│  This is not negotiable. This is not flexible. This is absolute.   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Not acceptable:**
+- "Those were already failing" → Fix them first
+- "Not related to my changes" → Doesn't matter, fix it
+- "It's flaky" → Flaky = bug, investigate
+
+**Treat test code like app code.** Test failures are bugs. Investigate them the way a 15-year SDET would - with thought and care, not by brushing them aside.
+
+If tests fail:
+1. Identify which test(s) failed
+2. Diagnose WHY - this is the important part:
+   - Your code broke it? Fix your code (regression)
+   - Test is for deleted code? Delete the test
+   - Test has wrong assertions? Fix the test
+   - Test is "flaky"? Investigate - flakiness is just another word for bug
+3. Fix appropriately (fix code, fix test, or delete dead test)
+4. Run specific test individually first
+5. Then run ALL tests
+6. Still failing? ASK USER - don't spin your wheels
+
+**Flaky tests are bugs, not mysteries:**
+- Sometimes the bug is in app code (race condition, timing issue)
+- Sometimes the bug is in test code (shared state, not parallel-safe)
+- Sometimes the bug is in test environment (cleanup not proper)
+
+Debug it. Find root cause. Fix it properly. Tests ARE code.
+
+## CI Feedback Loop (After Commit)
+
+**The SDLC doesn't end at local tests.** CI must pass too.
+
+```
+Local tests pass -> Commit -> Push -> Watch CI
+                                         |
+                              CI passes? -+-> YES -> Present for review
+                                         |
+                                         +-> NO -> Fix -> Push -> Watch CI
+                                                           |
+                                                   (max 2 attempts)
+                                                           |
+                                                   Still failing?
+                                                           |
+                                                   STOP and ASK USER
+```
+
+**How to watch CI:**
+1. Push changes to remote
+2. Check CI status:
+   ```bash
+   # Watch checks in real-time (blocks until complete)
+   gh pr checks --watch
+
+   # Or check status without blocking
+   gh pr checks
+
+   # View specific failed run logs
+   gh run view <RUN_ID> --log-failed
+   ```
+3. If CI fails:
+   - Read failure logs: `gh run view <RUN_ID> --log-failed`
+   - Diagnose root cause (same philosophy as local test failures)
+   - Fix and push again
+4. Max 2 fix attempts - if still failing, ASK USER
+5. If CI passes - proceed to present final summary
+
+**Context GC (compact during idle):** While waiting for CI (typically 3-5 min), suggest `/compact` if the conversation is long. Think of it like a time-based garbage collector — idle time + high memory pressure = good time to collect. Don't suggest on short conversations.
+
+**CI failures follow same rules as test failures:**
+- Your code broke it? Fix your code
+- CI config issue? Fix the config
+- Flaky? Investigate - flakiness is a bug
+- Stuck? ASK USER
+
+## CI Review Feedback Loop (After CI Passes)
+
+**CI passing isn't the end.** If CI includes a code reviewer, read and address its suggestions.
+
+```
+CI passes -> Read review suggestions
+                    |
+        Valid improvements? -+-> YES -> Implement -> Run tests -> Push
+                             |                                      |
+                             |                          Review again (iterate)
+                             |
+                             +-> NO (just opinions/style) -> Skip, note why
+                             |
+                             +-> None -> Done, present to user
+```
+
+**How to evaluate suggestions:**
+1. Read all CI review comments: `gh api repos/OWNER/REPO/pulls/PR/comments`
+2. For each suggestion, ask: **"Is this a real improvement or just an opinion?"**
+   - **Real improvement:** Fixes a bug, improves performance, adds missing error handling, reduces duplication, improves test coverage → Implement it
+   - **Opinion/style:** Different but equivalent formatting, subjective naming preference, "you could also..." without clear benefit → Skip it
+3. Implement the valid ones, run tests locally, push
+4. CI re-reviews — repeat until no substantive suggestions remain
+5. Max 3 iterations — if reviewer keeps finding new things, ASK USER
+
+**The goal:** User is only brought in at the very end, when both CI and reviewer are satisfied. The code should be polished before human review.
+
+**Customizable behavior** (set during wizard setup):
+- **Auto-implement** (default): Implement valid suggestions autonomously, skip opinions
+- **Ask first**: Present suggestions to user, let them decide which to implement
+- **Skip review feedback**: Ignore CI review suggestions, only fix CI failures
+
+## DRY Principle
+
+**Before coding:** "What patterns exist I can reuse?"
+**After coding:** "Did I accidentally duplicate anything?"
+
+## Design System Check (If UI Change)
+
+**When to check:** CSS/styling changes, new UI components, color/font usage.
+**When to skip:** Backend-only changes, config/build changes, non-visual code.
+
+**Planning phase - "Design system check":**
+1. Read DESIGN_SYSTEM.md if it exists
+2. Check if change involves colors, fonts, spacing, or components
+3. Verify intended styles match design system tokens
+4. Flag if introducing new patterns not in design system
+
+**Review phase - "Visual consistency check":**
+1. Are colors from the design system palette?
+2. Are fonts/sizes from typography scale?
+3. Are spacing values from the spacing scale?
+4. Do new components follow existing patterns?
+
+**If no DESIGN_SYSTEM.md exists:** Skip these checks (project has no documented design system).
+
+## Deployment Tasks (If Task Involves Deploy)
+
+**When to check:** Task mentions "deploy", "release", "push to prod", "staging", etc.
+**When to skip:** Code changes only, no deployment involved.
+
+**Before any deployment:**
+1. Read ARCHITECTURE.md → Find the Environments table and Deployment Checklist
+2. Verify which environment is the target (dev/staging/prod)
+3. Follow the deployment checklist in ARCHITECTURE.md
+
+**Confidence levels for deployment:**
+
+| Target | Required Confidence | If Lower |
+|--------|---------------------|----------|
+| Dev/Preview | MEDIUM or higher | Proceed with caution |
+| Staging | MEDIUM or higher | Proceed, note uncertainties |
+| **Production** | **HIGH only** | **ASK USER before deploying** |
+
+**Production deployment requires:**
+- All tests passing
+- Production build succeeding
+- Changes tested in staging/preview first
+- HIGH confidence (90%+)
+- If ANY doubt → ASK USER first
+
+**If ARCHITECTURE.md has no Environments section:** Ask user "How do you deploy to [target]?" before proceeding.
+
+## DELETE Legacy Code
+
+- Legacy code? DELETE IT
+- Backwards compatibility? NO - DELETE IT
+- "Just in case" fallbacks? DELETE IT
+
+**THE RULE:** Delete old code first. If it breaks, fix it properly.
+
+---
+
+**Full reference:** SDLC.md

--- a/cli/templates/skills/testing/SKILL.md
+++ b/cli/templates/skills/testing/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: testing
+description: TDD and testing philosophy for writing tests, test-driven development, integration tests, and unit tests. Use this skill when writing tests, doing TDD, or debugging test issues.
+argument-hint: [test type] [target]
+effort: high
+---
+# Testing Skill - TDD & Testing Philosophy
+
+## Task
+$ARGUMENTS
+
+## Testing Diamond (CRITICAL)
+
+```
+    /\         <- Few E2E (automated or manual sign-off at end)
+   /  \
+  /    \
+ /------\
+|        |     <- MANY Integration (real DB, real cache - BEST BANG FOR BUCK)
+|        |
+ \------/
+  \    /
+   \  /
+    \/         <- Few Unit (pure logic only)
+```
+
+**Why Integration Tests are Best Bang for Buck:**
+- **Speed**: Fast enough to run on every change
+- **Stability**: Touch real code, not mocks that lie
+- **Confidence**: If they pass, production usually works
+- **Real bugs**: Integration tests with real DB catch real bugs
+- Unit tests with mocks can "pass" while production fails
+
+## Minimal Mocking Philosophy
+
+| What | Mock? | Why |
+|------|-------|-----|
+| Database | NEVER | Use test DB or in-memory |
+| Cache | NEVER | Use isolated test instance |
+| External APIs | YES | Real calls = flaky + expensive |
+| Time/Date | YES | Determinism |
+
+**Mocks MUST come from REAL captured data:**
+- Capture real API response
+- Save to your fixtures directory (Claude will discover where yours is, e.g., `tests/fixtures/`, `test-data/`, etc.)
+- Import in tests
+- Never guess mock shapes!
+
+## TDD Tests Must PROVE
+
+| Phase | What It Proves |
+|-------|----------------|
+| RED | Test FAILS -> Bug exists or feature missing |
+| GREEN | Test PASSES -> Fix works or feature implemented |
+| Forever | Regression protection |
+
+**WRONG approach:**
+```
+// Writing test that passes with current (buggy) code
+assert currentBuggyBehavior == currentBuggyBehavior  // pseudocode
+```
+
+**CORRECT approach:**
+```
+// Writing test that FAILS with buggy code, PASSES with fix
+assert result.status == 'success'   // pseudocode - adapt to your framework
+assert result.data != null
+```
+
+## Unit Tests = Pure Logic ONLY
+
+A function qualifies for unit testing ONLY if:
+- No database calls
+- No external API calls
+- No file system access
+- No cache calls
+- Input -> Output transformation only
+
+Everything else needs integration tests.
+
+## When Stuck on Tests
+
+1. Add console.logs -> Check output
+2. Run single test in isolation
+3. Check fixtures match real API
+4. **STILL stuck?** ASK USER
+
+## After Session (Capture Learnings)
+
+If this session revealed testing insights, update the right place:
+- **Testing patterns, gotchas** -> `TESTING.md`
+- **Feature-specific test quirks** -> Feature docs (`*_PLAN.md`)
+- **General project context** -> `CLAUDE.md` (or `/revise-claude-md`)
+
+---
+
+**Full reference:** TESTING.md

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "agentic-sdlc-wizard",
+  "version": "1.15.0",
+  "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
+  "bin": {
+    "sdlc-wizard": "./cli/bin/sdlc-wizard.js"
+  },
+  "files": [
+    "cli/",
+    "CLAUDE_CODE_SDLC_WIZARD.md",
+    "CHANGELOG.md"
+  ],
+  "keywords": [
+    "claude-code",
+    "sdlc",
+    "tdd",
+    "ai-agent",
+    "developer-tools",
+    "code-quality"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BaseInfinity/agentic-ai-sdlc-wizard"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+# Test CLI distribution tool (agentic-sdlc-wizard)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI="$SCRIPT_DIR/../cli/bin/sdlc-wizard.js"
+PASSED=0
+FAILED=0
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAILED=$((FAILED + 1))
+}
+
+# Create a fresh temp dir for each test
+make_temp() {
+    local d
+    d=$(mktemp -d "${TMPDIR:-/tmp}/sdlc-cli-test-XXXXXX")
+    echo "$d"
+}
+
+echo "=== CLI Distribution Tests ==="
+echo ""
+
+# Test 1: --help exits 0 and shows usage
+test_help() {
+    if node "$CLI" --help 2>&1 | grep -q "Usage:"; then
+        pass "--help exits 0 and shows usage"
+    else
+        fail "--help should show usage text"
+    fi
+}
+
+# Test 2: --version exits 0 and matches package.json
+test_version() {
+    local cli_version pkg_version
+    cli_version=$(node "$CLI" --version 2>&1)
+    pkg_version=$(node -e "console.log(require('$SCRIPT_DIR/../package.json').version)")
+    if [ "$cli_version" = "$pkg_version" ]; then
+        pass "--version ($cli_version) matches package.json"
+    else
+        fail "--version ($cli_version) should match package.json ($pkg_version)"
+    fi
+}
+
+# Test 3: init --dry-run creates no files
+test_dry_run_no_files() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init --dry-run > /dev/null 2>&1)
+    if [ ! -d "$d/.claude" ]; then
+        pass "init --dry-run creates no files"
+    else
+        fail "init --dry-run should not create any files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 4: init creates all 7 expected files
+test_creates_all_files() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local count=0
+    [ -f "$d/.claude/settings.json" ] && count=$((count + 1))
+    [ -f "$d/.claude/hooks/sdlc-prompt-check.sh" ] && count=$((count + 1))
+    [ -f "$d/.claude/hooks/tdd-pretool-check.sh" ] && count=$((count + 1))
+    [ -f "$d/.claude/hooks/instructions-loaded-check.sh" ] && count=$((count + 1))
+    [ -f "$d/.claude/skills/sdlc/SKILL.md" ] && count=$((count + 1))
+    [ -f "$d/.claude/skills/testing/SKILL.md" ] && count=$((count + 1))
+    [ -f "$d/CLAUDE_CODE_SDLC_WIZARD.md" ] && count=$((count + 1))
+    if [ "$count" -eq 7 ]; then
+        pass "init creates all 7 expected files"
+    else
+        fail "init should create 7 files, found $count"
+    fi
+    rm -rf "$d"
+}
+
+# Test 5: init sets hooks as executable
+test_hooks_executable() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local exec_count=0
+    [ -x "$d/.claude/hooks/sdlc-prompt-check.sh" ] && exec_count=$((exec_count + 1))
+    [ -x "$d/.claude/hooks/tdd-pretool-check.sh" ] && exec_count=$((exec_count + 1))
+    [ -x "$d/.claude/hooks/instructions-loaded-check.sh" ] && exec_count=$((exec_count + 1))
+    if [ "$exec_count" -eq 3 ]; then
+        pass "init sets all 3 hooks as executable"
+    else
+        fail "init should set 3 hooks as executable, found $exec_count"
+    fi
+    rm -rf "$d"
+}
+
+# Test 6: init skips existing files without --force
+test_skip_existing() {
+    local d
+    d=$(make_temp)
+    mkdir -p "$d/.claude/hooks"
+    echo "existing" > "$d/.claude/settings.json"
+    local output
+    output=$(cd "$d" && node "$CLI" init 2>&1)
+    if echo "$output" | grep -q "SKIP.*settings.json"; then
+        # Verify file was NOT overwritten
+        local content
+        content=$(cat "$d/.claude/settings.json")
+        if [ "$content" = "existing" ]; then
+            pass "init skips existing files without --force"
+        else
+            fail "init should not overwrite existing files without --force"
+        fi
+    else
+        fail "init should report SKIP for existing files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 7: init --force overwrites existing files
+test_force_overwrite() {
+    local d
+    d=$(make_temp)
+    mkdir -p "$d/.claude/hooks"
+    echo "old" > "$d/.claude/settings.json"
+    (cd "$d" && node "$CLI" init --force > /dev/null 2>&1)
+    local content
+    content=$(cat "$d/.claude/settings.json")
+    if [ "$content" != "old" ]; then
+        pass "init --force overwrites existing files"
+    else
+        fail "init --force should overwrite existing files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 8: init creates correct directory structure
+test_dir_structure() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local ok=true
+    [ -d "$d/.claude/hooks" ] || ok=false
+    [ -d "$d/.claude/skills/sdlc" ] || ok=false
+    [ -d "$d/.claude/skills/testing" ] || ok=false
+    if [ "$ok" = true ]; then
+        pass "init creates correct directory structure"
+    else
+        fail "init should create .claude/hooks, .claude/skills/sdlc, .claude/skills/testing"
+    fi
+    rm -rf "$d"
+}
+
+# Test 9: init copies wizard doc
+test_wizard_doc() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    if [ -f "$d/CLAUDE_CODE_SDLC_WIZARD.md" ] && grep -q "SDLC Wizard" "$d/CLAUDE_CODE_SDLC_WIZARD.md"; then
+        pass "init copies wizard doc with correct content"
+    else
+        fail "init should copy CLAUDE_CODE_SDLC_WIZARD.md"
+    fi
+    rm -rf "$d"
+}
+
+# Test 10: settings.json is valid JSON with 3 hook events
+test_settings_json() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local hook_count
+    hook_count=$(python3 -c "
+import json, sys
+with open('$d/.claude/settings.json') as f:
+    data = json.load(f)
+hooks = data.get('hooks', {})
+print(len(hooks))
+" 2>/dev/null)
+    if [ "$hook_count" = "3" ]; then
+        pass "settings.json is valid JSON with 3 hook events"
+    else
+        fail "settings.json should have 3 hook events, found: $hook_count"
+    fi
+    rm -rf "$d"
+}
+
+# Test 11: .gitignore gets required entries
+test_gitignore_append() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local ok=true
+    grep -q ".claude/plans/" "$d/.gitignore" || ok=false
+    grep -q ".claude/settings.local.json" "$d/.gitignore" || ok=false
+    if [ "$ok" = true ]; then
+        pass ".gitignore gets required entries"
+    else
+        fail ".gitignore should contain .claude/plans/ and .claude/settings.local.json"
+    fi
+    rm -rf "$d"
+}
+
+# Test 12: .gitignore entries not duplicated on re-run
+test_gitignore_no_dupes() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    (cd "$d" && node "$CLI" init --force > /dev/null 2>&1)
+    local count
+    count=$(grep -c ".claude/plans/" "$d/.gitignore")
+    if [ "$count" -eq 1 ]; then
+        pass ".gitignore entries not duplicated on re-run"
+    else
+        fail ".gitignore should have exactly 1 .claude/plans/ entry, found $count"
+    fi
+    rm -rf "$d"
+}
+
+# Test 13: Template hooks contain expected content
+test_hook_content() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local ok=true
+    grep -q "SDLC BASELINE" "$d/.claude/hooks/sdlc-prompt-check.sh" || ok=false
+    grep -q "TDD CHECK" "$d/.claude/hooks/tdd-pretool-check.sh" || ok=false
+    grep -q "SDLC wizard files" "$d/.claude/hooks/instructions-loaded-check.sh" || ok=false
+    if [ "$ok" = true ]; then
+        pass "Template hooks contain expected content"
+    else
+        fail "Template hooks should contain SDLC BASELINE, TDD CHECK, SDLC wizard files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 14: Template skills have correct frontmatter
+test_skill_frontmatter() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local ok=true
+    grep -q "^name: sdlc$" "$d/.claude/skills/sdlc/SKILL.md" || ok=false
+    grep -q "^effort: high$" "$d/.claude/skills/sdlc/SKILL.md" || ok=false
+    grep -q "^name: testing$" "$d/.claude/skills/testing/SKILL.md" || ok=false
+    grep -q "^effort: high$" "$d/.claude/skills/testing/SKILL.md" || ok=false
+    if [ "$ok" = true ]; then
+        pass "Template skills have correct frontmatter (name + effort)"
+    else
+        fail "Skills should have name and effort: high in frontmatter"
+    fi
+    rm -rf "$d"
+}
+
+# Test 15: Template tdd hook uses /src/ pattern (not .github/workflows/)
+test_tdd_hook_generic() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    if grep -q '"/src/"' "$d/.claude/hooks/tdd-pretool-check.sh"; then
+        if ! grep -q '.github/workflows/' "$d/.claude/hooks/tdd-pretool-check.sh"; then
+            pass "Template tdd hook uses /src/ pattern (generic)"
+        else
+            fail "Template tdd hook should NOT reference .github/workflows/"
+        fi
+    else
+        fail "Template tdd hook should use /src/ pattern"
+    fi
+    rm -rf "$d"
+}
+
+# Test 16: Template settings.json has NO allowedTools key
+test_no_allowed_tools() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    if ! grep -q "allowedTools" "$d/.claude/settings.json"; then
+        pass "Template settings.json has no allowedTools key"
+    else
+        fail "Template settings.json should NOT have allowedTools (project-specific)"
+    fi
+    rm -rf "$d"
+}
+
+# Run all tests
+test_help
+test_version
+test_dry_run_no_files
+test_creates_all_files
+test_hooks_executable
+test_skip_existing
+test_force_overwrite
+test_dir_structure
+test_wizard_doc
+test_settings_json
+test_gitignore_append
+test_gitignore_no_dupes
+test_hook_content
+test_skill_frontmatter
+test_tdd_hook_generic
+test_no_allowed_tools
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+
+if [ $FAILED -gt 0 ]; then
+    exit 1
+fi
+
+echo ""
+echo "All CLI distribution tests passed!"


### PR DESCRIPTION
## Summary

- Adds `npx agentic-sdlc-wizard init` — one-command installation of the full SDLC enforcement layer
- Copies 7 files: 3 hooks, 2 skills, settings.json, wizard doc
- Generic templates (not meta-repo-specific — tdd hook uses `/src/`, testing skill omits meta-repo section)
- Zero runtime dependencies, Node 18+, CommonJS
- `--force` to overwrite, `--dry-run` to preview
- 16 regression tests in `tests/test-cli.sh`
- Appends `.claude/plans/` and `.claude/settings.local.json` to `.gitignore`

## Test plan

- [x] 16 CLI tests pass locally
- [x] All existing tests pass (self-update: 21, compliance: 10, hooks: 24, version: 13, schema: 9, json: 7)
- [x] Smoke tested: init, --force, --dry-run, --help, --version
- [ ] CI validates + E2E quick check pass