### PR TITLE
feat(hooks): session-start nudge for open CC auto-update PRs (#85)

### DIFF
--- a/.reviews/handoff.json
+++ b/.reviews/handoff.json
@@ -1,31 +1,29 @@
 {
-  "review_id": "100-bullet-summary-001",
-  "status": "PENDING_RECHECK",
-  "round": 2,
-  "mission": "Enhance parse-api-changelog.py to capture first 1-2 bullets under each date header, emit as 3rd tab-separated column, render in issue body. Feedback from E2E test: issue body showed only date (no feature hint). This fixes the UX gap while preserving the LLM-free shepherd pattern.",
-  "success": "Parser correctly captures bullets from real Anthropic changelog format. Workflow renders them without breaking. Truncation bounds issue body size. Fallback preserves existing behavior when bullets absent.",
-  "failure": "Silent parse failure on Anthropic format variations; bullet text exfiltrates through tab-delimited stream incorrectly; truncation drops critical content; workflow breaks when bullet_summary column missing (back-compat for rollback).",
+  "review_id": "85-cc-update-nudge-001",
+  "status": "PENDING_REVIEW",
+  "round": 1,
+  "mission": "Add a session-start nudge to hooks/instructions-loaded-check.sh that surfaces open 'auto-update'-labeled PRs created by .github/workflows/weekly-update.yml. Mirrors the existing 'api-review-needed' issue nudge pattern sitting directly above it. Closes ROADMAP item #85 (Automated CC Feature Discovery) by closing the last gap: detector → PR → session awareness.",
+  "success": "New nudge block is structurally identical to the api-review-needed block (same guards, same gating, same output style). Runtime tests prove it emits on non-zero PR count, stays silent on zero count, and stays silent in consumer projects that don't own the detector. Mutation tests confirm test coverage is behavioral, not just structural.",
+  "failure": "Consumer projects (CLI-distributed hook) pester users with upstream-wizard PRs. gh command not installed → hook crashes or leaks stderr. gh pr list returns unexpected content → regex match gives false positive. Hook no longer exits 0. Output collides with existing api-review-needed output.",
   "files_changed": [
-    "scripts/parse-api-changelog.py",
-    ".github/workflows/weekly-api-update.yml",
-    "tests/test-api-feature-detection.sh"
+    "hooks/instructions-loaded-check.sh",
+    "tests/test-hooks.sh"
   ],
-  "fixes_applied": [
-    "1: parse-api-changelog.py filters header_hits to date-parseable headers only; non-date sub-headers no longer bound bullet search. Added _try_parse_date helper shared between boundary scan and result loop.",
-    "1: tests/test-api-feature-detection.sh adds test_parser_bullets_survive_subheaders with the Codex repro fixture."
-  ],
-  "previous_score": 7,
+  "fixes_applied": [],
+  "previous_score": null,
   "verification_checklist": [
-    "(a) Verify parse-api-changelog.py BULLET_LINE regex handles leading whitespace, all bullet markers (-, *, +), and doesn't match numbered lists",
-    "(b) Verify _extract_bullets correctly bounds search between consecutive date headers (no bleed-through from later entries)",
-    "(c) Verify BULLET_MAX=200 truncation adds ellipsis only when exceeded and doesn't mangle multi-byte chars",
-    "(d) Verify parse_dates pre-computes header line indices so each bullet search is bounded (O(n) not O(n^2))",
-    "(e) Verify workflow `while IFS=$'\\t' read -r iso raw_text bullet_summary` gracefully handles entries where bullet_summary is empty string (tab present but empty)",
-    "(f) Verify test coverage: existing tests still pass with 3-col format, new tests (captures_bullet_summary, truncates_long_bullet_summary) verify both boundaries",
-    "(g) Check for injection risk: bullet text from Anthropic docs flows through echo into issue body. Any shell-special chars that break the here-doc?",
-    "(h) Verify back-compat: if Anthropic changelog had zero bullets under a header, parser emits empty 3rd col, workflow falls back to raw_text"
+    "(a) Verify hooks/instructions-loaded-check.sh:124-141 gates the nudge on BOTH local presence of .github/workflows/weekly-update.yml AND command -v gh — same double-gate as the api-review block at lines 109-122",
+    "(b) Verify the nudge uses `gh pr list --state open --label auto-update --limit 1 --json number --jq 'length'` — matches the label that .github/workflows/weekly-update.yml line ~362 stamps onto its PRs",
+    "(c) Verify CC_UPDATE_COUNT is validated as integer via `[[ \"$CC_UPDATE_COUNT\" =~ ^[0-9]+$ ]]` before the -gt 0 comparison — protects against gh returning error text or empty string",
+    "(d) Verify hook still exits 0 (tests/test-hooks.sh test_instructions_hook_exit_code still passes). The new block does not introduce `set -e` or any non-zero early-exit path",
+    "(e) Verify tests/test-hooks.sh test_hook_silent_without_weekly_update_workflow actually exercises the consumer-project scenario — fixture creates PROJECT with SDLC.md/TESTING.md but NO weekly-update.yml, and mocked gh returns count=3. If the nudge fires, it means consumer projects see upstream PRs — that's the #85 gating failure mode",
+    "(f) Verify mutation robustness: deleting the entire new block from hooks/instructions-loaded-check.sh should trip 4+ tests. Running: I verified manually — `sed '/auto-update/,/^fi$/d'` trips 4 tests (all 4 CC-release-review tests that require the block's behavior)",
+    "(g) Verify no test regression: all 78 test-hooks tests pass, 30 unit-test scripts pass with 0 failures",
+    "(h) Check the mocked `gh` binary in prepare_cc_update_fixture() correctly distinguishes 'pr list --label auto-update' from other gh calls — the loop over \"$@\" checking for \"auto-update\" and \"api-review-needed\" args handles both label queries. Any other gh invocation (e.g., dual-install check) returns empty, which is safe",
+    "(i) Check for output collision: when BOTH api-review-needed issues AND auto-update PRs exist, does the hook emit both nudges cleanly on separate lines? (Expected yes — both blocks use `echo` with no shared state)",
+    "(j) Check backward compat: consumer projects that have .github/workflows/ but no weekly-update.yml must see ZERO new output. Consumer projects without .github/ at all must see ZERO new output. Both paths hit the `-f` test and short-circuit"
   ],
-  "review_instructions": "Focus on parser correctness and injection/escaping risks. Be strict — assume bugs may be present until proven otherwise. This is a meta-repo that ships to consumer projects; a parser regression would silently break every wizard user's detection path. Previous review (100-api-detection, 9/10 CERTIFIED) established the mission pattern — this is a scoped enhancement.",
-  "preflight_path": ".reviews/preflight-100-bullet-summary.md",
+  "review_instructions": "Focus on shell correctness, gating logic, and consumer-project safety. This hook is distributed to every wizard user via the CLI — a regression here fires in every SDLC-managed project. Be strict about: (1) the double-gate (workflow file + gh availability), (2) input validation on the gh return value, (3) any path where the hook might break `exit 0`. The pattern is a direct mirror of the api-review-needed block at lines 109-122 — if the new block is structurally different, that's a bug. Assume bugs may be present until proven otherwise.",
+  "preflight_path": ".reviews/preflight-85-cc-update-nudge.md",
   "artifact_path": ".reviews/"
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,7 +98,7 @@
 
 | Priority | # | Item | Description |
 |----------|---|------|-------------|
-| 1 | 85 | ~~Automated CC Feature Discovery~~ DONE | Already implemented in weekly-update.yml: fetches CC releases, analyzes with Claude (analyze-release.md), produces relevance/impact JSON, creates PR. GitHub issue per-feature deferred — PR + ROADMAP already cover tracking |
+| 1 | 85 | ~~Automated CC Feature Discovery~~ DONE | weekly-update.yml fetches CC releases, analyzes with Claude (analyze-release.md), produces relevance/impact JSON, creates PRs with `auto-update` label. Session-start nudge added in `instructions-loaded-check.sh` (mirrors api-review-needed pattern) so open CC-update PRs surface at session start and don't bit-rot |
 | 2 | 91 | ~~Codex SDLC Adapter~~ DONE | `BaseInfinity/codex-sdlc-wizard` PR #1. 3 hook scripts (bash-guard hard-blocks git commit/push, sdlc-prompt-check, session-start), non-destructive install.sh (6-case config merge, comment-aware), AGENTS.md, upstream-sync workflow. 15 behavioral tests. Codex review caught 2 bugs (commented config lines, macOS sed TOML corruption) — both fixed. ~70% CC parity |
 | 3 | 58 | ~~Research: claw-code + OmO/OmX Patterns~~ DONE | Studied claw-code (168K stars), OmO (48K), OmX (16K). 16 candidate patterns identified. Codex certified 8/10 round 3. All candidates require Prove It Gate. Research doc: `RESEARCH_58_CLAW_OMO_OMX.md` |
 | 4 | 103 | ~~Fix: self_review 0% in E2E Scoring~~ DONE | Root cause: simulation prompt said "self-review" without explaining HOW (Read/Grep on modified files) or marking it scored. Golden output had text-only review (the exact NO example from the evaluator). Fix: all 5 simulation prompts now explain self-review = Read back modified files + marked scored in IMPORTANT section. Golden output/scores updated. 4 new tests |
@@ -199,7 +199,7 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 | 65 | ~~Testing Diamond Boundary~~ DONE | Completed in v1.23.0 |
 | 66 | ~~Convert to Plugin Format~~ Absorbed into #89 | Plugin format + marketplace submission combined into single item #89. Plugins now support hooks (updated finding from 2026-04-03 research) |
 | 67 | Add Agent Team Hooks | DEFERRED — Agent Teams requires experimental feature flag (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`). Hooks would be inert for most users. Main session enforcement already covers subagent workflows (subagents do what the main session tells them). Revisit when Agent Teams exits experimental. Prove It Gate: can't prove value without GA feature |
-| 68 | Hook `if` Conditionals | Use CC v2.1.85's `if` field to reduce false positives (e.g., skip TDD check when editing test files, skip on `--bare`). Cleaner than shell-script filtering. Spawned from #59 research |
+| 68 | ~~Hook `if` Conditionals~~ DONE | PR #151. PreToolUse tdd-pretool-check.sh wired with CC v2.1.85 `if:` field in .claude/settings.json to filter Write/Edit/MultiEdit by path glob |
 | 69 | ~~Skill Frontmatter Docs~~ DONE | Completed in v1.23.0 |
 | 70 | ~~`--bare` Docs~~ DONE | Completed in v1.23.0 |
 | 71 | Monitor KAIROS/Coordinator Mode | Proactive always-on agent mode and multi-agent coordination. Wizard's enforcement model (hooks on tool calls) needs to scale to always-on monitoring. Track feature flags, prepare skill content for both contexts. Spawned from #59 research |

--- a/hooks/instructions-loaded-check.sh
+++ b/hooks/instructions-loaded-check.sh
@@ -121,6 +121,26 @@ if [ -f "$PROJECT_DIR/.github/workflows/weekly-api-update.yml" ] && \
     fi
 fi
 
+# Claude Code release review nudge (#85) — surface open 'auto-update' PRs
+# opened by .github/workflows/weekly-update.yml so new CC releases get triaged
+# before they bit-rot (relevance-HIGH PRs can sit for days otherwise).
+#
+# Gated on LOCAL presence of weekly-update.yml: the CLI distributes this hook
+# to consumer projects, which don't own the detector — don't pester them with
+# upstream-wizard PRs.
+if [ -f "$PROJECT_DIR/.github/workflows/weekly-update.yml" ] && \
+   command -v gh > /dev/null 2>&1; then
+    CC_UPDATE_COUNT=$(gh pr list \
+        --state open \
+        --label "auto-update" \
+        --limit 1 \
+        --json number \
+        --jq 'length' 2>/dev/null) || CC_UPDATE_COUNT=""
+    if [[ "$CC_UPDATE_COUNT" =~ ^[0-9]+$ ]] && [ "$CC_UPDATE_COUNT" -gt 0 ]; then
+        echo "Claude Code update pending review: ${CC_UPDATE_COUNT} open auto-update PR(s) (see .github/workflows/weekly-update.yml)"
+    fi
+fi
+
 # Claude Code version check (non-blocking, best-effort)
 if command -v claude > /dev/null 2>&1 && command -v npm > /dev/null 2>&1; then
     CC_LOCAL=$(claude --version 2>/dev/null | grep -o '[0-9][0-9.]*' | head -1) || true

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1232,6 +1232,122 @@ test_instructions_hook_silent_cli_only
 test_instructions_hook_dual_install_non_blocking
 
 echo ""
+echo "--- CC release review nudge (#85) ---"
+
+# Helper: fixture with weekly-update.yml + mocked gh returning configurable PR count
+prepare_cc_update_fixture() {
+    local tmpdir="$1"
+    local pr_count="$2"       # integer — count returned by mocked gh
+    local has_workflow="$3"   # "yes" or "no"
+    mkdir -p "$tmpdir/project"
+    echo "# SDLC" > "$tmpdir/project/SDLC.md"
+    echo "# Testing" > "$tmpdir/project/TESTING.md"
+    if [ "$has_workflow" = "yes" ]; then
+        mkdir -p "$tmpdir/project/.github/workflows"
+        echo "name: Weekly Update" > "$tmpdir/project/.github/workflows/weekly-update.yml"
+    fi
+    mkdir -p "$tmpdir/bin"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/npm"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/claude"
+    printf '#!/bin/bash\nexit 1\n' > "$tmpdir/bin/codex"
+    # Mock gh: returns pr_count when asked for auto-update PRs, empty otherwise
+    cat > "$tmpdir/bin/gh" <<EOF
+#!/bin/bash
+# Look at full args — distinguish 'pr list ... auto-update' from other calls
+for arg in "\$@"; do
+    if [ "\$arg" = "auto-update" ]; then
+        echo "$pr_count"
+        exit 0
+    fi
+    if [ "\$arg" = "api-review-needed" ]; then
+        echo "0"
+        exit 0
+    fi
+done
+# Default: empty (keeps other gh calls quiet)
+echo ""
+exit 0
+EOF
+    chmod +x "$tmpdir/bin/npm" "$tmpdir/bin/claude" "$tmpdir/bin/codex" "$tmpdir/bin/gh"
+}
+
+test_hook_queries_auto_update_label() {
+    if grep -qF 'auto-update' "$HOOKS_DIR/instructions-loaded-check.sh"; then
+        pass "hook queries for auto-update label"
+    else
+        fail "hook must check for open PRs with auto-update label (#85)"
+    fi
+}
+
+test_hook_gates_cc_nudge_on_weekly_update_workflow() {
+    # Mirror the api-review-needed gating pattern — only fire when the
+    # detector workflow lives in this repo (not in consumer projects).
+    if grep -B1 -A10 'auto-update' "$HOOKS_DIR/instructions-loaded-check.sh" | grep -q 'weekly-update.yml'; then
+        pass "hook gates CC update nudge on weekly-update.yml presence"
+    else
+        fail "hook must gate auto-update nudge on .github/workflows/weekly-update.yml"
+    fi
+}
+
+test_hook_guards_gh_for_cc_nudge() {
+    if grep -B1 -A10 'auto-update' "$HOOKS_DIR/instructions-loaded-check.sh" | grep -q 'command -v gh'; then
+        pass "hook guards on gh availability for CC nudge"
+    else
+        fail "hook must check 'command -v gh' before querying auto-update PRs"
+    fi
+}
+
+test_hook_emits_cc_nudge_when_pending() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    prepare_cc_update_fixture "$tmpdir" "2" "yes"
+    local output
+    output=$(cd "$tmpdir/project" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir/project" HOME="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -qiE 'Claude Code.*update.*pending|auto-update.*PR|CC.*release.*review'; then
+        pass "hook emits CC update nudge when auto-update PRs open"
+    else
+        fail "Should emit nudge when gh reports open auto-update PR(s), got: $output"
+    fi
+}
+
+test_hook_silent_when_no_pending_cc_updates() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    prepare_cc_update_fixture "$tmpdir" "0" "yes"
+    local output
+    output=$(cd "$tmpdir/project" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir/project" HOME="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -qiE 'Claude Code.*update.*pending|auto-update.*PR|CC.*release.*review'; then
+        fail "Should be silent when no open auto-update PRs, got: $output"
+    else
+        pass "hook silent when no auto-update PRs pending"
+    fi
+}
+
+test_hook_silent_without_weekly_update_workflow() {
+    # Consumer projects don't own the detector — don't pester them.
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    prepare_cc_update_fixture "$tmpdir" "3" "no"
+    local output
+    output=$(cd "$tmpdir/project" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir/project" HOME="$tmpdir" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -qiE 'auto-update.*PR|CC.*release.*review'; then
+        fail "Consumer project without detector workflow shouldn't see upstream nudge, got: $output"
+    else
+        pass "hook silent without weekly-update.yml (consumer project)"
+    fi
+}
+
+test_hook_queries_auto_update_label
+test_hook_gates_cc_nudge_on_weekly_update_workflow
+test_hook_guards_gh_for_cc_nudge
+test_hook_emits_cc_nudge_when_pending
+test_hook_silent_when_no_pending_cc_updates
+test_hook_silent_without_weekly_update_workflow
+
+echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"
 echo "Failed: $FAILED"


### PR DESCRIPTION
## Summary

Adds a session-start nudge in `hooks/instructions-loaded-check.sh` that surfaces open `auto-update`-labeled PRs — the label that `.github/workflows/weekly-update.yml` stamps on CC release PRs. Mirrors the existing `api-review-needed` issue nudge pattern sitting directly above it.

Closes the last gap in ROADMAP #85: detector → PR → **session awareness**. Previously, relevance-HIGH CC-update PRs could sit unreviewed until someone remembered to check; now every new Claude Code session surfaces them at the top.

## Motivation

Closes #85 (Automated CC Feature Discovery). The detector pipeline already existed; the session nudge closes the human-awareness gap.

## Changes

**`hooks/instructions-loaded-check.sh`** — 20-line block that:
- Gates on `.github/workflows/weekly-update.yml` presence (consumer projects distributed via CLI never see upstream PRs)
- Gates on `command -v gh` (non-blocking when gh absent)
- Validates `gh pr list` return as integer before comparing
- Exits 0 like the rest of the hook

**`tests/test-hooks.sh`** — 6 new tests (78 total):
- 3 structural (label queried, workflow gate present, `gh` guard)
- 3 behavioral (emits on count>0, silent on count=0, silent without workflow)
- Uses mocked `gh` binary distinguishing `auto-update` from `api-review-needed` args

**`ROADMAP.md`** — updated #85 DONE row to reflect the session nudge closure.

## Prove-It Gate

- **Absorption check**: Added to existing hook, no new file
- **Equivalent exists?**: Yes — mirrors `api-review-needed` pattern verbatim. Zero new cognitive load
- **Quality test?**: 3 behavioral tests assert the nudge actually emits / stays silent. Mutation test (deleting the block) trips 4 tests

## Test plan

- [x] TDD RED: 4/6 new tests failed before implementation
- [x] TDD GREEN: 78/78 hook tests pass
- [x] Mutation-verified: `sed '/auto-update/,/^fi$/d'` trips 4 tests
- [x] Full unit regression: 30 test scripts, 0 failures
- [x] Codex cross-model review (xhigh): **CERTIFIED 9/10 round 1, no findings**