### PR TITLE
fix(sdlc): close 5 enforcement gaps in TodoWrite checklist (#39)

### DIFF
--- a/.claude/skills/sdlc/SKILL.md
+++ b/.claude/skills/sdlc/SKILL.md
@@ -18,7 +18,7 @@ TodoWrite([
   // PLANNING PHASE (Plan Mode for non-trivial tasks)
   { content: "Find and read relevant documentation", status: "in_progress", activeForm: "Reading docs" },
   { content: "Assess doc health - flag issues (ask before cleaning)", status: "pending", activeForm: "Checking doc health" },
-  { content: "DRY scan: What patterns exist to reuse?", status: "pending", activeForm: "Scanning for reusable patterns" },
+  { content: "DRY scan: What patterns exist to reuse? New pattern = get approval", status: "pending", activeForm: "Scanning for reusable patterns" },
   { content: "Blast radius: What depends on code I'm changing?", status: "pending", activeForm: "Checking dependencies" },
   { content: "Design system check (if UI change)", status: "pending", activeForm: "Checking design system" },
   { content: "Restate task in own words - verify understanding", status: "pending", activeForm: "Verifying understanding" },
@@ -39,12 +39,15 @@ TodoWrite([
   { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
   { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
   { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
+  { content: "Scope guard: only changes related to task? No legacy/fallback code left?", status: "pending", activeForm: "Checking scope and legacy code" },
   // CI FEEDBACK LOOP (if CI monitoring enabled in setup - skip if no CI)
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
   { content: "Read CI review - implement valid suggestions, iterate until clean", status: "pending", activeForm: "Addressing CI review feedback" },
+  { content: "Post-deploy verification (if deploy task — see Deployment Tasks)", status: "pending", activeForm: "Verifying deployment" },
   // FINAL
-  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" }
+  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" },
+  { content: "Capture learnings (if any — update TESTING.md, CLAUDE.md, or feature docs)", status: "pending", activeForm: "Capturing session learnings" }
 ])
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@
 | 36 | CI Local Shepherd Model | Research: replace autofix bot back-and-forth with local CI shepherd loop. Agent watches CI, reads all output, fixes locally, pushes once. Iterate until reviewers happy + tests pass. Compare token cost, noise, quality vs bot model. Keep bot as fallback for unattended PRs |
 | 37 | Lesson Contribution Hook | Auto-detect key SDLC lessons during sessions. Offer to create GH issue on user's repo. Optionally contribute back to wizard repo. Hook into "After Session" step — if learnings captured, prompt for issue creation |
 | 38 | `/clear` vs `/compact` Guidance | Research when `/clear` is beneficial vs `/compact` in SDLC workflows. Add recommendation to wizard setup. Most users never use `/clear` — validate if that's optimal or if there are cases where fresh context beats compressed context |
+| 39 | SDLC Enforcement Gap Audit | DONE — Audited all documented SDLC sections vs TodoWrite/hook/E2E enforcement. Fixed 5 gaps: capture learnings, scope guard, deploy tasks, new pattern approval, legacy delete check. Enforcement coverage 7/12 → 12/12. 6 new tests. Future: add E2E scoring criteria for scope_guard, after_session, deploy |
 
 ## Review Pipeline
 

--- a/cli/templates/skills/sdlc/SKILL.md
+++ b/cli/templates/skills/sdlc/SKILL.md
@@ -18,7 +18,7 @@ TodoWrite([
   // PLANNING PHASE (Plan Mode for non-trivial tasks)
   { content: "Find and read relevant documentation", status: "in_progress", activeForm: "Reading docs" },
   { content: "Assess doc health - flag issues (ask before cleaning)", status: "pending", activeForm: "Checking doc health" },
-  { content: "DRY scan: What patterns exist to reuse?", status: "pending", activeForm: "Scanning for reusable patterns" },
+  { content: "DRY scan: What patterns exist to reuse? New pattern = get approval", status: "pending", activeForm: "Scanning for reusable patterns" },
   { content: "Blast radius: What depends on code I'm changing?", status: "pending", activeForm: "Checking dependencies" },
   { content: "Design system check (if UI change)", status: "pending", activeForm: "Checking design system" },
   { content: "Restate task in own words - verify understanding", status: "pending", activeForm: "Verifying understanding" },
@@ -39,12 +39,15 @@ TodoWrite([
   { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
   { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
   { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
+  { content: "Scope guard: only changes related to task? No legacy/fallback code left?", status: "pending", activeForm: "Checking scope and legacy code" },
   // CI FEEDBACK LOOP (if CI monitoring enabled in setup - skip if no CI)
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
   { content: "Read CI review - implement valid suggestions, iterate until clean", status: "pending", activeForm: "Addressing CI review feedback" },
+  { content: "Post-deploy verification (if deploy task — see Deployment Tasks)", status: "pending", activeForm: "Verifying deployment" },
   // FINAL
-  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" }
+  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" },
+  { content: "Capture learnings (if any — update TESTING.md, CLAUDE.md, or feature docs)", status: "pending", activeForm: "Capturing session learnings" }
 ])
 ```
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -436,6 +436,99 @@ test_template_hook_setup_redirect() {
     fi
 }
 
+# ---------------------------------------------------------------------------
+# SDLC Enforcement Gap Audit Tests
+# Verify that documented SDLC sections have TodoWrite enforcement
+# ---------------------------------------------------------------------------
+
+SKILL_TEMPLATE="$SCRIPT_DIR/../cli/templates/skills/sdlc/SKILL.md"
+
+# Test: TodoWrite checklist has "capture learnings" / "after session" task
+test_todowrite_has_capture_learnings() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    if echo "$todowrite_section" | grep -qi 'capture.*learning\|after.*session\|learnings'; then
+        pass "TodoWrite has capture learnings task"
+    else
+        fail "TodoWrite missing capture learnings task — After Session section not enforced"
+    fi
+}
+
+# Test: TodoWrite checklist has scope guard / stay in lane reminder
+test_todowrite_has_scope_guard() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    if echo "$todowrite_section" | grep -qi 'scope.*guard\|stay.*lane\|scope.*check\|only.*related'; then
+        pass "TodoWrite has scope guard task"
+    else
+        fail "TodoWrite missing scope guard task — Scope Guard section not enforced"
+    fi
+}
+
+# Test: TodoWrite checklist has deployment conditional tasks
+test_todowrite_has_deploy_tasks() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    if echo "$todowrite_section" | grep -qi 'deploy\|post-deploy\|deployment'; then
+        pass "TodoWrite has deployment tasks"
+    else
+        fail "TodoWrite missing deployment tasks — Deployment section not enforced"
+    fi
+}
+
+# Test: TodoWrite checklist has new pattern approval check
+test_todowrite_has_new_pattern_check() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    if echo "$todowrite_section" | grep -qi 'new.*pattern\|pattern.*approv\|pattern.*exist'; then
+        pass "TodoWrite has new pattern approval check"
+    else
+        fail "TodoWrite missing new pattern check — New Pattern section not enforced"
+    fi
+}
+
+# Test: TodoWrite checklist has legacy/delete code check
+test_todowrite_has_legacy_delete_check() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    if echo "$todowrite_section" | grep -qi 'legacy\|delete.*old\|fallback.*code\|backward.*compat'; then
+        pass "TodoWrite has legacy code delete check"
+    else
+        fail "TodoWrite missing legacy delete check — DELETE Legacy Code section not enforced"
+    fi
+}
+
+# Test: Enforcement coverage score — count documented sections with TodoWrite tasks
+# This is the "audit score" — tracks how many prose sections have enforcement
+test_enforcement_coverage_score() {
+    local todowrite_section
+    todowrite_section=$(sed -n '/^TodoWrite(\[/,/^\])/p' "$SKILL_TEMPLATE")
+    local enforced=0
+    local total=12
+
+    # Already enforced (baseline)
+    echo "$todowrite_section" | grep -qi 'doc\|read.*doc' && enforced=$((enforced + 1))          # Planning: read docs
+    echo "$todowrite_section" | grep -qi 'DRY\|reuse\|pattern.*exist' && enforced=$((enforced + 1)) # DRY scan
+    echo "$todowrite_section" | grep -qi 'blast.*radius\|depend' && enforced=$((enforced + 1))    # Blast radius
+    echo "$todowrite_section" | grep -qi 'confidence' && enforced=$((enforced + 1))                # Confidence
+    echo "$todowrite_section" | grep -qi 'TDD RED\|failing test' && enforced=$((enforced + 1))    # TDD RED
+    echo "$todowrite_section" | grep -qi 'self.review\|code.review' && enforced=$((enforced + 1)) # Self-review
+    echo "$todowrite_section" | grep -qi 'security' && enforced=$((enforced + 1))                  # Security review
+
+    # New enforcement (gaps we're fixing)
+    echo "$todowrite_section" | grep -qi 'capture.*learning\|after.*session' && enforced=$((enforced + 1))  # After Session
+    echo "$todowrite_section" | grep -qi 'scope.*guard\|stay.*lane\|scope.*check' && enforced=$((enforced + 1))   # Scope Guard
+    echo "$todowrite_section" | grep -qi 'deploy' && enforced=$((enforced + 1))                    # Deploy tasks
+    echo "$todowrite_section" | grep -qi 'new.*pattern\|pattern.*approv' && enforced=$((enforced + 1))  # New pattern
+    echo "$todowrite_section" | grep -qi 'legacy\|delete.*old\|fallback' && enforced=$((enforced + 1))  # Legacy delete
+
+    if [ "$enforced" -ge "$total" ]; then
+        pass "Enforcement coverage: $enforced/$total documented sections have TodoWrite tasks"
+    else
+        fail "Enforcement coverage: $enforced/$total — missing TodoWrite tasks for $((total - enforced)) documented sections"
+    fi
+}
+
 # Run all tests
 test_sdlc_hook_exists
 test_sdlc_hook_keywords
@@ -467,6 +560,15 @@ test_sdlc_hook_setup_redirect_missing_testing
 test_sdlc_hook_normal_when_setup_complete
 test_sdlc_hook_setup_redirect_empty_stubs
 test_template_hook_setup_redirect
+
+echo ""
+echo "--- SDLC enforcement gap audit ---"
+test_todowrite_has_capture_learnings
+test_todowrite_has_scope_guard
+test_todowrite_has_deploy_tasks
+test_todowrite_has_new_pattern_check
+test_todowrite_has_legacy_delete_check
+test_enforcement_coverage_score
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
## Summary
- Audit found 5 documented SDLC sections with zero TodoWrite enforcement
- Added missing tasks: capture learnings, scope guard, deploy verification, new pattern approval, legacy code check
- Enforcement coverage went from 7/12 → 12/12
- 6 new tests including a coverage score test that catches future regressions

## Test plan
- [x] TDD RED: 5 tests failed (missing TodoWrite tasks)
- [x] TDD GREEN: All 6 new tests pass after adding tasks
- [x] Full suite green (all 12 test scripts)
- [x] Template ↔ live SKILL.md verified identical
- [ ] CI validate passes
- [ ] E2E quick check shows no regression