### PR TITLE
fix(api-detect): capture gh api stdout for already_exists check

### DIFF
--- a/.github/workflows/weekly-api-update.yml
+++ b/.github/workflows/weekly-api-update.yml
@@ -97,21 +97,23 @@ jobs:
           # Ensure the label exists (idempotent). Only swallow the known
           # 422 "already_exists" response — any other failure (auth, 5xx)
           # should fail loudly so we don't operate blind.
-          label_err=$(mktemp)
+          # NOTE: `gh api` writes the JSON error body to STDOUT (not stderr)
+          # on non-2xx, so we capture both streams to find 'already_exists'.
+          label_out=$(mktemp)
           if ! gh api "repos/${REPO}/labels" --method POST \
                -f name="${REVIEW_LABEL}" \
                -f color='0E8A16' \
                -f description='Anthropic API changelog entries pending session-time review (#100)' \
-               2>"$label_err"; then
-            if grep -q 'already_exists' "$label_err"; then
+               >"$label_out" 2>&1; then
+            if grep -q 'already_exists' "$label_out"; then
               echo "label ${REVIEW_LABEL} already exists — continuing"
             else
-              cat "$label_err" >&2
-              rm -f "$label_err"
+              cat "$label_out" >&2
+              rm -f "$label_out"
               exit 1
             fi
           fi
-          rm -f "$label_err"
+          rm -f "$label_out"
 
           # Build issue body from /tmp/new_entries.txt.
           {


### PR DESCRIPTION
## Summary

**Production hotfix.** The `api-review-needed` label-create step in `weekly-api-update.yml` fails on every dispatch after the first one.

## Root cause

`gh api` writes the JSON error body to **stdout** on non-2xx responses, not stderr. The `already_exists` check was grepping stderr only, which just contains `gh: Validation Failed (HTTP 422)` — no `already_exists` token. Check fails → step fails → no issue gets opened.

First dispatch on 2026-04-17 masked this: label didn't exist yet, POST succeeded with 2xx, never hit the error path. Second dispatch (today, after the label existed) failed with exit 1.

Evidence in [run 24587168625 logs](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/actions/runs/24587168625):
```
gh: Validation Failed (HTTP 422)
{"message":"Validation Failed","errors":[{"resource":"Label","code":"already_exists","field":"name"}],...}
```

## Fix

Redirect both streams to the same file: `>"$label_out" 2>&1`. The `already_exists` grep now sees the JSON body, the filter works, and genuine failures still fail loudly (uncaught message prints to stderr + exit 1).

## Test plan

- [x] YAML validates
- [x] 33/33 API detection tests pass
- [ ] CI green
- [ ] After merge, re-fire workflow with rolled-back seed — must succeed and open the enriched-body issue from #186