### PR TITLE
docs: GPT-5.5 preferred for cross-model review + README quickstart

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -3465,11 +3465,12 @@ Use an independent AI model from a different company as a code reviewer. The aut
 
 **Why this works:** Two AI systems from different companies (e.g., Claude writes, GPT reviews) provide adversarial diversity. They have fundamentally different training, different failure modes, and different strengths. What one misses, the other catches.
 
-**Use the best model at the deepest reasoning.** This is your quality gate — don't economize on it. Always use the latest, most capable model available (currently GPT-5.4) at maximum reasoning effort (`xhigh`). Cheaper/faster models miss things. The whole point is catching what the authoring model couldn't.
+**Use the best model at the deepest reasoning.** This is your quality gate — don't economize on it. Always use the latest, most capable model available (**GPT-5.5 if you have access**, otherwise GPT-5.4) at maximum reasoning effort (`xhigh` — this is non-negotiable, lower settings miss subtle errors). Cheaper/faster models miss things. The whole point is catching what the authoring model couldn't.
 
 **Prerequisites:**
 - Codex CLI installed: `npm i -g @openai/codex`
 - OpenAI API key configured: `export OPENAI_API_KEY=...`
+- Codex CLI picks up your OpenAI account's best available model automatically. If you have GPT-5.5 access, `codex exec` uses it; otherwise it falls back to GPT-5.4. No config change needed on your side.
 - This is a local workflow tool — not required for CI/CD
 
 **The Protocol:**

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ Layer 1: PHILOSOPHY
 | **Pre-tool TDD hooks** | Before source edits, a hook reminds Claude to write tests first. CI scoring checks whether it actually followed TDD |
 | **Self-evolving loop** | Weekly/monthly external research + local CI shepherd loop — you approve, the system gets better |
 
+## Optional: Cross-Model Review (Codex)
+
+Claude can't grade its own homework. Have a **different AI from a different company** review Claude's work — different training, different blind spots, different biases. We use OpenAI's Codex CLI, and it's **three commands to set up**:
+
+```bash
+npm i -g @openai/codex
+export OPENAI_API_KEY=sk-...
+codex --version   # confirm ready
+```
+
+That's it. Codex picks up your OpenAI account's best available model automatically — **if you have GPT-5.5, it uses GPT-5.5; otherwise GPT-5.4**. No model config needed.
+
+**How to use it:** after Claude's self-review passes, write a one-file mission brief and run:
+
+```bash
+codex exec -c 'model_reasoning_effort="xhigh"' -s danger-full-access \
+  -o .reviews/latest-review.md \
+  "Read .reviews/handoff.json and review per the checklist. Output findings + CERTIFIED or NOT CERTIFIED."
+```
+
+`xhigh` reasoning is **non-negotiable** — lower settings miss subtle bugs. See [CLAUDE_CODE_SDLC_WIZARD.md](CLAUDE_CODE_SDLC_WIZARD.md#cross-model-review-loop-optional) for the full protocol (handoff format, round-2 dialogue loop, preflight docs). Real-world: this catches P0/P1 issues in 2-3 out of 10 reviews that Claude's self-review rated as clean.
+
 ## How It Works
 
 **Think Iron Man:** Jarvis is nothing without Tony Stark. Tony Stark is still Tony Stark. But together? They make Iron Man. This SDLC is your suit - you build it over time, improve it for your needs, and it makes you both better.


### PR DESCRIPTION
## Summary

Two doc updates:
1. Cross-model review section in `CLAUDE_CODE_SDLC_WIZARD.md` now says **GPT-5.5 preferred, GPT-5.4 fallback**. Codex CLI auto-picks best available — no config change needed.
2. `README.md` gets a new **Optional: Cross-Model Review (Codex)** section with 3-command setup and one-liner example. Frames it as easy to adopt.

`xhigh` reasoning remains non-negotiable (existing guidance, reinforced).

## Why

Per memory `research_gpt_5_5_release.md`: GPT-5.5 shipped April 2026. OpenAI positions it as "noticeably stronger than Claude Opus 4.7 at reasoning/autonomy." Relevant to our reviewer-tier strategy — no executor-tier change yet (vendor quote ≠ evidence, wait for independent benchmark).

User callout (2026-04-24): "chat gpt5.5 dropped we need to update the sdlc-wizard to include that for cross model review if people have it on" + "prefer xhigh for cross model review... mention in README how easy it is to use."

## Test plan

- [x] `bash tests/test-doc-consistency.sh` — 22/0 green
- [x] `bash tests/test-workflow-triggers.sh` — green
- No code changes, no test impact expected in CI validate.
- e2e-* will red on API credit cap as usual (known canary).

## Scope excluded

- No executor-tier change (Opus 4.7 stays as default builder — wait for independent 5.5 benchmarks)
- Not updating historical "cross-model audit (Codex GPT-5.4)" reference at CLAUDE_CODE_SDLC_WIZARD.md:104 — that's accurate historical record of what happened