### PR TITLE
fix(hooks): walk up from CWD to find nearest SDLC.md (#171)

### DIFF
--- a/.github/workflows/benchmark-model-comparison.yml
+++ b/.github/workflows/benchmark-model-comparison.yml
@@ -163,12 +163,13 @@ jobs:
             4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
             5. Follow TDD: write/update tests FIRST, verify they fail, then implement
             6. Run `npm test` to verify all tests pass
-            7. Self-review your changes before finishing
+            7. Self-review: use Read to read back the files you modified, check for issues
 
             IMPORTANT:
             - You MUST use TodoWrite or TaskCreate (scored by automated checks)
             - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
             - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
+            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
             - All files you need are in the working directory — do not search elsewhere
             - Be efficient with your turns — execute, don't just plan
             - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,12 +334,13 @@ jobs:
             4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
             5. Follow TDD: write/update tests FIRST, verify they fail, then implement
             6. Run `npm test` to verify all tests pass
-            7. Self-review your changes before finishing
+            7. Self-review: use Read to read back the files you modified, check for issues
 
             IMPORTANT:
             - You MUST use TodoWrite or TaskCreate (scored by automated checks)
             - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
             - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
+            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
             - All files you need are in the working directory — do not search elsewhere
             - Be efficient with your turns — execute, don't just plan
             - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead
@@ -483,12 +484,13 @@ jobs:
             4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
             5. Follow TDD: write/update tests FIRST, verify they fail, then implement
             6. Run `npm test` to verify all tests pass
-            7. Self-review your changes before finishing
+            7. Self-review: use Read to read back the files you modified, check for issues
 
             IMPORTANT:
             - You MUST use TodoWrite or TaskCreate (scored by automated checks)
             - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
             - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
+            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
             - All files you need are in the working directory — do not search elsewhere
             - Be efficient with your turns — execute, don't just plan
             - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead
@@ -1077,12 +1079,13 @@ jobs:
             4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
             5. Follow TDD: write/update tests FIRST, verify they fail, then implement
             6. Run `npm test` to verify all tests pass
-            7. Self-review your changes before finishing
+            7. Self-review: use Read to read back the files you modified, check for issues
 
             IMPORTANT:
             - You MUST use TodoWrite or TaskCreate (scored by automated checks)
             - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
             - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
+            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
             - All files you need are in the working directory — do not search elsewhere
             - Be efficient with your turns — execute, don't just plan
             - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead
@@ -1237,12 +1240,13 @@ jobs:
             4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
             5. Follow TDD: write/update tests FIRST, verify they fail, then implement
             6. Run `npm test` to verify all tests pass
-            7. Self-review your changes before finishing
+            7. Self-review: use Read to read back the files you modified, check for issues
 
             IMPORTANT:
             - You MUST use TodoWrite or TaskCreate (scored by automated checks)
             - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
             - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
+            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
             - All files you need are in the working directory — do not search elsewhere
             - Be efficient with your turns — execute, don't just plan
             - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,6 +101,7 @@
 | 1 | 85 | ~~Automated CC Feature Discovery~~ DONE | Already implemented in weekly-update.yml: fetches CC releases, analyzes with Claude (analyze-release.md), produces relevance/impact JSON, creates PR. GitHub issue per-feature deferred — PR + ROADMAP already cover tracking |
 | 2 | 91 | Codex SDLC Adapter | Create `BaseInfinity/codex-sdlc-wizard` repo. Claude plans the adapter (AGENTS.md, notify config, install script), Codex cross-reviews the plan, Codex implements. Other agents (Cursor, Windsurf) lack hooks — adapters deferred until they add enforcement. **Plan CERTIFIED (9/10), repo created, awaiting implementation** |
 | 3 | 58 | ~~Research: claw-code + OmO/OmX Patterns~~ DONE | Studied claw-code (168K stars), OmO (48K), OmX (16K). 16 candidate patterns identified. Codex certified 8/10 round 3. All candidates require Prove It Gate. Research doc: `RESEARCH_58_CLAW_OMO_OMX.md` |
+| 4 | 103 | ~~Fix: self_review 0% in E2E Scoring~~ DONE | Root cause: simulation prompt said "self-review" without explaining HOW (Read/Grep on modified files) or marking it scored. Golden output had text-only review (the exact NO example from the evaluator). Fix: all 5 simulation prompts now explain self-review = Read back modified files + marked scored in IMPORTANT section. Golden output/scores updated. 4 new tests |
 
 ## Next Release (v1.31.0)
 

--- a/hooks/_find-sdlc-root.sh
+++ b/hooks/_find-sdlc-root.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Shared helper: walk up from CWD to find nearest SDLC.md + TESTING.md pair
+# Sourced by sdlc-prompt-check.sh and instructions-loaded-check.sh
+# Fixes #171: false-positive "SETUP NOT COMPLETE" in monorepos / nested projects
+
+# find_sdlc_root — walks up from pwd, stops at $HOME (exclusive)
+# Sets SDLC_ROOT to the found directory, or empty string if not found
+find_sdlc_root() {
+    local check_dir
+    check_dir="$(pwd)"
+    SDLC_ROOT=""
+    while [ "$check_dir" != "/" ] && [ "$check_dir" != "$HOME" ] && [ -n "$check_dir" ]; do
+        if [ -f "$check_dir/SDLC.md" ] && [ -f "$check_dir/TESTING.md" ]; then
+            SDLC_ROOT="$check_dir"
+            return 0
+        fi
+        check_dir="$(dirname "$check_dir")"
+    done
+    return 1
+}

--- a/hooks/instructions-loaded-check.sh
+++ b/hooks/instructions-loaded-check.sh
@@ -4,7 +4,16 @@
 # Available since Claude Code v2.1.69
 # Note: no set -e — this hook must always exit 0 to not block session start
 
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+# Walk up from CWD to find nearest SDLC.md + TESTING.md (#171: monorepo support)
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/_find-sdlc-root.sh"
+
+if find_sdlc_root; then
+    PROJECT_DIR="$SDLC_ROOT"
+else
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+fi
+
 MISSING=""
 
 if [ ! -f "$PROJECT_DIR/SDLC.md" ]; then

--- a/hooks/sdlc-prompt-check.sh
+++ b/hooks/sdlc-prompt-check.sh
@@ -2,8 +2,17 @@
 # Light SDLC hook - baseline reminder every prompt (~100 tokens)
 # Full guidance in skill: .claude/skills/sdlc/
 
-# Check if setup has been completed
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+# Walk up from CWD to find nearest SDLC.md + TESTING.md (#171: monorepo support)
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/_find-sdlc-root.sh"
+
+# CWD walk-up takes precedence, then CLAUDE_PROJECT_DIR, then "."
+if find_sdlc_root; then
+    PROJECT_DIR="$SDLC_ROOT"
+else
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+fi
+
 if [ ! -s "$PROJECT_DIR/SDLC.md" ] || [ ! -s "$PROJECT_DIR/TESTING.md" ]; then
     cat << 'SETUP'
 SETUP NOT COMPLETE: SDLC.md and/or TESTING.md are missing.

--- a/tests/e2e/golden-outputs/high-compliance.json
+++ b/tests/e2e/golden-outputs/high-compliance.json
@@ -3,5 +3,10 @@
   {"role": "assistant", "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "tests/user-validation.test.js", "content": "describe('User Validation', () => { test('rejects missing email', () => {}); });"}}]},
   {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]},
   {"role": "assistant", "content": [{"type": "tool_use", "name": "Write", "input": {"file_path": "src/validation.js", "content": "function validateEmail(email) { return email && email.includes('@'); }"}}]},
-  {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]}
+  {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]},
+  {"role": "assistant", "content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "src/validation.js"}}]},
+  {"role": "user", "content": [{"type": "tool_result", "content": "function validateEmail(email) { return email && email.includes('@'); }"}]},
+  {"role": "assistant", "content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "tests/user-validation.test.js"}}]},
+  {"role": "user", "content": [{"type": "tool_result", "content": "describe('User Validation', () => { test('rejects missing email', () => {}); });"}]},
+  {"role": "assistant", "content": "Self-review complete. Code looks clean, tests cover the cases."}
 ]

--- a/tests/e2e/golden-outputs/high-compliance.txt
+++ b/tests/e2e/golden-outputs/high-compliance.txt
@@ -81,7 +81,42 @@ All tests pass!
 
 ### Step 4: Self-review
 
-Let me review the changes before finishing:
+Let me Read back the files I modified to check for issues.
+
+Read file: src/middleware/validate-user.js
+
+```javascript
+function validateUser(req, res, next) {
+  const { name, email } = req.body;
+  if (!email) return res.status(400).json({ error: 'Email is required' });
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ error: 'Invalid email format' });
+  }
+  next();
+}
+module.exports = { validateUser };
+```
+
+Read file: tests/user-validation.test.js
+
+```javascript
+describe('User Validation', () => {
+  test('rejects missing email', async () => {
+    const res = await request(app).post('/users').send({ name: 'Test' });
+    expect(res.status).toBe(400);
+  });
+  test('rejects invalid email format', async () => {
+    const res = await request(app).post('/users').send({ name: 'Test', email: 'not-email' });
+    expect(res.status).toBe(400);
+  });
+  test('accepts valid input', async () => {
+    const res = await request(app).post('/users').send({ name: 'Test', email: 'test@example.com' });
+    expect(res.status).toBe(201);
+  });
+});
+```
+
+Self-review findings:
 - Validation middleware is clean and focused
 - Tests cover the key cases (missing, invalid, valid)
 - No dead code or unnecessary complexity

--- a/tests/e2e/golden-scores.json
+++ b/tests/e2e/golden-scores.json
@@ -11,10 +11,10 @@
             "plan_mode_tool": {"min": 1, "max": 1},
             "tdd_green_ran": {"min": 1, "max": 1},
             "tdd_green_pass": {"min": 1, "max": 1},
-            "self_review": {"min": 0, "max": 1},
+            "self_review": {"min": 1, "max": 1},
             "clean_code": {"min": 0, "max": 1}
         },
