### PR TITLE
feat(hook): update notification on session start (#64)

### DIFF
--- a/.claude/hooks/instructions-loaded-check.sh
+++ b/.claude/hooks/instructions-loaded-check.sh
@@ -20,4 +20,16 @@ if [ -n "$MISSING" ]; then
     echo "Invoke Skill tool, skill=\"setup-wizard\" to generate them."
 fi
 
+# Version update check (non-blocking, best-effort)
+SDLC_MD="$PROJECT_DIR/SDLC.md"
+if [ -f "$SDLC_MD" ]; then
+    INSTALLED_VERSION=$(grep -o 'SDLC Wizard Version: [0-9.]*' "$SDLC_MD" | head -1 | sed 's/SDLC Wizard Version: //')
+    if [ -n "$INSTALLED_VERSION" ] && command -v npm > /dev/null 2>&1; then
+        LATEST_VERSION=$(npm view agentic-sdlc-wizard version 2>/dev/null) || true
+        if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$INSTALLED_VERSION" ]; then
+            echo "SDLC Wizard update available: ${INSTALLED_VERSION} → ${LATEST_VERSION} (run /update-wizard)"
+        fi
+    fi
+fi
+
 exit 0

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -45,10 +45,11 @@ Extract the latest version from the first `## [X.X.X]` line.
 Parse all CHANGELOG entries between the user's installed version and the latest. Present a clear summary:
 
 ```
-Installed: 1.20.0
-Latest:    1.22.0
+Installed: 1.21.0
+Latest:    1.23.0
 
 What changed:
+- [1.23.0] Update notification hook, ...
 - [1.22.0] Plan auto-approval, debugging workflow, /feedback skill, BRANDING.md detection, ...
 - [1.21.0] Confidence-driven setup, prove-it gate, cross-model release review, ...
 - [1.20.0] Version-pinned CC update gate, Tier 1 flakiness fix, flaky test guidance, ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.23.0] - 2026-04-01
+
+### Added
+- Update notification hook — `instructions-loaded-check.sh` checks npm for newer wizard version each session. Non-blocking, graceful on network failure. One-liner: "SDLC Wizard update available: X → Y (run /update-wizard)" (#64)
+- 6 quality tests for update notification (fake npm in PATH, version comparison, failure modes)
+
 ## [1.22.0] - 2026-04-01
 
 ### Added

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2401,7 +2401,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.22.0 -->
+<!-- SDLC Wizard Version: 1.23.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3302,7 +3302,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.22.0 -->
+<!-- SDLC Wizard Version: 1.23.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@
 
 | Priority | # | Item | Description |
 |----------|---|------|-------------|
-| 1 | 64 | Update Notification Hook | `instructions-loaded-check.sh` checks for newer wizard version on npm each session. One-liner notification, non-blocking, <1s |
+| 1 | 64 | Update Notification Hook | DONE — `instructions-loaded-check.sh` checks npm each session. 6 quality tests (fake npm, version comparison, failure modes). Non-blocking, graceful on network failure |
 | 2 | 59 | Research: CC Architecture (Public Sources) | Deep research CC's public architecture — hook execution, skill loading, plugin system, upcoming features. Are we aligned or fighting it? Cross-model review findings |
 | 3 | 57 | Research: Context Position Audit ("Lost in the Middle") | Audit whether critical instructions are buried in middle of wizard doc / SDLC skill. Restructure if so. Validate with before/after E2E scores |
 | 4 | 56 | Research: Adversarial Review Prompting | Test "find at least N problems" forcing technique. Does it improve self-review and cross-model review quality? A/B validate on real PRs |
@@ -95,6 +95,7 @@
 | 61 | Research: Parity Audit Skill for Migrations | Evaluate subsystem gap analysis with coverage ratios as a potential `/migration` skill (pattern seen in multiple harness projects). Would users doing rewrites benefit from automated parity tracking? Is this a real gap or a theoretical nice-to-have? Prove It Gate applies |
 | 62 | Research: Bidirectional Plugin Ecosystem Loop | Two-way contribution with Anthropic's `knowledge-work-plugins` ecosystem. Inbound: scan official plugins for patterns that outperform our approach (legal, engineering, etc.), adopt or recommend as complementary. Outbound: contribute our proven patterns (TDD enforcement, Prove It Gate, cross-model review) upstream. `/feedback` skill could route contributions both ways — to our repo AND to official plugin repos. Validate: does the `.claude-plugin` + `skills/` structure they use align with ours? What MCP connectors do they use that we don't? Cross-model review |
 | 63 | Evaluate: Batched Codex Release Review | Currently cross-model review runs per-PR. Evaluate whether a batched release-level Codex review (all changes since last release) catches different issues than per-PR reviews. May not be needed — per-PR + release review checklist already covers it. Low priority until evidence suggests a gap |
+| 65 | Testing Diamond Boundary Clarification | Wizard's diamond section says E2E = "Playwright/Cypress" and integration = "real DB/cache" but doesn't draw the explicit line: **E2E = tests through the user's actual UI/browser, Integration = tests real systems via API without UI**. Evidence: contract-review-kit install classified Copilot Chat API tests as E2E instead of integration because the boundary wasn't explicit. Small wording fix in wizard doc + SDLC skill |
 | 64 | Update Notification Hook | `instructions-loaded-check.sh` runs every session but doesn't check for updates. Add a quick `npm view agentic-sdlc-wizard version` check vs installed version in SDLC.md. One-liner: "SDLC Wizard update available: 1.21.0 → 1.22.0 (run /update-wizard)". Non-blocking, <1s overhead |
 
 ## Review Pipeline

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.22.0 -->
+<!-- SDLC Wizard Version: 1.23.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.22.0 |
+| Wizard Version | 1.23.0 |
 | Last Updated | 2026-04-01 |
 | Claude Code Baseline | v2.1.85+ |
 

--- a/cli/templates/hooks/instructions-loaded-check.sh
+++ b/cli/templates/hooks/instructions-loaded-check.sh
@@ -20,4 +20,16 @@ if [ -n "$MISSING" ]; then
     echo "Invoke Skill tool, skill=\"setup-wizard\" to generate them."
 fi
 
+# Version update check (non-blocking, best-effort)
+SDLC_MD="$PROJECT_DIR/SDLC.md"
+if [ -f "$SDLC_MD" ]; then
+    INSTALLED_VERSION=$(grep -o 'SDLC Wizard Version: [0-9.]*' "$SDLC_MD" | head -1 | sed 's/SDLC Wizard Version: //')
+    if [ -n "$INSTALLED_VERSION" ] && command -v npm > /dev/null 2>&1; then
+        LATEST_VERSION=$(npm view agentic-sdlc-wizard version 2>/dev/null) || true
+        if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$INSTALLED_VERSION" ]; then
+            echo "SDLC Wizard update available: ${INSTALLED_VERSION} → ${LATEST_VERSION} (run /update-wizard)"
+        fi
+    fi
+fi
+
 exit 0

--- a/cli/templates/skills/update/SKILL.md
+++ b/cli/templates/skills/update/SKILL.md
@@ -45,10 +45,11 @@ Extract the latest version from the first `## [X.X.X]` line.
 Parse all CHANGELOG entries between the user's installed version and the latest. Present a clear summary:
 
 ```
-Installed: 1.20.0
-Latest:    1.22.0
+Installed: 1.21.0
+Latest:    1.23.0
 
 What changed:
+- [1.23.0] Update notification hook, ...
 - [1.22.0] Plan auto-approval, debugging workflow, /feedback skill, BRANDING.md detection, ...
 - [1.21.0] Confidence-driven setup, prove-it gate, cross-model release review, ...
 - [1.20.0] Version-pinned CC update gate, Tier 1 flakiness fix, flaky test guidance, ...

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "./cli/bin/sdlc-wizard.js"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -617,6 +617,132 @@ test_wizard_confidence_effort_max
 test_skill_confidence_effort_max
 
 echo ""
+echo "--- Update notification tests ---"
+
+# Test 35: Shows update notification when newer version available
+test_update_notification_newer_available() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.20.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    # Create fake npm that returns a newer version
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/npm"
+    local output
+    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "update available" && echo "$output" | grep -q "1.20.0" && echo "$output" | grep -q "1.22.0"; then
+        pass "Shows update notification when newer version available"
+    else
+        fail "Should show update notification with both versions, got: $output"
+    fi
+}
+
+# Test 36: No notification when versions match
+test_update_notification_same_version() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.22.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/npm"
+    local output
+    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "update available"; then
+        fail "Should NOT show update notification when versions match, got: $output"
+    else
+        pass "No update notification when versions match"
+    fi
+}
+
+# Test 37: No notification when npm is not available
+test_update_notification_npm_unavailable() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.20.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    # Empty bin dir — npm not in PATH
+    mkdir -p "$tmpdir/bin"
+    local output
+    output=$(PATH="$tmpdir/bin" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    local exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -q "update available"; then
+        pass "No notification and exit 0 when npm unavailable"
+    else
+        fail "Should silently skip when npm unavailable, exit=$exit_code, got: $output"
+    fi
+}
+
+# Test 38: No notification when npm fails (e.g., network error)
+test_update_notification_npm_fails() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.20.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/npm"
+    local output
+    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    local exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -q "update available"; then
+        pass "No notification and exit 0 when npm fails"
+    else
+        fail "Should silently skip when npm fails, exit=$exit_code, got: $output"
+    fi
+}
+
+# Test 39: No notification when SDLC.md lacks version metadata
+test_update_notification_no_version_metadata() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo "# SDLC Config" > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/npm"
+    local output
+    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "update available"; then
+        fail "Should NOT show notification when SDLC.md has no version metadata, got: $output"
+    else
+        pass "No notification when SDLC.md lacks version metadata"
+    fi
+}
+
+# Test 40: Update notification mentions /update-wizard
+test_update_notification_mentions_update_wizard() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.20.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/npm"
+    local output
+    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "/update-wizard"; then
+        pass "Update notification mentions /update-wizard"
+    else
+        fail "Update notification should mention /update-wizard, got: $output"
+    fi
+}
+
+test_update_notification_newer_available
+test_update_notification_same_version
+test_update_notification_npm_unavailable
+test_update_notification_npm_fails
+test_update_notification_no_version_metadata
+test_update_notification_mentions_update_wizard
+
+echo ""
 echo "--- SDLC enforcement gap audit ---"
 test_todowrite_has_capture_learnings
 test_todowrite_has_scope_guard


### PR DESCRIPTION
## Summary
- `instructions-loaded-check.sh` now checks npm for newer wizard version each session
- Non-blocking, graceful on network failure (`|| true`), silent when npm unavailable
- Output: `SDLC Wizard update available: X → Y (run /update-wizard)`
- 6 quality tests with fake npm in PATH (behavior tests, not existence tests)
- Version bump to 1.23.0 across all version-tracked files

## Test plan
- [x] TDD RED: 2 tests fail before implementation (positive-case tests)
- [x] TDD GREEN: all 46 hook tests pass after implementation
- [x] Full suite: 427 tests across 16 files, 0 failures
- [x] Template parity: `diff` confirms live hook == CLI template
- [ ] CI validates on push