### PR TITLE
fix(hooks): SessionStart doesn't expose model — effort-only detection

### DIFF
--- a/hooks/instructions-loaded-check.sh
+++ b/hooks/instructions-loaded-check.sh
@@ -66,6 +66,24 @@ if command -v codex > /dev/null 2>&1 && [ -d "$PROJECT_DIR/.reviews" ]; then
     fi
 fi
 
+# Model/effort upgrade check (non-blocking, best-effort)
+RECOMMENDED_MODEL="claude-opus-4-7"
+RECOMMENDED_EFFORT="xhigh"
+if command -v jq > /dev/null 2>&1; then
+    EFFORT=""
+    PROJ="${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}"
+    for f in "$PROJ/.claude/settings.local.json" "$PROJ/.claude/settings.json" "$HOME/.claude/settings.json"; do
+        if [ -f "$f" ]; then
+            val=$(jq -r '.effortLevel // empty' "$f" 2>/dev/null)
+            if [ -n "$val" ]; then EFFORT="$val"; break; fi
+        fi
+    done
+    if [ -n "$EFFORT" ] && [ "$EFFORT" != "$RECOMMENDED_EFFORT" ]; then
+        echo "Upgrade available: effort $EFFORT → $RECOMMENDED_EFFORT (run: /effort $RECOMMENDED_EFFORT)"
+        echo "Recommended model: $RECOMMENDED_MODEL (run: /model $RECOMMENDED_MODEL)"
+    fi
+fi
+
 # Claude Code version check (non-blocking, best-effort)
 if command -v claude > /dev/null 2>&1 && command -v npm > /dev/null 2>&1; then
     CC_LOCAL=$(claude --version 2>/dev/null | grep -o '[0-9][0-9.]*' | head -1) || true

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-# SessionStart hook — nudges user when a better model or effort level is available
-# Reads model from JSON stdin (SessionStart payload), effort from settings.json
+# SessionStart hook — nudges user when effort level is below recommended
+# and tells Claude the recommended model so it can compare against its own
+# CC does NOT expose the model to hooks, so model nudge relies on Claude
+# seeing this output and comparing against its system prompt
 # Non-blocking: always exits 0
 
-# Recommended model and effort — update these when new models ship
 RECOMMENDED_MODEL="claude-opus-4-7"
 RECOMMENDED_EFFORT="xhigh"
 
-input=$(cat)
+# Drain stdin (SessionStart sends JSON but model field isn't in it)
+cat > /dev/null
 
 if ! command -v jq > /dev/null 2>&1; then
-    exit 0
-fi
-
-model=$(echo "$input" | jq -r '.model // empty' 2>/dev/null)
-if [ -z "$model" ]; then
     exit 0
 fi
 
@@ -30,21 +27,17 @@ for f in "$project_dir/.claude/settings.local.json" "$project_dir/.claude/settin
     fi
 done
 
-nudge_model=""
-nudge_effort=""
-
-if [ "$model" != "$RECOMMENDED_MODEL" ]; then
-    nudge_model="model: $model → $RECOMMENDED_MODEL (run: /model $RECOMMENDED_MODEL)"
-fi
+nudge=""
 
 if [ -n "$effort" ] && [ "$effort" != "$RECOMMENDED_EFFORT" ]; then
-    nudge_effort="effort: $effort → $RECOMMENDED_EFFORT (run: /effort $RECOMMENDED_EFFORT)"
+    nudge="effort: $effort → $RECOMMENDED_EFFORT (run: /effort $RECOMMENDED_EFFORT)"
 fi
 
-if [ -n "$nudge_model" ] || [ -n "$nudge_effort" ]; then
+if [ -n "$nudge" ]; then
     echo "Upgrade available:"