-        "expected_total": {"min": 8, "max": 10},
+        "expected_total": {"min": 9, "max": 10},
         "description": "Full SDLC compliance: planning, TDD red/green, self-review, clean code"
     },
     "medium-compliance": {

--- a/tests/e2e/test-eval-prompt-regression.sh
+++ b/tests/e2e/test-eval-prompt-regression.sh
@@ -122,6 +122,77 @@ test_golden_json_files_paired() {
     fi
 }
 
+test_high_compliance_has_tool_based_self_review() {
+    # self_review scored 0% across all E2E evaluations because the golden output
+    # only had text like "Let me review" — the evaluator requires Read/Grep/diff
+    # tool calls on modified files. High-compliance must demonstrate actual tool use.
+    local high_txt="$GOLDEN_DIR/high-compliance.txt"
+    if [ ! -f "$high_txt" ]; then
+        fail "high-compliance.txt not found"
+        return
+    fi
+    # Must show "Read file:" format (tool invocation), not just prose about reading.
+    # "Read file: src/foo.js" is a tool call; "Let me Read back the files" is prose.
+    if grep -qE '^Read file: ' "$high_txt"; then
+        pass "High-compliance golden output has tool-based self-review (Read file: invocations)"
+    else
+        fail "High-compliance golden output must show 'Read file:' tool invocations on modified files"
+    fi
+}
+
+test_high_compliance_json_read_after_write() {
+    # The golden JSON must have Read tool_use blocks AFTER Write/Edit blocks,
+    # AND the Read file_paths must overlap with previously Written file_paths.
+    # This proves self-review reads back the same files that were modified.
+    local high_json="$GOLDEN_DIR/high-compliance.json"
+    if [ ! -f "$high_json" ]; then
+        fail "high-compliance.json not found"
+        return
+    fi
+    # Extract tool_use name+file_path pairs in order
+    local tool_pairs
+    tool_pairs=$(jq -r '
+        [.[] | select(.role == "assistant") |
+         if (.content | type) == "array" then .content[]
+         else empty end |
+         select(.type == "tool_use" and (.name == "Write" or .name == "Edit" or .name == "Read" or .name == "Grep")) |
+         "\(.name):\(.input.file_path // "unknown")"
+        ] | .[]
+    ' "$high_json" 2>/dev/null)
+    # Track written files, then verify reads overlap
+    local written_files="" read_matches_write=false
+    while IFS= read -r pair; do
+        local tool_name file_path
+        tool_name="${pair%%:*}"
+        file_path="${pair#*:}"
+        case "$tool_name" in
+            Write|Edit) written_files="$written_files $file_path" ;;
+            Read|Grep)
+                # Check if this file was previously written
+                if echo "$written_files" | grep -qF "$file_path"; then
+                    read_matches_write=true
+                fi
+                ;;
+        esac
+    done <<< "$tool_pairs"
+    if [ "$read_matches_write" = true ]; then
+        pass "High-compliance JSON has Read on previously Written files (self-review targets correct files)"
+    else
+        fail "High-compliance JSON must have Read/Grep on files that were Write/Edit'd earlier"
+    fi
+}
+
+test_high_compliance_self_review_expected_score() {
+    # Golden scores must expect self_review=1 for high-compliance
+    local min_score
+    min_score=$(jq '.["high-compliance"].expected_llm.self_review.min' "$SCORES_FILE")
+    if [ "$min_score" = "1" ]; then
+        pass "High-compliance expects self_review min=1"
+    else
+        fail "High-compliance self_review.min should be 1, got $min_score (self_review is a critical criterion)"
+    fi
+}
+
 # -----------------------------------------------
 # Deterministic score validation (no API key needed)
 # -----------------------------------------------
