### PR TITLE
feat(eval): harness design patterns — calibrated evaluator + critical criteria

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -49,6 +49,26 @@ TodoWrite([
 ])
 ```
 
+## SDLC Quality Checklist (Scoring Rubric)
+
+Your work is scored on these criteria. **Critical** criteria are must-pass.
+
+| Criterion | Points | Critical? | What Counts |
+|-----------|--------|-----------|-------------|
+| task_tracking | 1 | | Use TodoWrite or TaskCreate |
+| confidence | 1 | | State HIGH/MEDIUM/LOW |
+| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files |
+| plan_mode_outline | 1 | | Outline steps before coding |
+| plan_mode_tool | 1 | | Use TodoWrite/TaskCreate/EnterPlanMode |
+| tdd_green_ran | 1 | | Run tests, show runner output |
+| tdd_green_pass | 1 | | All tests pass in final run |
+| self_review | 1 | **YES** | Read back files/diffs you modified |
+| clean_code | 1 | | One coherent approach, no dead code |
+
+**Total: 10 points** (11 for UI tasks, +1 for design_system check)
+
+Critical miss on `tdd_red` or `self_review` = process failure regardless of total score.
+
 ## New Pattern & Test Design Scrutiny (PLANNING)
 
 **New design patterns require human approval:**

--- a/cli/templates/skills/sdlc/SKILL.md
+++ b/cli/templates/skills/sdlc/SKILL.md
@@ -49,6 +49,26 @@ TodoWrite([
 ])
 ```
 
+## SDLC Quality Checklist (Scoring Rubric)
+
+Your work is scored on these criteria. **Critical** criteria are must-pass.
+
+| Criterion | Points | Critical? | What Counts |
+|-----------|--------|-----------|-------------|
+| task_tracking | 1 | | Use TodoWrite or TaskCreate |
+| confidence | 1 | | State HIGH/MEDIUM/LOW |
+| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files |
+| plan_mode_outline | 1 | | Outline steps before coding |
+| plan_mode_tool | 1 | | Use TodoWrite/TaskCreate/EnterPlanMode |
+| tdd_green_ran | 1 | | Run tests, show runner output |
+| tdd_green_pass | 1 | | All tests pass in final run |
+| self_review | 1 | **YES** | Read back files/diffs you modified |
+| clean_code | 1 | | One coherent approach, no dead code |
+
+**Total: 10 points** (11 for UI tasks, +1 for design_system check)
+
+Critical miss on `tdd_red` or `self_review` = process failure regardless of total score.
+
 ## New Pattern & Test Design Scrutiny (PLANNING)
 
 **New design patterns require human approval:**

