### PR TITLE
docs(wizard,setup): surface /less-permission-prompts native skill

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -4060,6 +4060,15 @@ When Anthropic provides official plugins that overlap with this SDLC:
 
 **Re-run `claude-code-setup` periodically** (quarterly, or when your project expands in scope) to catch new automations — MCP servers, hooks, subagents — that weren't relevant at initial setup but are now.
 
+**Complementary native skills worth knowing:**
+
+| Native Skill | What It Does | When to Run |
+|--------------|--------------|-------------|
+| `/less-permission-prompts` | Scans transcripts for common read-only Bash/MCP calls and proposes a prioritized allowlist | After a few sessions — reduces permission friction without auto mode |
+| `/permissions` | Pre-allow specific commands and check them into `.claude/settings.json` | Anytime you want an auditable team allowlist |
+
+These are shipped by Claude Code itself. The wizard doesn't reimplement them — it points you at them so you benefit from the native version's ongoing maintenance.
+
 ### When Claude Code Improves
 
 Claude Code is actively improving. When they add built-in features:

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -224,10 +224,11 @@ Tell the user:
 > **Exit Claude Code and restart it** for the new configuration to take effect.
 > On restart, the SDLC hook will fire and you'll see the checklist in every response.
 >
-> **Optional next step:**
+> **Optional next steps:**
 > - Run `/claude-automation-recommender` for stack-specific tooling suggestions (MCP servers, formatting hooks, type-checking hooks, plugins)
+> - After a few sessions, run `/less-permission-prompts` — a native Claude Code skill that scans your transcripts for common read-only Bash and MCP calls and proposes a prioritized allowlist. Reduces permission friction without enabling auto mode.
 >
-> The recommender is complementary to the SDLC wizard — it adds tooling recommendations, not process enforcement.
+> Both are complementary to the SDLC wizard — they add tooling and quality-of-life, not process enforcement.
 
 ## Rules
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -226,7 +226,9 @@ Tell the user:
 >
 > **Optional next steps:**
 > - Run `/claude-automation-recommender` for stack-specific tooling suggestions (MCP servers, formatting hooks, type-checking hooks, plugins)
-> - After a few sessions, run `/less-permission-prompts` — a native Claude Code skill that scans your transcripts for common read-only Bash and MCP calls and proposes a prioritized allowlist. Reduces permission friction without enabling auto mode.
+> - After a few sessions, run `/less-permission-prompts` — a native Claude Code skill
+>   that scans your transcripts for common read-only Bash/MCP calls and proposes a
+>   prioritized allowlist. Reduces permission friction without enabling auto mode.
 >
 > Both are complementary to the SDLC wizard — they add tooling and quality-of-life, not process enforcement.
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -402,6 +402,31 @@ test_hooks_recommend_opus_1m_alias() {
     fi
 }
 
+# Setup skill must point users at /less-permission-prompts so they can
+# auto-tune their allowlist without enabling auto mode. This is a native CC
+# skill (ships with the CLI), so we just reference it — we don't reimplement.
+test_setup_skill_mentions_less_permission_prompts() {
+    local SKILL="$REPO_ROOT/skills/setup/SKILL.md"
+    if [ ! -f "$SKILL" ]; then fail "skills/setup/SKILL.md not found"; return; fi
+    if grep -qF '/less-permission-prompts' "$SKILL"; then
+        pass "skills/setup/SKILL.md mentions /less-permission-prompts"
+    else
+        fail "skills/setup/SKILL.md should recommend /less-permission-prompts post-setup"
+    fi
+}
+
+# Wizard doc must surface /less-permission-prompts in a Further Reading /
+# complementary-tools section so readers know it's native CC, not wizard-owned.
+test_wizard_doc_mentions_less_permission_prompts() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    if grep -qF '/less-permission-prompts' "$DOC"; then
+        pass "CLAUDE_CODE_SDLC_WIZARD.md mentions /less-permission-prompts"
+    else
+        fail "CLAUDE_CODE_SDLC_WIZARD.md should reference /less-permission-prompts as a complementary native skill"
+    fi
+}
+
 test_wizard_doc_recommends_opus_1m
 test_sdlc_skill_recommends_opus_1m
 test_cli_template_sets_opus_1m_model
@@ -409,6 +434,8 @@ test_cli_template_autocompact_tuned_for_1m
 test_setup_skill_describes_1m_default
 test_repo_settings_match_template_autocompact
 test_hooks_recommend_opus_1m_alias
+test_setup_skill_mentions_less_permission_prompts
+test_wizard_doc_mentions_less_permission_prompts
 
 # ────────────────────────────────────────────
 # Summary

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -427,6 +427,18 @@ test_wizard_doc_mentions_less_permission_prompts() {
     fi
 }
 
+# Pin the second row of the "Complementary native skills" table too —
+# otherwise a future edit could silently drop /permissions and no test catches it.
+test_wizard_doc_mentions_permissions_command() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    if grep -qE '\| `/permissions` \|' "$DOC"; then
+        pass "CLAUDE_CODE_SDLC_WIZARD.md pins /permissions row in complementary-skills table"
+    else
+        fail "CLAUDE_CODE_SDLC_WIZARD.md should keep /permissions in the complementary-skills table"
+    fi
+}
+
 test_wizard_doc_recommends_opus_1m
 test_sdlc_skill_recommends_opus_1m
 test_cli_template_sets_opus_1m_model
@@ -436,6 +448,7 @@ test_repo_settings_match_template_autocompact
 test_hooks_recommend_opus_1m_alias
 test_setup_skill_mentions_less_permission_prompts
 test_wizard_doc_mentions_less_permission_prompts
+test_wizard_doc_mentions_permissions_command
 
 # ────────────────────────────────────────────
 # Summary


### PR DESCRIPTION
## Summary
- Points users at Claude Code's native `/less-permission-prompts` skill (scans transcripts, proposes allowlist) instead of us reimplementing it
- Adds it as an Optional Next Step in the setup skill (Step 12), alongside `/claude-automation-recommender`
- Adds a "Complementary native skills" table to `CLAUDE_CODE_SDLC_WIZARD.md` covering both `/less-permission-prompts` and `/permissions`
- Regression guards in `tests/test-doc-consistency.sh` pin both references

## Why
Boris's Opus 4.7 tips highlighted `/less-permission-prompts` as a permission-friction reducer. It's a native CC skill, not a wizard candidate. Surfacing it is free value; reimplementing would be bloat. This keeps the "use official plugins" doctrine visible.

## Test plan
- [x] `bash tests/test-doc-consistency.sh` — 19 passed (2 new)
- [x] `bash tests/test-cli.sh` — passed
- [x] `bash tests/test-hooks.sh` — passed
- [x] `bash tests/test-compliance.sh` — passed
- [x] `bash tests/test-docs-usability.sh` — passed
- [x] `bash tests/test-prove-it.sh` — passed
- [x] `bash tests/test-plugin.sh` — passed
- [x] `bash tests/test-setup-path.sh` — passed
- [x] `bash tests/test-self-update.sh` — passed