### PR TITLE
feat(community): GitHub issue + PR templates (#98)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a bug in the SDLC Wizard (CLI, hooks, skills, workflows, tests)
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- What broke? Include any error messages or unexpected behavior. -->
+
+## What you expected
+
+<!-- What should have happened? -->
+
+## Reproduction
+
+<!-- Minimal steps to reproduce. A small repro is much more useful than a long description. -->
+
+1.
+2.
+3.
+
+## Environment
+
+- **SDLC Wizard version:** <!-- run `grep 'Wizard Version' SDLC.md` in your project, or check package.json -->
+- **Claude Code version:** <!-- run `claude --version` -->
+- **OS:** <!-- macOS / Linux / Windows -->
+- **Install channel:** <!-- npx / Homebrew / curl script / plugin / GitHub Releases -->
+
+## Logs / output
+
+<!-- Paste any relevant CLI output, hook logs, or CI run URLs. -->
+
+```
+```
+
+## In-session alternative
+
+If this is a usability or workflow question rather than a bug, consider running `/feedback` inside a Claude Code session — it files a redacted feedback issue automatically with more context pre-filled.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: In-session feedback
+    url: https://github.com/BaseInfinity/agentic-ai-sdlc-wizard#feedback
+    about: Prefer `/feedback` inside Claude Code — auto-fills context and redacts secrets
+  - name: Discussions
+    url: https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/discussions
+    about: Open-ended conversations, ideas, and troubleshooting

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Propose a new SDLC enforcement rule, hook, skill, or workflow
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## What's the gap
+
+<!-- What real development problem does this solve? Prefer concrete evidence (incident, PR, transcript excerpt) over theoretical gaps. -->
+
+## Proposed solution
+
+<!-- What should the wizard do? Which layer — hook, skill, workflow, CLI flag? -->
+
+## Prove-It Gate
+
+The wizard is deliberately lean. New additions must show their value before landing:
+
+- [ ] Is there a real, observed gap (not theoretical)?
+- [ ] Does something equivalent already exist (native CC feature, existing skill, third-party)?
+- [ ] If equivalent exists: what makes this better? (A/B evidence, quality comparison)
+- [ ] Can you write a test that proves quality, not just existence?
+
+Answering these up front dramatically speeds up triage.
+
+## Alternatives considered
+
+<!-- What else could solve this? Why is your proposal better? -->
+
+## In-session alternative
+
+`/feedback` inside a Claude Code session files a suggestion with richer context pre-filled.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,19 @@
+---
+name: Question
+about: Ask how something works, or whether the wizard supports a use case
+title: "question: "
+labels: question
+assignees: ''
+---
+
+## Your question
+
+<!-- What are you trying to do? What have you tried? -->
+
+## Context
+
+<!-- Version, setup, what you've already read (SDLC.md, CLAUDE_CODE_SDLC_WIZARD.md, CONTRIBUTING.md). -->
+
+## In-session alternative
+
+If you're inside a Claude Code session, `/feedback` can also surface questions to the maintainer.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- For release PRs and trivial doc tweaks, feel free to strip unused sections. -->
+
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Motivation
+
+<!-- What problem or roadmap item does this close? Link issue/PR/roadmap row. -->
+
+Closes #
+
+## Prove-It Gate (for new skills, hooks, or features)
+
+If this PR introduces a new component, tick the boxes. Skip this section for pure bug fixes or refactors.
+
+- [ ] Does equivalent functionality already exist (native CC, existing skill, third-party)?
+- [ ] If yes: evidence this is better (A/B test, quality comparison, gap analysis)
+- [ ] If no: what gap does this fill? Is the gap observed or theoretical?
+- [ ] Tests prove OUTPUT QUALITY, not just existence
+- [ ] Absorption check: could this be a section in an existing skill rather than a new component?
+
+## Test plan
+
+- [ ]
+- [ ]
+- [ ] Full regression suite green (see `CONTRIBUTING.md` for the command chain)
+- [ ] Cross-model review via Codex xhigh if change is substantial (security, auth, release, skill/workflow edits)
+
+## Follow-ups / known limitations
+
+<!-- Anything deferred? Any known sharp edges for reviewers? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,9 @@ jobs:
       - name: Run Memory Audit Protocol tests
         run: ./tests/test-memory-audit-protocol.sh
 
+      - name: Run community paths tests
+        run: ./tests/test-community-paths.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-doc-consistency.sh && \
    ./tests/test-api-feature-detection.sh && \
    ./tests/test-memory-audit-protocol.sh && \
+   ./tests/test-community-paths.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/README.md
+++ b/README.md
@@ -252,3 +252,11 @@ Share patterns, ask questions, compare notes on AI agents, automation, and SDLC 
 ## Contributing
 
 PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for evaluation methodology and testing.
+
+## Feedback
+
+Three ways to report bugs, request features, or ask questions:
+
+- **In-session:** run `/feedback` inside any Claude Code session using this wizard — auto-fills context and redacts secrets before filing
+- **Issue templates:** [bug report](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/issues/new?template=bug_report.md), [feature request](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/issues/new?template=feature_request.md), [question](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/issues/new?template=question.md)
+- **Discussions:** open-ended conversations at [github.com/BaseInfinity/agentic-ai-sdlc-wizard/discussions](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard/discussions)

--- a/tests/test-community-paths.sh
+++ b/tests/test-community-paths.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Community feedback + contribution paths tests (#98)
+# Validates: issue templates exist with required fields, PR template exists,
+# CONTRIBUTING.md is discoverable from README, /feedback skill is wired.
+#
+# Why: external contributors shouldn't hit a blank "New issue" form. They
+# need bug/feature/question routes with labels + minimum field guidance.
+# When these paths drift (e.g., template deleted, label missing), external
+# feedback quality degrades silently.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ISSUE_DIR="$REPO_ROOT/.github/ISSUE_TEMPLATE"
+PR_TEMPLATE="$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md"
+
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Community Paths Tests (#98) ==="
+echo ""
+
+# ────────────────────────────────────────────
+# Issue templates
+# ────────────────────────────────────────────
+
+test_issue_template_dir_exists() {
+    if [ -d "$ISSUE_DIR" ]; then
+        pass ".github/ISSUE_TEMPLATE/ directory exists"
+    else
+        fail ".github/ISSUE_TEMPLATE/ directory missing — external contributors hit blank issue form"
+    fi
+}
+
+test_bug_report_template() {
+    local f="$ISSUE_DIR/bug_report.md"
+    if [ ! -f "$f" ]; then
+        fail "bug_report.md template missing"
+        return
+    fi
+    # Must have YAML frontmatter with name, about, labels
+    local missing=""
+    for key in '^name:' '^about:' '^labels:'; do
+        if ! grep -q "$key" "$f"; then
+            missing="${missing:+${missing}, }${key//^/}"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        pass "bug_report.md has required frontmatter (name/about/labels)"
+    else
+        fail "bug_report.md missing frontmatter keys: $missing"
+    fi
+}
+
+test_feature_request_template() {
+    local f="$ISSUE_DIR/feature_request.md"
+    if [ ! -f "$f" ]; then
+        fail "feature_request.md template missing"
+        return
+    fi
+    if grep -q '^name:' "$f" && grep -q '^about:' "$f" && grep -q '^labels:' "$f"; then
+        pass "feature_request.md has required frontmatter"
+    else
+        fail "feature_request.md missing required frontmatter"
+    fi
+}
+
+test_question_template() {
+    local f="$ISSUE_DIR/question.md"
+    if [ ! -f "$f" ]; then
+        fail "question.md template missing"
+        return
+    fi
+    if grep -q '^name:' "$f" && grep -q '^labels:' "$f"; then
+        pass "question.md has required frontmatter"
+    else
+        fail "question.md missing required frontmatter"
+    fi
+}
+
+test_issue_templates_reference_feedback_skill() {
+    # At least one template should mention /feedback so users know about it
+    if grep -rq '/feedback' "$ISSUE_DIR" 2>/dev/null; then
+        pass "Issue templates mention /feedback skill as alternative path"
+    else
+        fail "No issue template mentions /feedback skill — users don't know about in-session feedback"
+    fi
+}
+
+test_bug_template_mentions_sdlc_version() {
+    # Diagnosis requires knowing the user's wizard version
+    if grep -qE 'Wizard Version|sdlc[_ -]?wizard.*version|SDLC\.md' "$ISSUE_DIR/bug_report.md" 2>/dev/null; then
+        pass "bug_report.md asks for wizard version (critical for diagnosis)"
+    else
+        fail "bug_report.md doesn't ask for wizard version — triage will be harder"
+    fi
+}
+
+# ────────────────────────────────────────────
+# PR template
+# ────────────────────────────────────────────
+
+test_pr_template_exists() {
+    if [ -f "$PR_TEMPLATE" ]; then
+        pass "PULL_REQUEST_TEMPLATE.md exists"
+    else
+        fail "PULL_REQUEST_TEMPLATE.md missing — contributors don't know what to include"
+    fi
+}
+
+test_pr_template_has_test_plan() {
+    if [ ! -f "$PR_TEMPLATE" ]; then return; fi
+    if grep -qiE 'test plan|test\s*checklist|## tests?' "$PR_TEMPLATE"; then
+        pass "PR template has test plan section"
+    else
+        fail "PR template missing test plan section — TDD evidence won't be captured"
+    fi
+}
+
+test_pr_template_has_summary_section() {
+    if [ ! -f "$PR_TEMPLATE" ]; then return; fi
+    if grep -qiE '## summary|## what|## description' "$PR_TEMPLATE"; then
+        pass "PR template has summary/what section"
+    else
+        fail "PR template missing summary section"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Discoverability from README + CONTRIBUTING
+# ────────────────────────────────────────────
+
+test_readme_links_to_contributing() {
+    if grep -qE 'CONTRIBUTING\.md|contributing\.md|CONTRIBUTING\]' "$REPO_ROOT/README.md"; then
+        pass "README links to CONTRIBUTING.md"
+    else
+        fail "README does not link to CONTRIBUTING.md — discoverability gap"
+    fi
+}
+
+test_contributing_exists_and_nonempty() {
+    local f="$REPO_ROOT/CONTRIBUTING.md"
+    if [ -f "$f" ] && [ -s "$f" ]; then
+        pass "CONTRIBUTING.md exists and non-empty"
+    else
+        fail "CONTRIBUTING.md missing or empty"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Run
+# ────────────────────────────────────────────
+
+test_issue_template_dir_exists
+test_bug_report_template
+test_feature_request_template
+test_question_template
+test_issue_templates_reference_feedback_skill
+test_bug_template_mentions_sdlc_version
+
+test_pr_template_exists
+test_pr_template_has_test_plan
+test_pr_template_has_summary_section
+
+test_readme_links_to_contributing
+test_contributing_exists_and_nonempty
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+
+echo "All community paths tests passed!"

--- a/tests/test-community-paths.sh
+++ b/tests/test-community-paths.sh
@@ -79,10 +79,44 @@ test_question_template() {
         fail "question.md template missing"
         return
     fi
-    if grep -q '^name:' "$f" && grep -q '^labels:' "$f"; then
-        pass "question.md has required frontmatter"
+    # All three markdown templates must have name/about/labels — consistent contract
+    if grep -q '^name:' "$f" && grep -q '^about:' "$f" && grep -q '^labels:' "$f"; then
+        pass "question.md has required frontmatter (name/about/labels)"
     else
-        fail "question.md missing required frontmatter"
+        fail "question.md missing required frontmatter (name/about/labels)"
+    fi
+}
+
+test_config_yml_exists() {
+    local f="$ISSUE_DIR/config.yml"
+    if [ -f "$f" ]; then
+        pass ".github/ISSUE_TEMPLATE/config.yml exists"
+    else
+        fail "config.yml missing — blank issues not disabled, contact links not surfaced"
+    fi
+}
+
+test_config_yml_disables_blank_issues() {
+    local f="$ISSUE_DIR/config.yml"
+    if [ ! -f "$f" ]; then return; fi
+    if grep -qE '^blank_issues_enabled:[[:space:]]*false' "$f"; then
+        pass "config.yml disables blank issues (forces users into a template)"
+    else
+        fail "config.yml does not set blank_issues_enabled: false"
+    fi
+}
+
+test_config_yml_has_contact_links() {
+    local f="$ISSUE_DIR/config.yml"
+    if [ ! -f "$f" ]; then return; fi
+    # contact_links schema: each entry has name/url/about. Check at least one full triple.
+    if grep -q '^contact_links:' "$f" \
+       && grep -qE '^\s*-\s*name:' "$f" \
+       && grep -qE '^\s*url:' "$f" \
+       && grep -qE '^\s*about:' "$f"; then
+        pass "config.yml has contact_links with name/url/about schema"
+    else
+        fail "config.yml missing valid contact_links entries (name/url/about)"
     fi
 }
 
@@ -163,6 +197,9 @@ test_issue_template_dir_exists
 test_bug_report_template
 test_feature_request_template
 test_question_template
+test_config_yml_exists
+test_config_yml_disables_blank_issues
+test_config_yml_has_contact_links
 test_issue_templates_reference_feedback_skill
 test_bug_template_mentions_sdlc_version
 


### PR DESCRIPTION
## Summary

Closes #98 (partial — templates + discoverability). External contributors previously hit a blank 'New issue' form and had no PR template to guide TDD evidence capture.

## What's in this PR

- **Issue templates** in `.github/ISSUE_TEMPLATE/`:
  - `bug_report.md` — asks for wizard version (triage blocker), CC version, OS, install channel. Points to `/feedback` for in-session auto-redacted filing
  - `feature_request.md` — embeds Prove-It Gate checklist (absorption, equivalent-exists, quality-test) so low-value proposals self-filter
  - `question.md` — routes questions to labeled issues or `/feedback`
  - `config.yml` — disables blank issues, adds contact links to Discussions + in-session feedback
- **PR template** at `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Motivation (with `Closes #`), Prove-It Gate checklist for new components, Test plan, Follow-ups
- **README "Feedback" section** — three-path surface (in-session, issue templates, Discussions)
- **GitHub Discussions enabled** — previously 404, now live
- **`tests/test-community-paths.sh`** — 14 tests covering template existence, frontmatter schema, config.yml schema, PR template sections, discoverability. Mutation-verified (deleting config.yml trips test; stripping `about:` from template trips test)

## Provenance

- Codex xhigh review: 5/10 NOT CERTIFIED → 10/10 CERTIFIED after 2 rounds
- Round 1 caught: (a) Discussions URL 404'd, (b) tests passed vacuously when config.yml deleted — both fixed, both mutation-verified

## Test plan

- [x] `./tests/test-community-paths.sh` — 14 passed, 0 failed
- [x] Full regression suite: `./tests/test-doc-consistency.sh` (20 pass), `./tests/test-docs-usability.sh` (26 pass), `./tests/test-hooks.sh`, `./tests/test-memory-audit-protocol.sh`
- [x] Mutation: `rm config.yml` → FAIL as expected
- [x] Mutation: strip `about:` from question.md → FAIL as expected
- [x] Manual: `curl -sI -L github.com/BaseInfinity/agentic-ai-sdlc-wizard/discussions` → HTTP 200
- [ ] CI green on PR