--- a/tests/e2e/evaluate.sh
+++ b/tests/e2e/evaluate.sh
@@ -240,6 +240,14 @@ EVAL_RESULT=$(echo "$EVAL_RESULT" | jq \
     .max_score = ([.criteria[].max] | add)
     ')
 
+# Check critical criteria (self_review and tdd_red are must-pass)
+CRITICAL_RESULT=$(check_critical_criteria "$EVAL_RESULT")
+CRITICAL_MISS=$(echo "$CRITICAL_RESULT" | jq -r '.critical_miss')
+CRITICAL_FAILURES=$(echo "$CRITICAL_RESULT" | jq -c '.critical_failures')
+if [ "$CRITICAL_MISS" = "true" ]; then
+    echo "CRITICAL MISS: $CRITICAL_FAILURES" >&2
+fi
+
 # Parse the evaluation result
 SCORE=$(echo "$EVAL_RESULT" | jq -r '.score // 0')
 SUMMARY=$(echo "$EVAL_RESULT" | jq -r '.summary // "No summary"')
@@ -260,11 +268,14 @@ if [ -f "$BASELINES_FILE" ]; then
 fi
 
 # Determine pass/warn/fail based on baseline comparison
-# Pass: score >= baseline
+# Pass: score >= baseline AND no critical miss
 # Warn: score >= min_acceptable but < baseline
-# Fail: score < min_acceptable
-# Skip: LLM judge outage already forced PASS=false
-if [ "$LLM_OUTAGE" = "true" ]; then
+# Fail: score < min_acceptable OR critical miss OR LLM outage
+if [ "$CRITICAL_MISS" = "true" ]; then
+    PASS="false"
+    BASELINE_STATUS="fail"
+    echo "FAIL: Critical criteria missed ($CRITICAL_FAILURES) — process failure regardless of score" >&2
+elif [ "$LLM_OUTAGE" = "true" ]; then
     BASELINE_STATUS="fail"
 elif [ "$(echo "$SCORE >= $BASELINE" | bc -l)" -eq 1 ]; then
     PASS="true"
@@ -332,10 +343,14 @@ if [ "$JSON_OUTPUT" = "--json" ]; then
         --arg sdp_interpretation "$SDP_INTERPRETATION" \
         --argjson eval_duration "$EVAL_DURATION" \
         --arg eval_prompt_version "$EVAL_PROMPT_VERSION" \
+        --argjson critical_miss "$CRITICAL_MISS" \
+        --argjson critical_failures "$CRITICAL_FAILURES" \
         '. + {
             pass: ($pass == "true"),
             eval_duration: $eval_duration,
             eval_prompt_version: $eval_prompt_version,
+            critical_miss: $critical_miss,
+            critical_failures: $critical_failures,
             baseline_comparison: {
                 status: $baseline_status,
                 baseline: $baseline,

--- a/tests/e2e/lib/eval-criteria.sh
+++ b/tests/e2e/lib/eval-criteria.sh
@@ -135,6 +135,10 @@ Did the agent outline steps or create a plan before writing code?
 
 Look for: numbered steps, bullet-point plan, "here's my approach", task breakdown,
 or any explicit planning before implementation begins. YES/NO.
+
+## Calibration Examples
+YES example: "Agent listed 3 numbered steps: 1) read existing code, 2) write tests, 3) implement fix"
+NO example: "Agent immediately started editing files without describing any approach"
 Q
             ;;
         plan_mode_tool)
@@ -144,6 +148,10 @@ Did the agent use a structured tool to plan or track work before coding?
 Look for: TodoWrite or TaskCreate usage (creating a task list IS structured planning),
 EnterPlanMode, or writing a plan file. Any of these count as YES.
 Simply describing steps verbally without using any tool does NOT count. YES/NO.
+
+## Calibration Examples
+YES example: "Agent called TodoWrite with 4 tasks before any Edit tool calls"
+NO example: "Agent described steps in text but never used TodoWrite/TaskCreate/EnterPlanMode"
 Q
             ;;
         tdd_green_ran)
@@ -152,6 +160,10 @@ Does the output show test execution output (e.g., test runner results, PASS/FAIL
 
 Look for: test runner output like "X tests passed", "PASS", "FAIL", pytest/jest/mocha
 output, or any clear evidence that tests were actually run. YES/NO.
+
+## Calibration Examples
+YES example: "Output shows: 'Tests: 5 passed, 5 total'"
+NO example: "Agent said 'tests should pass' but no test runner output appears"
 Q
             ;;
         tdd_green_pass)
@@ -160,6 +172,10 @@ Do all tests pass in the final test run shown in the output?
 
 Look for: the LAST test execution in the output. Do all tests pass? If there are
 failures in the final run, answer NO. If no tests were run, answer NO. YES/NO.
+
+## Calibration Examples
+YES example: "Final test run shows: '12 passed, 0 failed'"
+NO example: "Last test output shows: '11 passed, 1 failed' — there's a remaining failure"
 Q
             ;;
         self_review)
@@ -170,6 +186,10 @@ Look for: reading back specific files or diffs they modified, running a review
 command, or examining their output for correctness. Simply stating "let me review"
 or "I'll review my changes" without actually reading back files does NOT count.
 Must show evidence of actually inspecting the work product. YES/NO.
+
+## Calibration Examples
+YES example: "Agent used Read tool on files it modified, ran git diff, caught a typo and fixed it"
+NO example: "Agent stated 'I reviewed my changes' but never used Read/Grep/diff on modified files"
 Q
             ;;
         clean_code)