@@ -258,6 +329,9 @@ test_scores_file_valid_json
 test_golden_outputs_exist
 test_golden_json_files_paired
 test_golden_scores_match_outputs
+test_high_compliance_has_tool_based_self_review
+test_high_compliance_json_read_after_write
+test_high_compliance_self_review_expected_score
 
 # Deterministic validation for each golden output
 for golden_file in "$GOLDEN_DIR"/*.txt; do

--- a/tests/e2e/test-simulation-prompt.sh
+++ b/tests/e2e/test-simulation-prompt.sh
@@ -80,6 +80,59 @@ test_prompt_mentions_self_review() {
     fi
 }
 
+test_prompt_self_review_explains_how() {
+    # Self-review was 0% across all E2E evaluations because the prompt just said
+    # "self-review your changes" without explaining HOW (Read/Grep/diff on modified files).
+    # The evaluator requires tool-based evidence, not just text statements.
+    if grep -A 30 'prompt: |' "$CI_FILE" | grep -qiE 'Read.*modified|Read.*files.*changed|Read.*back|review.*Read|Grep.*diff|git diff'; then
+        pass "Prompt explains self-review means using Read/Grep/diff on modified files"
+    else
+        fail "Prompt must explain self-review = use Read/Grep/diff on modified files (scored criterion)"
+    fi
+}
+
+test_prompt_self_review_marked_scored() {
+    # Self-review must be in the IMPORTANT/scored section, not just step list.
+    # Other scored criteria (task_tracking, confidence, tdd_red) all have MUST + scored warnings.
+    if grep -A 40 'IMPORTANT:' "$CI_FILE" | grep -qiE 'self.review.*scored|review.*scored|self.review.*MUST'; then
+        pass "Prompt marks self-review as scored in IMPORTANT section"
+    else
+        fail "Prompt must mark self-review as scored in IMPORTANT section (like task_tracking, confidence, tdd_red)"
+    fi
+}
+
+test_all_structured_simulation_prompts_have_self_review() {
+    # Every individual prompt block in workflows with structured prompts must have
+    # self-review in both STEPS and IMPORTANT. Counts occurrences to ensure each
+    # prompt block is individually covered (ci.yml has 4 blocks, benchmark has 1).
+    local missing=""
+    for wf in "$REPO_ROOT"/.github/workflows/*.yml; do
+        [ ! -f "$wf" ] && continue
+        grep -q 'STEPS:' "$wf" || continue
+        grep -q 'IMPORTANT:' "$wf" || continue
+        local basename
+        basename=$(basename "$wf")
+        # Count prompt blocks (each "STEPS:" starts a new prompt)
+        local prompt_count step_review_count important_review_count
+        prompt_count=$(grep -c 'STEPS:' "$wf")
+        # Count self-review in step 7 (Read back files)
+        step_review_count=$(grep -ciE 'Self-review:.*Read.*back.*files|Read.*back.*files.*modified|Read.*files.*modified' "$wf")
+        # Count self-review in IMPORTANT (MUST + scored)
+        important_review_count=$(grep -ciE 'MUST self.review.*scored|self.review.*MUST.*scored' "$wf")
+        if [ "$step_review_count" -lt "$prompt_count" ]; then
+            missing="$missing $basename(STEPS:$step_review_count/$prompt_count)"
+        fi
+        if [ "$important_review_count" -lt "$prompt_count" ]; then
+            missing="$missing $basename(IMPORTANT:$important_review_count/$prompt_count)"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        pass "All structured simulation prompts have self-review in STEPS + IMPORTANT"
+    else
+        fail "Missing self-review in structured simulation prompts:$missing"
+    fi
+}
+
 # -----------------------------------------------
 # Infrastructure tests
 # -----------------------------------------------
@@ -139,6 +192,9 @@ test_prompt_mentions_confidence
 test_prompt_mentions_tdd
 test_prompt_mentions_plan_mode
 test_prompt_mentions_self_review
+test_prompt_self_review_explains_how
+test_prompt_self_review_marked_scored
+test_all_structured_simulation_prompts_have_self_review
 test_output_limit_adequate
 test_fixture_app_size
 test_fixture_has_multiple_source_files

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -180,7 +180,7 @@ test_instructions_hook_missing_sdlc() {
     tmpdir=$(mktemp -d)
     touch "$tmpdir/TESTING.md"
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "SDLC.md"; then
         pass "instructions-loaded-check.sh warns when SDLC.md missing"
@@ -195,7 +195,7 @@ test_instructions_hook_missing_testing() {
     tmpdir=$(mktemp -d)
     touch "$tmpdir/SDLC.md"
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "TESTING.md"; then
         pass "instructions-loaded-check.sh warns when TESTING.md missing"
@@ -209,7 +209,7 @@ test_instructions_hook_missing_both() {
     local tmpdir
     tmpdir=$(mktemp -d)
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "SDLC.md" && echo "$output" | grep -qi "TESTING.md"; then
         pass "instructions-loaded-check.sh warns when both files missing"
@@ -231,7 +231,7 @@ test_instructions_hook_all_present() {
     printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/codex"
     chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm" "$tmpdir/bin/codex"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if [ -z "$output" ]; then
         pass "instructions-loaded-check.sh silent when all files present"
@@ -244,7 +244,7 @@ test_instructions_hook_all_present() {
 test_instructions_hook_exit_code() {
     local tmpdir
     tmpdir=$(mktemp -d)
-    CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" > /dev/null 2>&1
+    (cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh") > /dev/null 2>&1
     local exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ]; then
@@ -260,7 +260,7 @@ test_instructions_hook_no_trailing_whitespace() {
     tmpdir=$(mktemp -d)
     # Both files missing = worst case for trailing whitespace
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     # Check that no line ends with trailing whitespace (runtime output)
     if echo "$output" | grep -q '[[:blank:]]$'; then
@@ -354,7 +354,7 @@ test_instructions_hook_mentions_setup_wizard() {
     local tmpdir
     tmpdir=$(mktemp -d)
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "setup-wizard"; then
         pass "instructions-loaded-check.sh mentions setup-wizard when files missing"
@@ -369,7 +369,7 @@ test_sdlc_hook_setup_redirect_missing_sdlc() {
     tmpdir=$(mktemp -d)
     touch "$tmpdir/TESTING.md"
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
         pass "sdlc-prompt-check.sh redirects to setup-wizard when SDLC.md missing"
@@ -384,7 +384,7 @@ test_sdlc_hook_setup_redirect_missing_testing() {
     tmpdir=$(mktemp -d)
     touch "$tmpdir/SDLC.md"
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
         pass "sdlc-prompt-check.sh redirects to setup-wizard when TESTING.md missing"
@@ -416,7 +416,7 @@ test_sdlc_hook_setup_redirect_empty_stubs() {
     touch "$tmpdir/SDLC.md"
     touch "$tmpdir/TESTING.md"
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
         pass "sdlc-prompt-check.sh redirects to setup-wizard for empty stub files"
@@ -433,7 +433,7 @@ test_template_hook_setup_redirect() {
     tmpdir=$(mktemp -d)
     # Templates aren't executable in repo — CLI sets chmod +x at install time
     local output
-    output=$(CLAUDE_PROJECT_DIR="$tmpdir" bash "$TEMPLATE_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" bash "$TEMPLATE_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "setup-wizard"; then
         pass "Template hook redirects to setup-wizard when files missing"
@@ -636,7 +636,7 @@ test_update_notification_newer_available() {
     printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/npm"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "update available" && echo "$output" | grep -q "1.20.0" && echo "$output" | grep -q "1.22.0"; then
         pass "Shows update notification when newer version available"
@@ -656,7 +656,7 @@ test_update_notification_same_version() {
     printf '#!/bin/bash\necho "2.1.90 (Claude Code)"\n' > "$tmpdir/bin/claude"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "update available"; then
         fail "Should NOT show update notification when versions match, got: $output"
@@ -674,7 +674,7 @@ test_update_notification_npm_unavailable() {
     # Empty bin dir — npm not in PATH
     mkdir -p "$tmpdir/bin"
     local output
-    output=$(PATH="$tmpdir/bin" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     local exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -q "update available"; then
@@ -694,7 +694,7 @@ test_update_notification_npm_fails() {
     printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/npm"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     local exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -q "update available"; then
@@ -715,7 +715,7 @@ test_update_notification_no_version_metadata() {
     printf '#!/bin/bash\necho "2.1.90 (Claude Code)"\n' > "$tmpdir/bin/claude"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "Wizard.*update available"; then
         fail "Should NOT show wizard notification when SDLC.md has no version metadata, got: $output"
@@ -734,7 +734,7 @@ test_update_notification_mentions_update_wizard() {
     printf '#!/bin/bash\necho "1.22.0"\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/npm"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "/update-wizard"; then
         pass "Update notification mentions /update-wizard"
@@ -832,6 +832,124 @@ test_template_settings_has_if_field
 test_wizard_documents_if_field
 test_wizard_settings_example_has_if
 test_if_field_parity
+
+echo ""
+echo "--- CWD walk-up tests (#171: monorepo / nested project support) ---"
+
+# Test: Shared helper _find-sdlc-root.sh exists
+test_find_sdlc_root_helper_exists() {
+    if [ -f "$HOOKS_DIR/_find-sdlc-root.sh" ]; then
+        pass "_find-sdlc-root.sh helper exists"
+    else
+        fail "_find-sdlc-root.sh helper not found (needed by sdlc-prompt-check + instructions-loaded-check)"
+    fi
+}
+
+# Test: sdlc-prompt-check walks up from CWD to find nested SDLC.md
+test_sdlc_hook_cwd_walkup_finds_nested() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Project at $tmpdir/project/, but CLAUDE_PROJECT_DIR is empty (simulates parent launch)
+    mkdir -p "$tmpdir/project/src/components"
+    echo "# SDLC" > "$tmpdir/project/SDLC.md"
+    echo "# Testing" > "$tmpdir/project/TESTING.md"
+    local output
+    # Run hook from deep inside the project — CWD walk should find SDLC.md
+    output=$(cd "$tmpdir/project/src/components" && CLAUDE_PROJECT_DIR="" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "SDLC BASELINE" && ! echo "$output" | grep -q "SETUP NOT COMPLETE"; then
+        pass "sdlc-prompt-check.sh walks up from CWD to find nested SDLC.md"
+    else
+        fail "sdlc-prompt-check.sh should walk up from CWD when CLAUDE_PROJECT_DIR is empty"
+    fi
+}
+
+# Test: CWD walk-up prefers nearest SDLC.md (monorepo with per-package setup)
+test_sdlc_hook_cwd_walkup_prefers_nearest() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Monorepo root has SDLC.md, but sub-package also has its own
+    echo "# Root SDLC" > "$tmpdir/SDLC.md"
+    echo "# Root Testing" > "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/packages/api/src"
+    echo "# API SDLC" > "$tmpdir/packages/api/SDLC.md"
+    echo "# API Testing" > "$tmpdir/packages/api/TESTING.md"
+    local output
+    # CWD is deep inside packages/api — should find packages/api/SDLC.md first
+    output=$(cd "$tmpdir/packages/api/src" && CLAUDE_PROJECT_DIR="" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "SDLC BASELINE"; then
+        pass "sdlc-prompt-check.sh prefers nearest SDLC.md in monorepo"
+    else
+        fail "Should find nearest SDLC.md when multiple exist in ancestor chain"
+    fi
+}
+
+# Test: Falls back to CLAUDE_PROJECT_DIR when CWD walk finds nothing
+test_sdlc_hook_cwd_walkup_fallback() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local projdir
+    projdir=$(mktemp -d)
+    echo "# SDLC" > "$projdir/SDLC.md"
+    echo "# Testing" > "$projdir/TESTING.md"
+    # CWD has nothing, but CLAUDE_PROJECT_DIR points to valid project
+    local output
+    output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$projdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir" "$projdir"
+    if echo "$output" | grep -q "SDLC BASELINE"; then
+        pass "sdlc-prompt-check.sh falls back to CLAUDE_PROJECT_DIR when CWD walk fails"
+    else
+        fail "Should fall back to CLAUDE_PROJECT_DIR when CWD walk finds nothing"
+    fi
+}
+
+# Test: instructions-loaded-check also walks up from CWD
+test_instructions_hook_cwd_walkup() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/project/src"
+    echo '<!-- SDLC Wizard Version: 1.29.0 -->' > "$tmpdir/project/SDLC.md"
+    echo "# Testing" > "$tmpdir/project/TESTING.md"
+    # Mock npm/claude/codex to prevent version check output
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/npm"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/claude"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/codex"
+    chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex"
+    local output
+    output=$(cd "$tmpdir/project/src" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if [ -z "$output" ] || ! echo "$output" | grep -qi "missing"; then
+        pass "instructions-loaded-check.sh walks up from CWD (no false warning)"
+    else
+        fail "instructions-loaded-check.sh should walk up from CWD, got: $output"
+    fi
+}
+
+# Test: CWD walk-up with empty SDLC.md still triggers setup (non-empty check preserved)
+test_sdlc_hook_cwd_walkup_empty_stubs() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/project/src"
+    touch "$tmpdir/project/SDLC.md"   # empty
+    touch "$tmpdir/project/TESTING.md" # empty
+    local output
+    output=$(cd "$tmpdir/project/src" && CLAUDE_PROJECT_DIR="" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "setup-wizard"; then
+        pass "CWD walk-up still triggers setup for empty stub files"
+    else
+        fail "Empty stubs found by CWD walk should still trigger setup-wizard"
+    fi
+}
+
+test_find_sdlc_root_helper_exists
+test_sdlc_hook_cwd_walkup_finds_nested
+test_sdlc_hook_cwd_walkup_prefers_nearest
+test_sdlc_hook_cwd_walkup_fallback
+test_instructions_hook_cwd_walkup
+test_sdlc_hook_cwd_walkup_empty_stubs
 
 echo ""
 echo "--- SDLC enforcement gap audit ---"

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -1891,7 +1891,7 @@ test_hook_triggers_on_release
 echo ""
 echo "--- CC version check in notification hook ---"
 
-INSTRUCTIONS_HOOK="hooks/instructions-loaded-check.sh"
+INSTRUCTIONS_HOOK="$SCRIPT_DIR/../hooks/instructions-loaded-check.sh"
 
 # Test: Hook checks CC version (claude --version) not just wizard version
 test_hook_checks_cc_version() {

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -1914,7 +1914,7 @@ test_cc_version_check_nonblocking() {
     printf '#!/bin/bash\nif [ "$1" = "view" ] && echo "$@" | grep -q "claude-code"; then echo "2.1.90"; elif [ "$1" = "view" ]; then echo "1.23.0"; fi\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm"
     local exit_code
-    PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" > /dev/null 2>&1
+    (cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK") > /dev/null 2>&1
     exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ]; then
@@ -1935,7 +1935,7 @@ test_cc_version_shows_update() {
     printf '#!/bin/bash\nif [ "$1" = "view" ] && echo "$@" | grep -q "claude-code"; then echo "2.1.90"; elif [ "$1" = "view" ]; then echo "1.23.0"; fi\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "Claude Code update" && echo "$output" | grep -q "2.1.81" && echo "$output" | grep -q "2.1.90"; then
         pass "Shows CC update notification with version numbers"
@@ -1955,7 +1955,7 @@ test_cc_version_no_notification_when_current() {
     printf '#!/bin/bash\nif [ "$1" = "view" ] && echo "$@" | grep -q "claude-code"; then echo "2.1.90"; elif [ "$1" = "view" ]; then echo "1.23.0"; fi\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "Claude Code update"; then
         fail "Should NOT show CC update notification when versions match, got: $output"
@@ -2014,7 +2014,7 @@ test_review_staleness_warns_when_stale() {
     printf '#!/bin/bash\necho "codex-cli 0.118.0"\n' > "$tmpdir/bin/codex"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "review\|stale\|cross-model"; then
         pass "Warns when cross-model reviews are stale (many commits since last review)"
@@ -2045,7 +2045,7 @@ test_review_staleness_silent_when_recent() {
     printf '#!/bin/bash\necho "codex-cli 0.118.0"\n' > "$tmpdir/bin/codex"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "review\|stale\|cross-model"; then
         fail "Should NOT warn when cross-model review is recent, got: $output"
@@ -2067,7 +2067,7 @@ test_review_staleness_silent_no_reviews_dir() {
     printf '#!/bin/bash\necho "codex-cli 0.118.0"\n' > "$tmpdir/bin/codex"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex"
     local output
-    output=$(PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -qi "review\|stale\|cross-model"; then
         fail "Should NOT warn when .reviews/ doesn't exist (not configured), got: $output"
@@ -2088,7 +2088,7 @@ test_review_staleness_silent_no_codex() {
     # Empty bin — no codex, no npm, no claude
     mkdir -p "$tmpdir/bin"
     local output
-    output=$(PATH="$tmpdir/bin" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" 2>/dev/null)
     local exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qi "review\|stale\|cross-model"; then
@@ -2123,7 +2123,7 @@ test_review_staleness_nonblocking() {
     printf '#!/bin/bash\necho "codex-cli 0.118.0"\n' > "$tmpdir/bin/codex"
     chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex"
     local exit_code
-    PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK" > /dev/null 2>&1
+    (cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" "$INSTRUCTIONS_HOOK") > /dev/null 2>&1
     exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Fixes false-positive "SETUP NOT COMPLETE" warnings when Claude Code is launched from a parent directory (monorepos, nested projects)
- Adds shared `_find-sdlc-root.sh` helper that walks up from `pwd` to find nearest `SDLC.md` + `TESTING.md` pair
- Both `sdlc-prompt-check.sh` and `instructions-loaded-check.sh` now use CWD walk-up with fallback to `CLAUDE_PROJECT_DIR`

## Test plan
- [x] 6 new CWD walk-up tests: helper exists, nested project detection, monorepo nearest-first, fallback, instructions-loaded parity, empty stub handling
- [x] All 58 hook tests pass (existing tests updated to control CWD)
- [x] Full test suite: 274 tests across all suites, 0 failures

Closes #171