### PR TITLE
v1.38.0: mixed-mode tier (#233) + prompt-hook-fires-once instrumentation (#224)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.37.1",
+      "version": "1.38.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,12 @@ jobs:
       - name: Run local shepherd tests
         run: ./tests/test-local-shepherd.sh
 
+      - name: Run repo complexity tests (#233)
+        run: ./tests/test-repo-complexity.sh
+
+      - name: Run prompt-hook-fires-once tests (#224)
+        run: ./tests/test-prompt-hook-fires-once.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # E2E test artifacts
 tests/e2e/.cache/
 
+# Generated test fixtures (rebuilt by tests/test-repo-complexity.sh on each run)
+tests/fixtures/complexity/
+
 # Claude Code local state
 .claude/plans/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the SDLC Wizard.
 
 ### Added
 
+- **Prompt-hook-fires-once instrumentation** — ROADMAP #224. `hooks/sdlc-prompt-check.sh` now records one tab-separated record (`<ts>\t<pid>\tsdlc-prompt-check`) per post-dedupe invocation when the opt-in env var `SDLC_HOOK_FIRE_LOG` is set. Maintainer can count lines per user prompt to verify CC 2.1.118's double-fire fix in real sessions; >1 line per prompt indicates regression. Unwritable paths fail silently. Procedure documented in `CLAUDE_CODE_SDLC_WIZARD.md` → "Verifying Prompt-Hook-Fires-Once". 6 regression tests in `tests/test-prompt-hook-fires-once.sh` cover the instrumentation contract (counter increments, opt-in semantics, log shape, output stability, error tolerance).
+
 - **Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer)** — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic classifies repos as `simple` or `complex` from filesystem signals (LOC, test count, hook count, workflow count, plus stakes flag for `.env` / `secrets/` / `credentials/`). Setup skill Step 9.5 expanded from binary y/N into a 3-way prompt:
   - **`[N]`** No pin (default, recommended for most repos) — preserves Claude Code auto-mode
   - **`[m]`** Mixed-mode pin `model: "sonnet[1m]"` — suggested for `simple` tier; coder runs on Sonnet, cross-model reviewer always stays at flagship (Opus 4.7 / gpt-5.5 xhigh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.38.0] - 2026-04-24
+
+### Added
+
+- **Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer)** — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic classifies repos as `simple` or `complex` from filesystem signals (LOC, test count, hook count, workflow count, plus stakes flag for `.env` / `secrets/` / `credentials/`). Setup skill Step 9.5 expanded from binary y/N into a 3-way prompt:
+  - **`[N]`** No pin (default, recommended for most repos) — preserves Claude Code auto-mode
+  - **`[m]`** Mixed-mode pin `model: "sonnet[1m]"` — suggested for `simple` tier; coder runs on Sonnet, cross-model reviewer always stays at flagship (Opus 4.7 / gpt-5.5 xhigh)
+  - **`[f]`** Flagship pin `model: "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — suggested for `complex` / stakes-flagged tier; current pre-#233 default
+  Stakes flag (`.env` / `secrets/` / `credentials/`) forces `complex` regardless of size and detects at any depth (e.g. `config/.env`, `app/secrets/`); the coder is doing security-relevant work and the saving isn't worth the risk. Heuristic outputs are advisory — the user always picks the final tier. New `tests/test-repo-complexity.sh` (11 tests) with six fixture repos (`tests/fixtures/complexity/{simple,complex,stakes,nested-stakes,boundary-simple,boundary-complex}-repo`) covers tier classification, nested stakes detection, threshold-boundary cases (29 tests = simple, 30 = complex), JSON shape, missing-dir error path, and the `npx agentic-sdlc-wizard complexity` CLI subcommand. Cross-model review section in `skills/sdlc/SKILL.md` explicitly notes the reviewer **always** runs at flagship regardless of coder pin — weakening the review leg defeats the savings. Update skill Step 7.5 recognizes `sonnet[1m]` as a valid mixed-mode pin (no migration prompt). Wizard doc gets a new "Mixed-Mode Tier" subsection documenting the split, when to use each tier, the prove-it gate (pair-test on 3+ simple repos before recommending mixed-mode as default), and tradeoffs. **Reconciles with #198:** mixed-mode is opt-in per-project via Step 9.5; no-pin remains the default.
+
 ## [1.37.1] - 2026-04-24
 
 ### Fixed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -940,6 +940,47 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 
 **Autocompact pairing (important):** If you opt into `opus[1m]`, also set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — otherwise CC's default autocompact fires at ~76K and destroys the headroom you're paying for. Step 9.5 writes both together when you opt in.
 
+### Mixed-Mode Tier (Sonnet coder + Opus reviewer, roadmap #233)
+
+For trivial / blank / config-only / CRUD-style repos, full Opus 4.7 on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
+
+**The split:**
+
+| Layer | Mixed-mode tier | Flagship tier |
+|-------|----------------|---------------|
+| Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
+| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) |
+| Effort floor (CC session) | xhigh; max preferred | xhigh; max preferred |
+
+The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
+
+**When mixed-mode is the right call:**
+- Repo is small (LOC < 10K), few tests (< 30), few hooks (< 5), few workflows (< 5), no `.env` / secrets handling
+- You're on API billing (not Max subscription) and 2× cost on simple repos actually matters
+- Tasks are predominantly mechanical — typo fixes, config tweaks, small CRUD endpoints
+- You're running the SDLC Wizard's setup flow against a sibling repo where the coder doesn't need flagship reasoning
+
+**When to stay flagship:**
+- Stakes-flagged repo: anywhere `.env` / `secrets/` / `credentials/` exists. Force flagship even if LOC is tiny — leaks are catastrophic
+- Architecture work, debugging non-obvious bugs, security review, anything where the *coder's* judgment matters as much as the reviewer's
+- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.7 fits the window better in a single thread
+
+**Auto-detection:** the setup wizard runs `cli/lib/repo-complexity.js` against the target repo and suggests the tier. Stakes flag (`.env` / `secrets/`) forces complex regardless of size. The user always picks the final answer — the heuristic is a hint, not a gate.
+
+**How to opt in (manual):**
+```json
+{
+  "model": "sonnet[1m]"
+}
+```
+Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different compaction characteristics than Opus's; let upstream defaults ride until we benchmark.
+
+**Prove-It Gate (#233 acceptance criterion):** mixed-mode ships only if pair-tested on 3+ simple repos shows Sonnet-coder + Opus-reviewer produces ≥ same SDLC scores as full-Opus baseline. The first version of the heuristic ships v1.38.0; pair-test results land in CHANGELOG before recommending mixed-mode as the default for any tier.
+
+**Tradeoffs (be honest):**
+- Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
+- Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
+
 ---
 
 ## Example Workflow (End-to-End)
@@ -2715,7 +2756,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3777,7 +3818,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -981,6 +981,36 @@ Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different
 - Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
 - Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
 
+### Verifying Prompt-Hook-Fires-Once (roadmap #224)
+
+CC 2.1.118 shipped a fix for `prompt` hooks double-firing when an agent-hook verifier subagent itself made tool calls. The bug would manifest as duplicate `SDLC BASELINE` injections per `UserPromptSubmit` — context bloat plus possible confusion. The dual-channel (project + plugin) double-print is already handled by `dedupe_plugin_or_project` in v1.37.1; this section is the runtime check for the *CC-internal* double-fire case.
+
+`hooks/sdlc-prompt-check.sh` ships an opt-in instrumentation: when the env var `SDLC_HOOK_FIRE_LOG` is set, every post-dedupe invocation appends one tab-separated record (`<unix-ts>\t<pid>\tsdlc-prompt-check`) to that log. Counting lines per prompt tells you whether CC fired the hook once or twice.
+
+**Maintainer procedure (real session):**
+
+```bash
+# 1. Pick a fresh log path
+export SDLC_HOOK_FIRE_LOG="$(mktemp /tmp/sdlc-fire-log.XXXXXX)"
+
+# 2. Restart Claude Code so the env propagates into spawned hooks
+#    (or set it in your shell rc / .envrc and start a fresh session)
+
+# 3. Run a normal SDLC session — including any task that triggers a verifier
+#    subagent (e.g., /code-review, /sdlc with multi-step planning)
+
+# 4. After N user prompts, count log lines:
+wc -l "$SDLC_HOOK_FIRE_LOG"
+#    Expect: N lines. >N indicates the CC double-fire bug regressed.
+
+# 5. Optional: tail the log live in another terminal to watch each fire:
+tail -f "$SDLC_HOOK_FIRE_LOG"
+```
+
+The instrumentation is opt-in — when the env var is unset, no log is written and no overhead is added. Unwritable log paths fail silently so a bad `SDLC_HOOK_FIRE_LOG` value never crashes the hook.
+
+**Regression test:** `tests/test-prompt-hook-fires-once.sh` covers the instrumentation contract (counter increments per invocation, opt-in semantics, log line shape, output stability, unwritable-path tolerance). It does *not* spawn Claude Code — that's a maintainer-runtime check by design. The test asserts the recording mechanism works so the maintainer's real-session count is trustworthy.
+
 ---
 
 ## Example Workflow (End-to-End)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-community-paths.sh && \
    ./tests/test-persist-score-history.sh && \
    ./tests/test-local-shepherd.sh && \
+   ./tests/test-repo-complexity.sh && \
+   ./tests/test-prompt-hook-fires-once.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.37.1 |
+| Wizard Version | 1.38.0 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/cli/bin/sdlc-wizard.js
+++ b/cli/bin/sdlc-wizard.js
@@ -3,6 +3,7 @@
 
 const { version } = require('../../package.json');
 const { init, check } = require('../init');
+const { detectComplexity } = require('../lib/repo-complexity');
 
 const args = process.argv.slice(2);
 
@@ -12,7 +13,8 @@ const flags = {
   json: args.includes('--json'),
 };
 
-const command = args.find((a) => !a.startsWith('--'));
+const positional = args.filter((a) => !a.startsWith('--'));
+const command = positional[0];
 
 if (args.includes('--version') || args.includes('-v')) {
   console.log(version);
@@ -24,13 +26,14 @@ if (args.includes('--help') || args.includes('-h') || !command) {
   agentic-sdlc-wizard v${version}
 
   Usage:
-    sdlc-wizard init [options]    Install SDLC wizard into current directory
-    sdlc-wizard check [options]   Check installation health and updates
+    sdlc-wizard init [options]               Install SDLC wizard into current directory
+    sdlc-wizard check [options]              Check installation health and updates
+    sdlc-wizard complexity [path]            Print mixed-mode tier heuristic (roadmap #233)
 
   Options:
     --force       Overwrite existing files (init only)
     --dry-run     Preview changes without writing (init only)
-    --json        Output as JSON (check only)
+    --json        Output as JSON (check / complexity)
     --version     Show version
     --help        Show this help
   `.trim());