@@ -180,6 +200,10 @@ Look for: no abandoned partial implementations left in, no contradictory changes
 that undo earlier work, no commented-out or dead code, and no disorganized
 jumping between unrelated changes. A single clear path from plan to completion
 counts as YES. YES/NO.
+
+## Calibration Examples
+YES example: "Agent planned a single approach, implemented it, tests passed — no abandoned code"
+NO example: "Agent tried approach A, abandoned it halfway, switched to approach B, left commented-out code from A"
 Q
             ;;
         design_system)
@@ -188,6 +212,10 @@ Did the agent check DESIGN_SYSTEM.md or reference design tokens before making UI
 
 Look for: reading DESIGN_SYSTEM.md, referencing design variables/tokens,
 or explicitly consulting the design system. YES/NO.
+
+## Calibration Examples
+YES example: "Agent Read DESIGN_SYSTEM.md, used --primary-color token from the design system"
+NO example: "Agent hardcoded #3b82f6 without checking the design system"
 Q
             ;;
         *)

--- a/tests/e2e/lib/eval-validation.sh
+++ b/tests/e2e/lib/eval-validation.sh
@@ -11,7 +11,7 @@
 #   source "$(dirname "$0")/lib/eval-validation.sh"
 
 # Prompt version — increment when the eval prompt changes materially
-EVAL_PROMPT_VERSION="v5"
+EVAL_PROMPT_VERSION="v6"
 
 # Validate that eval result JSON has required structure
 #
@@ -151,6 +151,30 @@ clamp_criteria_bounds() {
                 end
             )
         ) | from_entries)
+    '
+}
+
+# Check critical criteria — self_review and tdd_red are must-pass
+# Failing either means the SDLC process was fundamentally violated.
+#
+# Args:
+#   $1 - JSON string with .criteria object (must include tdd_red and self_review)
+#
+# Returns:
+#   JSON string: {"critical_miss": bool, "critical_failures": [...]}
+check_critical_criteria() {
+    local json="$1"
+    echo "$json" | jq '
+        {
+            critical_miss: (
+                (.criteria.self_review.points == 0) or
+                (.criteria.tdd_red.points == 0)
+            ),
+            critical_failures: [
+                (if .criteria.tdd_red.points == 0 then "tdd_red" else empty end),
+                (if .criteria.self_review.points == 0 then "self_review" else empty end)
+            ]
+        }
     '
 }
 

--- a/tests/e2e/test-eval-validation.sh
+++ b/tests/e2e/test-eval-validation.sh
@@ -805,6 +805,136 @@ test_tdd_consistency_forces_pass_to_no
 test_tdd_consistency_noop_when_ran
 test_tdd_consistency_forces_even_when_already_zero
 
