### PR TITLE
fix(#226): honest labeling for judge-CI vs true N-trial CI

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -692,7 +692,7 @@ jobs:
             | PHASE_A_FAILED | New CC version breaks SDLC enforcement | Don't upgrade |
 
             ---
-            *Statistical methodology: 5 trials, 95% CI, overlapping CI comparison*
+            *Scoring methodology: 1 simulation per phase, then scored 5× by the judge (judge-consistency band, not independent-trial CI). ROADMAP #226 tracks migration to true N-independent-trial scoring.*
 
   scan-community:
     runs-on: ubuntu-latest
@@ -1143,12 +1143,14 @@ jobs:
 
             ### E2E Test Results
 
-            | Phase | Score (95% CI) |
+            | Phase | Score (judge-CI band over 5 re-scorings of 1 run) |
             |-------|----------------|
             | Baseline | ${{ steps.baseline.outputs.ci }} |
             | With Changes | ${{ steps.candidate.outputs.ci }} |
 
             ### Verdict: **${{ steps.verdict.outputs.verdict }}**
+
+            > **Caveat:** The CI band above measures **judge consistency** (5 re-scorings of a single simulation transcript), not **execution variance** (which would require 5 independent simulations). See ROADMAP #226 for the migration to true N-trial scoring.
 
             - **IMPROVED**: Community patterns significantly improve SDLC scores
             - **STABLE**: No significant difference (safe to merge if patterns are useful)
@@ -1405,7 +1407,7 @@ jobs:
           # Append dynamic values safely via printf (no shell expansion)
           PRETTY_PATHS=$(echo "$OVERLAP_PATHS" | jq -r '.[]' 2>/dev/null | paste -sd ', ' - || echo "$OVERLAP_PATHS")
           printf '\n**Overlapping features:** %s\n' "$PRETTY_PATHS" >> /tmp/prove-it-comment.md
-          printf '\n| Variant | Score (95%% CI) |\n' >> /tmp/prove-it-comment.md
+          printf '\n| Variant | Score (judge-CI band, 5 re-scorings of 1 run — see ROADMAP #226) |\n' >> /tmp/prove-it-comment.md
           printf '|---------|----------------|\n' >> /tmp/prove-it-comment.md
           printf '| With Custom Features (baseline) | %s |\n' "$BASELINE_CI" >> /tmp/prove-it-comment.md
           printf '| Native Only (candidate) | %s |\n' "$CANDIDATE_CI" >> /tmp/prove-it-comment.md


### PR DESCRIPTION
## Summary

Partial fix for ROADMAP #226. Weekly-update workflow advertised '95% CI from 5 trials' but the underlying compute re-scores one simulation transcript 5× — that measures **judge consistency**, not **execution variance**.

Surfaced again in Codex cross-model review of #212 plan (2026-04-23): the weakness of the '≥3 PRs overlapping 95% CI' parity gate stems partly from this mislabeled CI in the weekly workflow.

## Fix scope

**Relabel, don't rescope.** This PR:
- Updates 3 PR body / comment templates in `weekly-update.yml` to say `judge-CI band over 5 re-scorings of 1 run` instead of `95% CI`
- Adds an explicit caveat paragraph linking to ROADMAP #226 so readers understand the limitation
- Leaves the underlying compute (`run-tier2-evaluation.sh` loop over a single OUTPUT_FILE) as-is

## Why not also fix the compute?

Running 5 **independent** simulations per weekly scan would ~5× the Anthropic API cost on that workflow — and today's credit-cap session already showed that's painful. True N-trial migration is the content of ROADMAP #226 and ROADMAP #212 (local-Max shepherd would subsidize the extra runs). Better to do it once, after #212, than patch two workflows twice.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/weekly-update.yml'))"` valid
- [ ] CI green