@@ -54,6 +57,16 @@ if (command === 'init') {
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);
+  }
+} else if (command === 'complexity') {
+  try {
+    const target = positional[1] || process.cwd();
+    const result = detectComplexity(target);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(2);
   }
 } else {
   console.error(`Unknown command: ${command}`);

--- a/cli/lib/repo-complexity.js
+++ b/cli/lib/repo-complexity.js
@@ -1,0 +1,167 @@
+// Roadmap #233: repo complexity heuristic for mixed-mode tier selection.
+//
+// Output: { tier: 'simple' | 'complex', score: <number>, signals: [...] }
+//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.7 reviewer)
+//   - 'complex' → setup wizard suggests full flagship (Opus 4.7 everywhere)
+// Cross-model review (Codex / external) always stays at the flagship tier
+// regardless of coder selection — see CLAUDE_CODE_SDLC_WIZARD.md.
+//
+// Classification (matches CLAUDE_CODE_SDLC_WIZARD.md → "Mixed-Mode Tier"):
+//   simple = LOC < 10K AND tests < 30 AND hooks < 5 AND workflows < 5 AND no stakes
+//   complex = ANY high signal OR stakes flag (.env / secrets/ / credentials/ at any depth)
+// `score` is an additive ladder kept for transparency (low=0, mid=1, high=2 per signal).
+//
+// Heuristic is intentionally cheap: a single sync filesystem walk, no parsing.
+// It is a setup-time hint, not a runtime gate; users can override the result.
+
+const fs = require('fs');
+const path = require('path');
+
+const STAKES_FILES = new Set(['.env', '.env.local', '.env.production', '.env.development', '.envrc']);
+const STAKES_DIRS = new Set(['secrets', 'credentials', '.secrets', '.credentials']);
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', 'target',
+  '.next', '.nuxt', 'coverage', '.cache', 'vendor', '__pycache__',
+]);
+const SOURCE_EXTS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
+  '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift',
+  '.c', '.h', '.cpp', '.hpp', '.cc',
+  '.sh', '.bash', '.zsh',
+]);
+const TEST_PATTERNS = [/\.test\.[jt]sx?$/, /\.spec\.[jt]sx?$/, /_test\.go$/, /test_.*\.py$/, /.*_test\.py$/];
+
+function isTestFile(name, parentDir) {
+  if (TEST_PATTERNS.some((p) => p.test(name))) return true;
+  return parentDir === 'tests' || parentDir === 'test' || parentDir === '__tests__' || parentDir === 'spec';
+}
+
+function walk(rootDir, repoRoot, onFile, onDir, visited) {
+  let entries;
+  try {
+    entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  } catch (_) {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(rootDir, entry.name);
+    if (entry.isSymbolicLink()) continue; // don't follow symlinks (cycle / out-of-tree risk)
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      // Resolve real path for cycle detection.
+      let realPath;
+      try {
+        realPath = fs.realpathSync(full);
+      } catch (_) {
+        continue;
+      }
+      if (visited.has(realPath)) continue;
+      visited.add(realPath);
+      onDir && onDir(full, entry.name);
+      walk(full, repoRoot, onFile, onDir, visited);
+    } else if (entry.isFile()) {
+      onFile(full, entry.name, path.basename(rootDir));
+    }
+  }
+}
+
+function countLines(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (!content) return 0;
+    return content.split('\n').length;
+  } catch (_) {
+    return 0;
+  }
+}
+
+function detectComplexity(repoPath) {
+  if (!fs.existsSync(repoPath)) {
+    throw new Error(`Repo path does not exist: ${repoPath}`);
+  }
+  const stat = fs.statSync(repoPath);
+  if (!stat.isDirectory()) {
+    throw new Error(`Repo path is not a directory: ${repoPath}`);
+  }
+  const repoRoot = path.resolve(repoPath);
+
+  let loc = 0;
+  let testFiles = 0;
+  let hookFiles = 0;
+  let workflowFiles = 0;
+  const stakesHits = [];
+  const visited = new Set([fs.realpathSync(repoRoot)]);
+
+  walk(
+    repoRoot,
+    repoRoot,
+    (filePath, name, parent) => {
+      const ext = path.extname(name).toLowerCase();
+      const rel = path.relative(repoRoot, filePath);
+      if (STAKES_FILES.has(name)) {
+        stakesHits.push(`stakes:file:${rel}`);
+      }
+      if (SOURCE_EXTS.has(ext) || ext === '.yml' || ext === '.yaml') {
+        if (isTestFile(name, parent)) testFiles++;
+        else if (SOURCE_EXTS.has(ext)) loc += countLines(filePath);
+      }
+      if (parent === 'hooks' && filePath.includes(`.claude${path.sep}hooks`) && (ext === '.sh' || ext === '.bash')) {
+        hookFiles++;
+      }
+      if (parent === 'workflows' && filePath.includes(`.github${path.sep}workflows`) && (ext === '.yml' || ext === '.yaml')) {
+        workflowFiles++;
+      }
+    },
+    (dirPath, name) => {
+      if (STAKES_DIRS.has(name)) {
+        const rel = path.relative(repoRoot, dirPath);
+        stakesHits.push(`stakes:dir:${rel || name}/`);
+      }
+    },
+    visited
+  );
+
+  // Bands match docs: LOC<10K / tests<30 / hooks<5 / workflows<5 = "simple band"
+  const signals = [];
+  let highHits = 0;
+  let score = 0;
+
+  function band(value, midThreshold, highThreshold, label) {
+    if (value >= highThreshold) {
+      score += 2;
+      highHits++;
+      signals.push(`${label}:${value} (high → +2)`);
+    } else if (value >= midThreshold) {
+      score += 1;
+      signals.push(`${label}:${value} (mid → +1)`);
+    } else {
+      signals.push(`${label}:${value} (low → +0)`);
+    }
+  }
+
+  band(loc, 1000, 10000, 'loc');
+  band(testFiles, 5, 30, 'tests');
+  band(hookFiles, 3, 5, 'hooks');
+  band(workflowFiles, 2, 5, 'workflows');
+
+  let tier = highHits > 0 ? 'complex' : 'simple';
+  if (stakesHits.length > 0) {
+    tier = 'complex';
+    signals.push(...stakesHits, 'override:stakes-forces-complex');
+  }
+
+  return { tier, score, signals };
+}
+
+module.exports = { detectComplexity };
+
+if (require.main === module) {
+  const target = process.argv[2] || '.';
+  try {
+    const result = detectComplexity(target);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+}

--- a/hooks/sdlc-prompt-check.sh
+++ b/hooks/sdlc-prompt-check.sh
@@ -12,6 +12,18 @@ source "$HOOK_DIR/_find-sdlc-root.sh"
 # plugin paths even when the script is sourced or invoked via aliases.
 dedupe_plugin_or_project "${BASH_SOURCE[0]}" || exit 0
 
+# Roadmap #224: opt-in fires-once instrumentation. CC 2.1.118 shipped a fix for
+# prompt hooks double-firing when a verifier subagent itself made tool calls.
+# When SDLC_HOOK_FIRE_LOG is set, append one tab-separated record per real
+# invocation (post-dedupe). Maintainer can compare line count against prompt
+# count to verify the CC fix in real sessions. See CLAUDE_CODE_SDLC_WIZARD.md →
+# "Verifying Prompt-Hook-Fires-Once" for the procedure.
+if [ -n "${SDLC_HOOK_FIRE_LOG:-}" ]; then
+    {
+        printf '%s\t%s\tsdlc-prompt-check\n' "$(date +%s)" "$$" >> "$SDLC_HOOK_FIRE_LOG"
+    } 2>/dev/null || true
+fi
+
 # CWD walk-up finds nearest SDLC project (#173: silent exit for non-SDLC dirs)
 if find_sdlc_root; then
     PROJECT_DIR="$SDLC_ROOT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -230,6 +230,8 @@ PLANNING -> DOCS -> TDD RED -> TDD GREEN -> Tests Pass -> Self-Review
 
 **The core insight:** The review PROTOCOL is universal across domains. Only the review INSTRUCTIONS change. Code review is the default template below. For non-code domains (research, persuasion, medical content), adapt the `review_instructions` and `verification_checklist` fields while keeping the same handoff/dialogue/convergence loop.
 
+**Reviewer always at the flagship tier (roadmap #233):** if the project pins `model: "sonnet[1m]"` (mixed-mode) or any non-flagship coder, the cross-model reviewer **still runs at the flagship**: `codex exec -c 'model_reasoning_effort="xhigh"'` (gpt-5.5) or an Opus 4.7 max equivalent. The whole point of mixed-mode is that adversarial review catches Sonnet's blind spots — weakening the reviewer leg defeats the savings. Don't downscale the review just because the coder is downscaled.
+
 ### Step 0: Write Preflight Self-Review Doc
 
 Before submitting to an external reviewer, document what YOU already checked. This is proven to reduce reviewer findings to 0-1 per round (evidence: anticheat repo preflight discipline).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -198,24 +198,45 @@ Write the shape as:
 
 Present suggestions and let the user confirm.
 
-### Step 9.5: Context Window Configuration (Opt-In)
+### Step 9.5: Context Window + Mixed-Mode Configuration (Opt-In)
 
-The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by default. This preserves Claude Code's built-in model auto-selection (Sonnet for cheap tasks, Opus for hard ones) and the upstream autocompact threshold. Power users who want guaranteed 1M context can opt in during setup.
+The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by default. This preserves Claude Code's built-in model auto-selection (Sonnet for cheap tasks, Opus for hard ones) and the upstream autocompact threshold. Power users can opt into a pin during setup; mixed-mode users (Sonnet coder + Opus reviewer) can pin Sonnet here too.
 
-**Why this is opt-in (issue #198):** A top-level `"model"` in `settings.json` tells Claude Code "the user has explicitly chosen a model" and disables auto-mode for the session. That is a real tradeoff — the pin is only worth it when you actually need the 1M headroom and want to lock to Opus 4.7.
+**Why this is opt-in (issue #198):** A top-level `"model"` in `settings.json` tells Claude Code "the user has explicitly chosen a model" and disables auto-mode for the session. That is a real tradeoff — pinning is only worth it when you actually need the 1M headroom or you've decided mixed-mode tier-splitting is better than per-turn auto-selection.
+
+**Run the complexity heuristic first (roadmap #233):**
+
+```bash
+npx agentic-sdlc-wizard complexity .
+```
+
+The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the result to suggest a default in the prompt below — do NOT override the user's choice. The heuristic flags any `.env` / `secrets/` / `credentials/` at any depth as a stakes signal that forces `complex` regardless of size.
 
 **Ask the user exactly once in Step 9.5:**
 
-> Pin the session to `opus[1m]` (Opus 4.7 with 1M context) and set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`?
+> Detected repo complexity: **{tier}** ({score}, signals: {loc, tests, hooks, workflows, stakes-flag if any}).
 >
-> - **No (default):** Leaves auto-mode enabled. Claude Code picks the model per turn, compaction follows upstream defaults. Recommended for most users.
-> - **Yes:** Long SDLC sessions (plan → TDD → review → CI shepherd on one feature) regularly cross 100K tokens; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.111+ and comfort with losing model auto-selection.
+> How do you want to configure the model for this repo?
 >
-> `[y/N]`
+> - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
+> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.7 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
+> - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.7 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.111+.
+>
+> `[N/m/f]`
 
-**If the user answers No (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
+**If the user answers `N` (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
 
-**If the user answers Yes:** Edit `.claude/settings.json` and add both fields at the top level:
+**If the user answers `m` (mixed-mode):** Edit `.claude/settings.json` and add:
+
+```json
+{
+  "model": "sonnet[1m]"
+}
+```
+
+Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window has different compaction characteristics than Opus; let the upstream default ride. Tell the user explicitly: "Cross-model reviews still run at the flagship — `codex exec -c 'model_reasoning_effort=\"xhigh\"'` (gpt-5.5) or any future Opus-tier reviewer. Mixed-mode is coder-only."
+
+**If the user answers `f` (flagship):** Edit `.claude/settings.json` and add both fields at the top level:
 
 ```json
 {
@@ -226,9 +247,10 @@ The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by 
 }
 ```
 
-Mention the escape hatch either way:
+Mention the escape hatch in all three cases:
 - To opt out later: remove the `model` line (and optionally the `env` block) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
-- For CI pipelines with short tasks, consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.
+- To switch tiers later: edit `.claude/settings.json` and replace the `model` value, or re-run `/setup-wizard` Step 9.5.
+- For CI pipelines with short tasks (flagship only), consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.
 
 This is project-scoped and shared with the team via git.
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -46,9 +46,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.37.1
+Latest:    1.38.0
 
 What changed:
+- [1.38.0] Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer) for simple repos — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI command. Setup Step 9.5 expanded from binary y/N to 3-way (no-pin / mixed / flagship). Cross-model review always stays at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default.
 - [1.37.1] Token-bloat fix: dedupe 2× SDLC BASELINE print when both project + plugin register the same hook (~300 tokens doubled per prompt). 5 hooks gain `dedupe_plugin_or_project()` helper. Codex 2-round 100/100.
 - [1.37.0] `monthly-research.yml` workflow deleted (ROADMAP #231 Phase 1) — 0 merged artifacts in 30d while burning $11-23/month; research happens inline now. `model-effort-check.sh` loud WARNING below xhigh (#217) — max preferred, xhigh floor; duplicate effort nudge in `instructions-loaded-check.sh` removed; single source of truth. Both changes Codex-certified.
 - [1.36.1] Repo renamed `agentic-ai-sdlc-wizard` → `claude-sdlc-wizard` (matches sibling pattern; npm package unchanged); `npm pkg fix` metadata cleanup; slug migration across docs/tests/configs
@@ -133,9 +134,11 @@ If the user is upgrading from a pre-#198 version, check their `.claude/settings.
 
 2. **If only one of the two fields matches** (e.g. `model: "opus[1m]"` but custom autocompact, or vice versa) — treat as intentional customization. Do not prompt.
 
-3. **If `model` is some other value** (e.g. `"sonnet"`, `"opus"`) — treat as user's explicit choice. Do not touch.
+3. **If `model` is `"sonnet[1m]"` (mixed-mode tier, roadmap #233, v1.38.0+)** — treat as user's explicit mixed-mode choice. Do not prompt; this is the supported mixed-mode pin. Mention in the upgrade summary: "Detected mixed-mode tier (Sonnet coder + flagship reviewer). Cross-model review still uses Opus / gpt-5.5 — see CLAUDE_CODE_SDLC_WIZARD.md → 'Mixed-Mode Tier'."
 
-4. **If neither field is set** — user is already on the new default. No action.
+4. **If `model` is some other value** (e.g. `"sonnet"`, `"opus"`) — treat as user's explicit choice. Do not touch.
+
+5. **If neither field is set** — user is already on the new default. No action.
 
 When removing: edit the file in place, drop the `model` key (and the `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` key if nothing else is in `env`, otherwise leave `env` alone). Never touch other keys the user added.
 

--- a/tests/test-prompt-hook-fires-once.sh
+++ b/tests/test-prompt-hook-fires-once.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Roadmap #224: regression test for sdlc-prompt-check.sh "fires exactly once"
+# instrumentation. CC 2.1.118 shipped a fix for prompt hooks double-firing when
+# an agent-hook verifier subagent itself made tool calls. We can't directly
+# unit-test CC's behavior, but we can ship instrumentation that records each
+# hook invocation so the maintainer can verify the fix holds in real sessions.
+#
+# Mechanism: when the env var SDLC_HOOK_FIRE_LOG is set, sdlc-prompt-check.sh
+# appends a single line per invocation: "<unix-ts>\t<pid>\t<source-marker>".
+# Maintainer procedure documented in CLAUDE_CODE_SDLC_WIZARD.md.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/sdlc-prompt-check.sh"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Prompt-Hook-Fires-Once Instrumentation Tests (Roadmap #224) ==="
+echo ""
+
+# Set up an isolated workspace with a complete SDLC project so the hook reaches
+# its main code path (instead of bailing on missing SDLC.md / TESTING.md).
+WORKSPACE="${TMPDIR:-/tmp}/sdlc-fire-test-$$"
+mkdir -p "$WORKSPACE"
+trap 'rm -rf "$WORKSPACE"' EXIT
+echo "# SDLC" > "$WORKSPACE/SDLC.md"
+echo "# Testing" > "$WORKSPACE/TESTING.md"
+LOG="$WORKSPACE/fire.log"
+
+invoke_hook() {
+    # cd into WORKSPACE so _find-sdlc-root.sh's `pwd` walk-up finds *this*
+    # workspace's SDLC.md, not whatever cwd the test is launched from.
+    # Without the cd the test silently exercises the repo root and gives
+    # a false-green when run from a parent dir.
+    (cd "$WORKSPACE" && SDLC_HOOK_FIRE_LOG="$LOG" CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}')
+}
+
+invoke_hook_uninstrumented() {
+    (cd "$WORKSPACE" && CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}')
+}
+
+test_counter_records_first_invocation() {
+    : > "$LOG"
+    invoke_hook > /dev/null
+    local lines
+    lines=$(wc -l < "$LOG" | tr -d ' ')
+    if [ "$lines" = "1" ]; then
+        pass "first invocation records exactly 1 line in log"
+    else
+        fail "first invocation recorded $lines lines (expected 1). Log:"
+        cat "$LOG" | sed 's/^/  /'
+    fi
+}
+
+test_counter_appends_per_invocation() {
+    : > "$LOG"
+    for i in 1 2 3 4 5; do
+        invoke_hook > /dev/null
+    done
+    local lines
+    lines=$(wc -l < "$LOG" | tr -d ' ')
+    if [ "$lines" = "5" ]; then
+        pass "5 invocations record exactly 5 lines (counter increments correctly)"
+    else
+        fail "5 invocations recorded $lines lines (expected 5). Log:"
+        cat "$LOG" | sed 's/^/  /'
+    fi
+}
+
+test_counter_is_opt_in() {
+    rm -f "$LOG"
+    CLAUDE_PROJECT_DIR="$WORKSPACE" bash "$HOOK" <<<'{"prompt":"hello"}' > /dev/null
+    if [ ! -f "$LOG" ]; then
+        pass "no SDLC_HOOK_FIRE_LOG env → no log file created (instrumentation is opt-in)"
+    else
+        fail "log file was created without env var being set: $LOG"
+    fi
+}
+
+test_log_line_shape() {
+    : > "$LOG"
+    invoke_hook > /dev/null
+    local line ts pid marker
+    line=$(head -1 "$LOG")
+    ts=$(printf '%s' "$line" | awk -F'\t' '{print $1}')
+    pid=$(printf '%s' "$line" | awk -F'\t' '{print $2}')
+    marker=$(printf '%s' "$line" | awk -F'\t' '{print $3}')
+    if [[ "$ts" =~ ^[0-9]+$ ]] && [[ "$pid" =~ ^[0-9]+$ ]] && [ -n "$marker" ]; then
+        pass "log line is tab-separated: ts=$ts pid=$pid marker=$marker"
+    else
+        fail "log line shape unexpected. Line: $line"
+    fi
+}
+
+test_instrumentation_doesnt_break_output() {
+    # Codex round 3 P1: weak assertion just checked "SDLC BASELINE: exists".
+    # Strengthen: instrumented stdout/stderr must be byte-identical to the
+    # non-instrumented run. Any leak (instrumentation marker on stdout, extra
+    # stderr noise) would fail the diff.
+    : > "$LOG"
+    local with without
+    with=$(invoke_hook 2>&1)
+    without=$(invoke_hook_uninstrumented 2>&1)
+    if [ "$with" = "$without" ]; then
+        pass "instrumented output is byte-identical to non-instrumented output"
+    else
+        fail "instrumentation altered hook output. Diff:"
+        diff <(printf '%s' "$without") <(printf '%s' "$with") | sed 's/^/  /'
+    fi
+}
+
+test_unwritable_log_does_not_crash() {
+    local bad_log="/this/path/does/not/exist/fire.log"
+    if SDLC_HOOK_FIRE_LOG="$bad_log" CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}' > /dev/null 2>&1; then
+        pass "hook tolerates unwritable SDLC_HOOK_FIRE_LOG path (does not crash)"
+    else
+        fail "hook crashed when SDLC_HOOK_FIRE_LOG was unwritable"
+    fi
+}
+
+test_counter_records_first_invocation
+test_counter_appends_per_invocation
+test_counter_is_opt_in
+test_log_line_shape
+test_instrumentation_doesnt_break_output
+test_unwritable_log_does_not_crash
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All instrumentation tests passed."

--- a/tests/test-repo-complexity.sh
+++ b/tests/test-repo-complexity.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Test cli/lib/repo-complexity.js heuristic
+# Heuristic decides whether a repo is "simple" (good fit for mixed-mode:
+# Sonnet coder + Opus reviewer) or "complex" (full Opus tier recommended).
+#
+# Roadmap #233: introduces repo_complexity signal so setup wizard can suggest
+# mixed-mode for trivial/CRUD repos and reserve flagship Opus 4.7 for
+# fixture-deep, multi-workflow, secrets-touching repos.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../cli/lib/repo-complexity.js"
+FIXTURES="$SCRIPT_DIR/fixtures/complexity"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Repo Complexity Heuristic Tests (Roadmap #233) ==="
+echo ""
+
+# ---- Setup fixtures ----
+
+setup_simple_repo() {
+    local dir="$FIXTURES/simple-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src"
+    cat > "$dir/src/main.js" <<'EOF'
+function add(a, b) { return a + b; }
+module.exports = { add };
+EOF
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "tiny", "version": "0.1.0" }
+EOF
+}
+
+setup_complex_repo() {
+    local dir="$FIXTURES/complex-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests" "$dir/.claude/hooks" "$dir/.claude/skills" "$dir/.github/workflows"
+    # Many test files
+    for i in $(seq 1 35); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    # Many hooks
+    for h in pre-commit pre-push prepare-commit lint-check format-check tdd-check; do
+        echo "#!/bin/bash" > "$dir/.claude/hooks/$h.sh"
+        chmod +x "$dir/.claude/hooks/$h.sh"
+    done
+    # Many workflows
+    for wf in ci pr-review release deploy weekly-update monthly-research; do
+        echo "name: $wf" > "$dir/.github/workflows/$wf.yml"
+    done
+    # Decent LOC
+    for i in $(seq 1 50); do
+        for j in $(seq 1 20); do
+            echo "function fn_${i}_${j}(x) { return x * $j; }"
+        done
+    done > "$dir/src/main.js"
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "complex-repo", "version": "0.1.0" }
+EOF
+}
+
+setup_stakes_repo() {
+    local dir="$FIXTURES/stakes-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src"
+    echo "function noop() {}" > "$dir/src/main.js"
+    # .env file forces complex regardless of size
+    cat > "$dir/.env" <<'EOF'
+API_KEY=fake
+DATABASE_URL=postgres://fake
+EOF
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "stakes-tiny", "version": "0.1.0" }
+EOF
+}
+
+# Codex finding #2: stakes detection must work at any depth.
+setup_nested_stakes_repo() {
+    local dir="$FIXTURES/nested-stakes-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/config" "$dir/app/secrets"
+    echo "function noop() {}" > "$dir/src/main.js"
+    cat > "$dir/config/.env" <<'EOF'
+API_KEY=fake-nested
+EOF
+    cat > "$dir/app/secrets/token.txt" <<'EOF'
+fake-token
+EOF
+}
+
+# Codex finding #3: just-below-threshold repo must classify as simple.
+# Per docs: simple = LOC<10K AND tests<30 AND hooks<5 AND workflows<5 AND no stakes.
+# Hits 4 mid signals; total score=4 but no high signals → simple.
+setup_boundary_simple_repo() {
+    local dir="$FIXTURES/boundary-simple-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests" "$dir/.claude/hooks" "$dir/.github/workflows"
+    # 29 tests (just below high threshold of 30)
+    for i in $(seq 1 29); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    # 4 hooks (just below high threshold of 5)
+    for h in pre-commit pre-push lint format; do
+        echo "#!/bin/bash" > "$dir/.claude/hooks/$h.sh"
+    done
+    # 4 workflows (just below high threshold of 5)
+    for wf in ci pr-review release deploy; do
+        echo "name: $wf" > "$dir/.github/workflows/$wf.yml"
+    done
+    # ~9000 LOC (just below high threshold of 10000)
+    for i in $(seq 1 450); do echo "// line filler $i: const x = $i;"; done > "$dir/src/main.js"
+}
+
+# Boundary complex: bump just one signal over its threshold → must classify as complex.
+setup_boundary_complex_repo() {
+    local dir="$FIXTURES/boundary-complex-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests"
+    # 30 tests = high → complex
+    for i in $(seq 1 30); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    echo "function tiny() {}" > "$dir/src/main.js"
+}
+
+setup_simple_repo
+setup_complex_repo
+setup_stakes_repo
+setup_nested_stakes_repo
+setup_boundary_simple_repo
+setup_boundary_complex_repo
+
+# ---- Tests ----
+
+test_lib_exists() {
+    if [ -f "$LIB" ]; then
+        pass "cli/lib/repo-complexity.js exists"
+    else
+        fail "cli/lib/repo-complexity.js not found"
+    fi
+}
+
+test_simple_repo_classified_simple() {
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "simple repo classified as 'simple' (got: $tier)"
+    else
+        fail "simple repo classified as '$tier' (expected 'simple'). Output: $out"
+    fi
+}
+
+test_complex_repo_classified_complex() {
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/complex-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ]; then
+        pass "complex repo classified as 'complex' (got: $tier)"
+    else
+        fail "complex repo classified as '$tier' (expected 'complex'). Output: $out"
+    fi
+}
+
+test_stakes_repo_forces_complex() {
+    local out tier reasons
+    out=$(node "$LIB" "$FIXTURES/stakes-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ] && echo "$out" | /usr/bin/grep -qiE 'env|stake|secret'; then
+        pass "stakes repo (with .env) forced to 'complex' with reason"
+    else
+        fail "stakes repo got '$tier' without env/stakes reason. Output: $out"
+    fi
+}
+
+test_outputs_valid_json() {
+    local out
+    out=$(node "$LIB" "$FIXTURES/simple-repo" 2>&1)
+    if echo "$out" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+        pass "outputs valid JSON"
+    else
+        fail "output is not valid JSON: $out"
+    fi
+}
+
+test_includes_signals() {
+    local out
+    out=$(node "$LIB" "$FIXTURES/complex-repo" 2>&1)
+    if echo "$out" | python3 -c "import sys, json; d=json.load(sys.stdin); assert 'signals' in d and isinstance(d['signals'], list); assert len(d['signals']) > 0; print('ok')" 2>/dev/null | /usr/bin/grep -q ok; then
+        pass "output includes non-empty signals array"
+    else
+        fail "output missing signals or empty. Output: $out"
+    fi
+}
+
+test_handles_missing_dir_gracefully() {
+    local out exit_code
+    out=$(node "$LIB" "/nonexistent-path-12345" 2>&1) || exit_code=$?
+    if [ "${exit_code:-0}" -ne 0 ] || echo "$out" | /usr/bin/grep -qi error; then
+        pass "missing dir is reported as error (exit $exit_code or 'error' in output)"
+    else
+        fail "missing dir did not produce error. Output: $out, exit: ${exit_code:-0}"
+    fi
+}
+
+test_nested_env_forces_complex() {
+    local out tier signals
+    out=$(node "$LIB" "$FIXTURES/nested-stakes-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ] && echo "$out" | /usr/bin/grep -q "config/.env" && echo "$out" | /usr/bin/grep -qE "stakes:dir:.*secrets"; then
+        pass "nested .env (config/.env) and nested secrets/ dir detected and force complex"
+    else
+        fail "nested stakes not detected. tier=$tier. Output: $out"
+    fi
+}
+
+test_boundary_simple_classified_simple() {
+    # Per docs: LOC<10K, tests<30, hooks<5, workflows<5, no stakes → simple
+    # Even if all four signals are mid-band (additive score=4), no high → simple.
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/boundary-simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "boundary-simple repo (29 tests, 4 hooks, 4 workflows, ~9K LOC) → simple"
+    else
+        fail "boundary-simple repo classified as '$tier' (expected 'simple'). Output: $out"
+    fi
+}
+
+test_boundary_complex_classified_complex() {
+    # 30 tests crosses the high threshold → must classify as complex.
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/boundary-complex-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ]; then
+        pass "boundary-complex repo (30 tests = high threshold) → complex"
+    else
+        fail "boundary-complex repo classified as '$tier' (expected 'complex'). Output: $out"
+    fi
+}
+
+test_cli_complexity_subcommand() {
+    # Codex finding #1: docs reference `npx agentic-sdlc-wizard complexity .` — must work via the CLI bin
+    local cli="$SCRIPT_DIR/../cli/bin/sdlc-wizard.js"
+    local out tier
+    out=$(node "$cli" complexity "$FIXTURES/simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "CLI subcommand 'complexity' works and returns valid output"
+    else
+        fail "CLI subcommand 'complexity' did not return tier=simple. Output: $out"
+    fi
+}
+
+test_lib_exists
+test_simple_repo_classified_simple
+test_complex_repo_classified_complex
+test_stakes_repo_forces_complex
+test_nested_env_forces_complex
+test_boundary_simple_classified_simple
+test_boundary_complex_classified_complex
+test_cli_complexity_subcommand
+test_outputs_valid_json
+test_includes_signals
+test_handles_missing_dir_gracefully
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

- **#233 Mixed-mode tier** — Sonnet 4.6 coder + Opus 4.7 reviewer split for simple repos. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI subcommand. Setup Step 9.5 expanded from binary y/N → 3-way (no-pin / mixed / flagship). Reviewer always at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default.
- **#224 Prompt-hook-fires-once instrumentation** — `hooks/sdlc-prompt-check.sh` records one tab-separated record per post-dedupe invocation when `SDLC_HOOK_FIRE_LOG` is set. Maintainer counts lines per prompt to verify CC 2.1.118's double-fire fix.
- **fix(ci)** — wires test-repo-complexity.sh + test-prompt-hook-fires-once.sh into `validate` (test-workflow-triggers was failing 164/1 without it).

## Tests

- 11/11 `tests/test-repo-complexity.sh` (NEW: tier classification, nested stakes, threshold boundary, CLI subcommand, error path)
- 6/6 `tests/test-prompt-hook-fires-once.sh` (NEW: counter increment, opt-in, log shape, byte-identical output diff, unwritable tolerance)
- 128/128 `tests/test-hooks.sh`
- 22/22 `tests/test-doc-consistency.sh`
- 165/165 `tests/test-workflow-triggers.sh`

## Cross-model review

- #233: Codex 2-round, round 1 5/10 (4 P1 findings), round 2 9/10 CERTIFIED
- #224: Codex 2-round, round 3 8/10 (test harness false-green), round 4 10/10 CERTIFIED

## Test plan

- [ ] CI `validate` job passes
- [ ] PR review job passes (advisory)
- [ ] Manual: run `npx agentic-sdlc-wizard complexity .` against this repo → expect `tier:complex`
- [ ] Manual: set `SDLC_HOOK_FIRE_LOG=/tmp/sdlc.log` in a fresh CC session, run a few prompts, verify `wc -l /tmp/sdlc.log` matches prompt count