+# -----------------------------------------------
+# check_critical_criteria tests
+# -----------------------------------------------
+echo ""
+echo "--- check_critical_criteria ---"
+
+test_critical_criteria_all_pass() {
+    local json='{
+        "criteria": {
+            "tdd_red": {"points": 2, "max": 2, "evidence": "Test before impl"},
+            "self_review": {"points": 1, "max": 1, "evidence": "Reviewed files"},
+            "clean_code": {"points": 1, "max": 1, "evidence": "Clean"}
+        }
+    }'
+    local result
+    result=$(check_critical_criteria "$json" 2>/dev/null) || true
+    if [ -z "$result" ]; then
+        fail "check_critical_criteria should return a result"
+        return
+    fi
+    local miss
+    miss=$(echo "$result" | jq -r '.critical_miss')
+    if [ "$miss" = "false" ]; then
+        pass "All critical criteria pass → critical_miss=false"
+    else
+        fail "Expected critical_miss=false, got $miss"
+    fi
+}
+
+test_critical_criteria_self_review_fail() {
+    local json='{
+        "criteria": {
+            "tdd_red": {"points": 2, "max": 2, "evidence": "Test before impl"},
+            "self_review": {"points": 0, "max": 1, "evidence": "No review"},
+            "clean_code": {"points": 1, "max": 1, "evidence": "Clean"}
+        }
+    }'
+    local result
+    result=$(check_critical_criteria "$json" 2>/dev/null) || true
+    if [ -z "$result" ]; then
+        fail "check_critical_criteria should return a result"
+        return
+    fi
+    local miss failures
+    miss=$(echo "$result" | jq -r '.critical_miss')
+    failures=$(echo "$result" | jq -r '.critical_failures | join(",")')
+    if [ "$miss" = "true" ] && [ "$failures" = "self_review" ]; then
+        pass "self_review=0 → critical_miss=true, failures=[self_review]"
+    else
+        fail "Expected critical_miss=true + self_review failure, got miss=$miss failures=$failures"
+    fi
+}
+
+test_critical_criteria_tdd_red_fail() {
+    local json='{
+        "criteria": {
+            "tdd_red": {"points": 0, "max": 2, "evidence": "No TDD"},
+            "self_review": {"points": 1, "max": 1, "evidence": "Reviewed"},
+            "clean_code": {"points": 1, "max": 1, "evidence": "Clean"}
+        }
+    }'
+    local result
+    result=$(check_critical_criteria "$json" 2>/dev/null) || true
+    if [ -z "$result" ]; then
+        fail "check_critical_criteria should return a result"
+        return
+    fi
+    local miss failures
+    miss=$(echo "$result" | jq -r '.critical_miss')
+    failures=$(echo "$result" | jq -r '.critical_failures | join(",")')
+    if [ "$miss" = "true" ] && [ "$failures" = "tdd_red" ]; then
+        pass "tdd_red=0 → critical_miss=true, failures=[tdd_red]"
+    else
+        fail "Expected critical_miss=true + tdd_red failure, got miss=$miss failures=$failures"
+    fi
+}
+
+test_critical_criteria_both_fail() {
+    local json='{
+        "criteria": {
+            "tdd_red": {"points": 0, "max": 2, "evidence": "No TDD"},
+            "self_review": {"points": 0, "max": 1, "evidence": "No review"},
+            "clean_code": {"points": 1, "max": 1, "evidence": "Clean"}
+        }
+    }'
+    local result
+    result=$(check_critical_criteria "$json" 2>/dev/null) || true
+    if [ -z "$result" ]; then
+        fail "check_critical_criteria should return a result"
+        return
+    fi
+    local miss count
+    miss=$(echo "$result" | jq -r '.critical_miss')
+    count=$(echo "$result" | jq '.critical_failures | length')
+    if [ "$miss" = "true" ] && [ "$count" = "2" ]; then
+        pass "Both critical criteria fail → critical_miss=true, 2 failures"
+    else
+        fail "Expected critical_miss=true + 2 failures, got miss=$miss count=$count"
+    fi
+}
+
+test_critical_criteria_non_critical_fail() {
+    local json='{
+        "criteria": {
+            "tdd_red": {"points": 2, "max": 2, "evidence": "Test before impl"},
+            "self_review": {"points": 1, "max": 1, "evidence": "Reviewed"},
+            "clean_code": {"points": 0, "max": 1, "evidence": "Messy"}
+        }
+    }'
+    local result
+    result=$(check_critical_criteria "$json" 2>/dev/null) || true
+    if [ -z "$result" ]; then
+        fail "check_critical_criteria should return a result"
+        return
+    fi
+    local miss
+    miss=$(echo "$result" | jq -r '.critical_miss')
+    if [ "$miss" = "false" ]; then
+        pass "Non-critical fail (clean_code=0) → critical_miss=false"
+    else
+        fail "Expected critical_miss=false for non-critical failure, got $miss"
+    fi
+}
+
+test_critical_criteria_all_pass
+test_critical_criteria_self_review_fail
+test_critical_criteria_tdd_red_fail
+test_critical_criteria_both_fail
+test_critical_criteria_non_critical_fail
+
 test_tech_debt_not_ui
 test_requires_not_ui
 test_actual_ui_detected