-    [ -n "$nudge_model" ] && echo "  $nudge_model"
-    [ -n "$nudge_effort" ] && echo "  $nudge_effort"
+    echo "  $nudge"
+    echo "  recommended model: $RECOMMENDED_MODEL (run: /model $RECOMMENDED_MODEL)"
+    echo "  (Claude: compare recommended model against your current model — nudge user if different)"
 fi
 
 exit 0

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1011,49 +1011,33 @@ test_model_effort_check_exists() {
     fi
 }
 
-# Test: detects stale model and outputs upgrade nudge
-test_model_effort_check_stale_model() {
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    mkdir -p "$tmpdir/.claude"
-    echo '{"effortLevel":"xhigh"}' > "$tmpdir/.claude/settings.json"
-    local output
-    output=$(echo '{"model":"claude-opus-4-6","session_id":"test"}' | HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
-    rm -rf "$tmpdir"
-    if echo "$output" | grep -q '/model'; then
-        pass "model-effort-check.sh nudges to upgrade model when on opus-4-6"
-    else
-        fail "model-effort-check.sh should nudge /model when on stale model, got: $output"
-    fi
-}
-
-# Test: detects stale effort and outputs upgrade nudge
+# Test: detects stale effort and outputs upgrade nudge with model recommendation
 test_model_effort_check_stale_effort() {
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(echo '{"model":"claude-opus-4-7","session_id":"test"}' | HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q '/effort'; then
-        pass "model-effort-check.sh nudges to upgrade effort when on high"
+    if echo "$output" | grep -q '/effort' && echo "$output" | grep -q 'recommended model'; then
+        pass "model-effort-check.sh nudges effort + recommends model when effort is stale"
     else
-        fail "model-effort-check.sh should nudge /effort when effort is stale, got: $output"
+        fail "model-effort-check.sh should nudge /effort and recommend model, got: $output"
     fi
 }
 
-# Test: silent when model and effort are both current
+# Test: silent when effort is already current
 test_model_effort_check_silent_when_current() {
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"xhigh"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(echo '{"model":"claude-opus-4-7","session_id":"test"}' | HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if [ -z "$output" ]; then
-        pass "model-effort-check.sh silent when model and effort are current"
+        pass "model-effort-check.sh silent when effort is current"
     else
         fail "model-effort-check.sh should be silent when current, got: $output"
     fi
@@ -1089,7 +1073,7 @@ test_model_effort_check_nested_cwd() {
     mkdir -p "$tmpdir/.claude" "$tmpdir/src/deep"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(cd "$tmpdir/src/deep" && echo '{"model":"claude-opus-4-7","session_id":"test"}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir/src/deep" && echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q '/effort'; then
         pass "model-effort-check.sh finds project settings via CLAUDE_PROJECT_DIR from nested CWD"
@@ -1106,7 +1090,7 @@ test_model_effort_check_local_overrides_project() {
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     echo '{"effortLevel":"xhigh"}' > "$tmpdir/.claude/settings.local.json"
     local output
-    output=$(echo '{"model":"claude-opus-4-7","session_id":"test"}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if [ -z "$output" ]; then
         pass "model-effort-check.sh respects local settings override (xhigh from local, silent)"
@@ -1116,7 +1100,6 @@ test_model_effort_check_local_overrides_project() {
 }
 
 test_model_effort_check_exists
-test_model_effort_check_stale_model
 test_model_effort_check_stale_effort
 test_model_effort_check_silent_when_current
 test_model_effort_check_no_stdin


### PR DESCRIPTION
## Summary
- SessionStart hook stdin JSON does NOT include model field (confirmed via CC docs)
- Original hook silently exited because model was always empty
- Fixed: detect effort from settings.json, output recommended model for Claude to compare against its system prompt
- Removed broken stdin model detection

## Test plan
- [x] 7 hook tests pass (stale effort, silent when current, no stdin, settings wiring, nested CWD, local override)
- [x] Removed stale_model test that was testing fake behavior
- [ ] Manual: restart session with effort=high, verify nudge appears