### PR TITLE
feat(benchmark): add Opus 4.7 + effort level to model comparison

### DIFF
--- a/.github/workflows/benchmark-model-comparison.yml
+++ b/.github/workflows/benchmark-model-comparison.yml
@@ -9,7 +9,16 @@ on:
         options:
           - 'claude-sonnet-4-6'
           - 'claude-opus-4-6'
-        default: 'claude-sonnet-4-6'
+          - 'claude-opus-4-7'
+        default: 'claude-opus-4-6'
+      effort:
+        description: 'Reasoning effort level'
+        type: choice
+        options:
+          - 'high'
+          - 'xhigh'
+          - 'max'
+        default: 'high'
       scenario:
         description: 'Scenario to run (filename without .md, or "all")'
         type: string
@@ -46,6 +55,7 @@ jobs:
         id: resolve
         env:
           INPUT_MODEL: ${{ inputs.model }}
+          INPUT_EFFORT: ${{ inputs.effort }}
           INPUT_SCENARIO: ${{ inputs.scenario }}
           INPUT_TRIALS: ${{ inputs.trials }}
           INPUT_MAX_TURNS: ${{ inputs.max_turns }}
@@ -68,6 +78,11 @@ jobs:
           if [ "$INPUT_MAX_TURNS" -gt 100 ]; then
             echo "::error::max_turns must be <= 100 (got $INPUT_MAX_TURNS). Cost guard."
             exit 1
+          fi
+
+          # Validate effort level (xhigh only valid on opus-4-7)
+          if [ "$INPUT_EFFORT" = "xhigh" ] && [ "$INPUT_MODEL" != "claude-opus-4-7" ]; then
+            echo "::warning::xhigh effort is only supported on claude-opus-4-7, falling back to high"
           fi
 
           # Resolve scenario list
@@ -146,6 +161,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ inputs.model }}
+            --effort ${{ inputs.effort }}
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *),Bash(git *),Glob,Grep,TodoWrite,TaskCreate,Task"
             --add-dir tests/e2e
@@ -288,6 +304,7 @@ jobs:
       - name: Write results artifact
         env:
           BENCH_MODEL: ${{ inputs.model }}
+          BENCH_EFFORT: ${{ inputs.effort }}
           BENCH_SCENARIO: ${{ matrix.scenario }}
           BENCH_TRIALS: ${{ inputs.trials }}
           BENCH_MAX_TURNS: ${{ inputs.max_turns }}
@@ -304,6 +321,7 @@ jobs:
 
           jq -n \
             --arg model "$BENCH_MODEL" \
+            --arg effort "$BENCH_EFFORT" \
             --arg scenario "$BENCH_SCENARIO" \
             --argjson trials "${BENCH_TRIALS:-5}" \
             --argjson successful "${EVAL_SUCCESSFUL:-0}" \
@@ -317,6 +335,7 @@ jobs:
             --argjson max_turns "${BENCH_MAX_TURNS:-55}" \
             '{
               model: $model,
+              effort: $effort,
               scenario: $scenario,
               trials: $trials,
               successful_trials: $successful,
@@ -340,6 +359,7 @@ jobs:
       - name: Write step summary
         env:
           BENCH_MODEL: ${{ inputs.model }}
+          BENCH_EFFORT: ${{ inputs.effort }}
           BENCH_SCENARIO: ${{ matrix.scenario }}
           BENCH_TRIALS_INPUT: ${{ inputs.trials }}
           EVAL_MEAN: ${{ steps.evaluate.outputs.mean }}
@@ -349,11 +369,12 @@ jobs:
           EVAL_SUCCESSFUL: ${{ steps.evaluate.outputs.successful_trials }}
         run: |
           cat >> $GITHUB_STEP_SUMMARY <<SUMMARY_EOF