--- a/tests/e2e/test-multi-call-eval.sh
+++ b/tests/e2e/test-multi-call-eval.sh
@@ -45,11 +45,11 @@ echo ""
 
 echo "--- Prompt version ---"
 
-test_prompt_version_v5() {
-    if [ "$EVAL_PROMPT_VERSION" = "v5" ]; then
-        pass "EVAL_PROMPT_VERSION is v5"
+test_prompt_version_v6() {
+    if [ "$EVAL_PROMPT_VERSION" = "v6" ]; then
+        pass "EVAL_PROMPT_VERSION is v6"
     else
-        fail "EVAL_PROMPT_VERSION should be v5, got: $EVAL_PROMPT_VERSION"
+        fail "EVAL_PROMPT_VERSION should be v6, got: $EVAL_PROMPT_VERSION"
     fi
 }
 
@@ -383,10 +383,61 @@ test_finalize_perfect_score_no_improvements() {
 }
 
 # -----------------------------------------------
+# Few-shot calibration tests
+# -----------------------------------------------
+
+echo ""
+echo "--- Few-shot calibration examples ---"
+
+test_few_shot_examples_in_prompts() {
+    local criteria
+    criteria=$(get_llm_criteria "ui")  # UI has all criteria
+    local all_have=true
+    for name in $criteria; do
+        local question
+        question=$(_get_binary_question "$name")
+        if ! echo "$question" | grep -q "YES example:"; then
+            all_have=false
+            fail "$name prompt missing 'YES example:'"
+            break
+        fi
+        if ! echo "$question" | grep -q "NO example:"; then
+            all_have=false
+            fail "$name prompt missing 'NO example:'"
+            break
+        fi
+    done
+    if [ "$all_have" = true ]; then
+        pass "All criterion prompts contain YES and NO calibration examples"
+    fi
+}
+
+test_few_shot_examples_distinct() {
+    local criteria
+    criteria=$(get_llm_criteria "standard")
+    local all_distinct=true
+    for name in $criteria; do
+        local question
+        question=$(_get_binary_question "$name")
+        local yes_example no_example
+        yes_example=$(echo "$question" | grep "YES example:" | head -1)
+        no_example=$(echo "$question" | grep "NO example:" | head -1)
+        if [ "$yes_example" = "$no_example" ]; then
+            all_distinct=false
+            fail "$name YES and NO examples are identical"
+            break
+        fi
+    done
+    if [ "$all_distinct" = true ]; then
+        pass "All criterion YES/NO examples are distinct"
+    fi
+}
+
+# -----------------------------------------------
 # Run all tests
 # -----------------------------------------------
 
-test_prompt_version_v5
+test_prompt_version_v6
 test_criteria_list_standard
 test_criteria_list_ui
 test_criteria_names_standard
@@ -409,6 +460,8 @@ test_aggregate_preserves_evidence
 test_finalize_adds_summary
 test_finalize_validates_schema
 test_finalize_perfect_score_no_improvements
+test_few_shot_examples_in_prompts
+test_few_shot_examples_distinct
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
## Summary

- Added few-shot YES/NO calibration examples to all 7 LLM judge criterion prompts (reduces scoring variance per Anthropic harness research)
- Added `check_critical_criteria()` — `tdd_red` and `self_review` are now must-pass criteria. Failing either = process failure regardless of total score (enforced in evaluate.sh)
- Added scoring rubric to SDLC skill so the agent knows exactly what it will be measured on (both copies kept in sync)
- Bumped EVAL_PROMPT_VERSION v5→v6. 8 new tests (46 eval-validation + 25 multi-call-eval). Codex cross-model review passed after critical enforcement fix.

## Test plan

- [x] 8 new tests pass (5 critical criteria + 2 few-shot + 1 version bump)
- [x] Full test suite 330+ tests, 0 failures
- [x] Codex cross-model review — found critical_miss wasn't enforced, fixed
- [ ] CI `validate` job passes
- [ ] CI `e2e-quick-check` verifies score STABLE or IMPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)