### PR TITLE
docs(#212): teach /sdlc about advisory-only E2E

### DIFF
--- a/SDLC.md
+++ b/SDLC.md
@@ -60,8 +60,8 @@ This repository uses the SDLC Wizard to enforce:
 To verify SDLC compliance:
 
 1. **Manual check**: Start new Claude session, observe hook output
-2. **E2E test**: Run `./tests/e2e/run-simulation.sh`
-3. **PR review**: Non-trivial PRs trigger AI code review workflow after CI passes
+2. **E2E test (advisory)**: `gh pr checkout <PR>` then `bash tests/e2e/local-shepherd.sh <PR>` — scores the PR on your Max subscription, posts PR comment + check-run. **Advisory-only since ROADMAP #212 Option 1 (2026-04-24); not a required merge check**. The legacy `tests/e2e/run-simulation.sh` is still runnable locally but has no CI role.
+3. **PR review**: Non-trivial PRs trigger AI code review workflow after `validate` passes (e2e is no longer a required check)
 
 ## Updating the Wizard
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -42,9 +42,16 @@ TodoWrite([
   { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
   { content: "Scope guard: only changes related to task? No legacy/fallback code left?", status: "pending", activeForm: "Checking scope and legacy code" },
   // CI FEEDBACK LOOP (if CI monitoring enabled in setup - skip if no CI)
+  // NOTE (meta-repo only, ROADMAP #212 Option 1, 2026-04-24): this repo no
+  // longer runs e2e simulation in CI. Only `validate` blocks merge. For E2E
+  // signal on a PR, checkout the PR locally and run:
+  //   bash tests/e2e/local-shepherd.sh <PR>
+  // which scores on Max subscription and posts an advisory check-run.
+  // Consumer repos still use their own CI as configured.
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
   { content: "Read CI review - implement valid suggestions, iterate until clean", status: "pending", activeForm: "Addressing CI review feedback" },
+  { content: "Meta-repo only: run local shepherd if PR needs E2E score (optional)", status: "pending", activeForm: "Running local shepherd" },
   { content: "Post-deploy verification (if deploy task — see Deployment Tasks)", status: "pending", activeForm: "Verifying deployment" },
   // FINAL
   { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" },


### PR DESCRIPTION
Follow-up to #231. Updates SDLC.md + skills/sdlc/SKILL.md so our own SDLC workflow knows E2E is now local-advisory, not a CI gate.

Concrete: when /sdlc hits the CI FEEDBACK LOOP step, it now knows to run `bash tests/e2e/local-shepherd.sh <PR>` locally if it wants an E2E score (instead of waiting for a CI job that no longer exists).

Doc-only. validate should pass.