-          ## Benchmark: ${BENCH_MODEL} on ${BENCH_SCENARIO}
+          ## Benchmark: ${BENCH_MODEL} (${BENCH_EFFORT}) on ${BENCH_SCENARIO}
 
           | Metric | Value |
           |--------|-------|
           | **Model** | \`${BENCH_MODEL}\` |
+          | **Effort** | \`${BENCH_EFFORT}\` |
           | **Scenario** | ${BENCH_SCENARIO} |
           | **Mean Score** | **${EVAL_MEAN:-N/A}** / 10 |
           | **95% CI** | [${EVAL_CI_LOWER:-N/A}, ${EVAL_CI_UPPER:-N/A}] |

--- a/.github/workflows/benchmark-model-comparison.yml
+++ b/.github/workflows/benchmark-model-comparison.yml
@@ -82,7 +82,8 @@ jobs:
 
           # Validate effort level (xhigh only valid on opus-4-7)
           if [ "$INPUT_EFFORT" = "xhigh" ] && [ "$INPUT_MODEL" != "claude-opus-4-7" ]; then
-            echo "::warning::xhigh effort is only supported on claude-opus-4-7, falling back to high"
+            echo "::error::xhigh effort is only supported on claude-opus-4-7 (got $INPUT_MODEL). GitHub Actions resolves inputs before shell runs, so the value cannot be overridden at runtime."
+            exit 1
           fi
 
           # Resolve scenario list
@@ -352,7 +353,7 @@ jobs:
       - name: Upload results artifact
         uses: actions/upload-artifact@v6
         with:
-          name: benchmark-${{ inputs.model }}-${{ matrix.scenario }}
+          name: benchmark-${{ inputs.model }}-${{ inputs.effort }}-${{ matrix.scenario }}
           path: /tmp/benchmark-results/
           retention-days: 90
 

--- a/tests/test-model-comparison.sh
+++ b/tests/test-model-comparison.sh
@@ -74,16 +74,17 @@ test_model_input_choice() {
     fi
 }
 
-# Test 4: Workflow model choices include both Opus and Sonnet
+# Test 4: Workflow model choices include Opus 4.6, Opus 4.7, and Sonnet
 test_model_choices() {
     if [ ! -f "$WORKFLOW" ]; then fail "Workflow file missing"; return; fi
-    local has_opus has_sonnet
-    has_opus=$(grep -c "claude-opus-4-6" "$WORKFLOW" || true)
+    local has_opus46 has_opus47 has_sonnet
+    has_opus46=$(grep -c "claude-opus-4-6" "$WORKFLOW" || true)
+    has_opus47=$(grep -c "claude-opus-4-7" "$WORKFLOW" || true)
     has_sonnet=$(grep -c "claude-sonnet-4-6" "$WORKFLOW" || true)
-    if [ "$has_opus" -gt 0 ] && [ "$has_sonnet" -gt 0 ]; then
-        pass "Workflow model choices include both claude-opus-4-6 and claude-sonnet-4-6"
+    if [ "$has_opus46" -gt 0 ] && [ "$has_opus47" -gt 0 ] && [ "$has_sonnet" -gt 0 ]; then
+        pass "Workflow model choices include claude-opus-4-6, claude-opus-4-7, and claude-sonnet-4-6"
     else
-        fail "Workflow missing one or both model choices (opus=$has_opus, sonnet=$has_sonnet)"
+        fail "Workflow missing model choices (opus46=$has_opus46, opus47=$has_opus47, sonnet=$has_sonnet)"
     fi
 }
 
@@ -118,6 +119,26 @@ test_max_turns_input() {
         pass "Workflow has max_turns input with number type, default 55"
     else
         fail "Workflow missing max_turns input with default 55"
+    fi
+}
+
+# Test 4b: Workflow has effort input with choice type (high/xhigh/max)
+test_effort_input() {
+    if [ ! -f "$WORKFLOW" ]; then fail "Workflow file missing"; return; fi
+    if grep -q "effort:" "$WORKFLOW" && grep -q "xhigh" "$WORKFLOW"; then
+        pass "Workflow has effort input with xhigh option"
+    else
+        fail "Workflow missing effort input with xhigh option"
+    fi
+}
+
+# Test 4c: Workflow passes --effort via claude_args
+test_effort_in_claude_args() {
+    if [ ! -f "$WORKFLOW" ]; then fail "Workflow file missing"; return; fi
+    if grep -q "\-\-effort" "$WORKFLOW"; then
+        pass "Workflow passes --effort via claude_args"
+    else
+        fail "Workflow missing --effort flag in claude_args"
     fi
 }
 
@@ -525,6 +546,8 @@ test_workflow_valid_yaml
 test_workflow_dispatch_trigger
 test_model_input_choice
 test_model_choices
+test_effort_input
+test_effort_in_claude_args
 test_scenario_input
 test_trials_input
 test_max_turns_input


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to benchmark workflow model choices
- Adds `effort` input parameter (high/xhigh/max) — xhigh is the new CC default for coding
- Passes `--effort` via `claude_args` to the simulation
- Records effort level in results artifact and step summary
- Warns when xhigh is used with non-4.7 models (unsupported)
- Changes default model from sonnet to opus-4-6 (better baseline)

## TDD
- 3 new tests (Test 4 updated + Tests 4b, 4c): 39/39 passing
- workflow-triggers: 162/0 passing
- No regressions in unrelated test suites

## Test plan
- [x] TDD RED: 3 failures on missing opus-4-7, effort input, --effort flag
- [x] TDD GREEN: all 39 model-comparison tests pass
- [x] Full test suite: no regressions from these changes
- [ ] Trigger benchmark with opus-4-6 (high) for baseline
- [ ] Trigger benchmark with opus-4-7 (xhigh) for comparison