### PR TITLE
docs: add Automation Station community section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # SDLC Wizard - Claude Instructions
 
+> **Part of the [XDLC ecosystem](https://github.com/BaseInfinity/xdlc)** — this is the SDLC sibling, installed into every project as the code quality layer.
+>
+> **Skills first → wizard later.** Build skills on real work; only graduate to a self-improving wizard once re-use proves what's portable. sdlc-wizard earned the wizard form — it didn't start there.
+
 ## Project Overview
 
 This is a **meta-repository** - it contains the SDLC Wizard documentation and automation, not traditional application code.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ This isn't the only Claude Code SDLC tool. Here's an honest comparison:
 | [CHANGELOG.md](CHANGELOG.md) | Version history, what changed and when |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute, evaluation methodology |
 
+## Community
+
+Come join **[Automation Station](https://discord.com/invite/fGPEF7GHrF)** — a community Discord packed with software engineers bringing 40+ years of combined experience across every area of the stack (frontend, backend, infra, embedded, data, QA, DevOps, you name it). Share patterns, ask questions, compare notes on AI agents, automation, and SDLC tooling.
+
 ## Contributing
 
 PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for evaluation methodology and testing.


### PR DESCRIPTION
## Summary
- Adds a **Community** section to the README linking to the Automation Station Discord
- Highlights 40+ years combined engineering experience across stack areas
- Placed just before Contributing

## Test plan
- [x] README renders correctly (markdown formatting preserved)
- [x] Link to Discord verified