### PR TITLE
v1.39.0: community feature-discovery scanner (#207)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.37.1",
+      "version": "1.38.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Run prompt-hook-fires-once tests (#224)
         run: ./tests/test-prompt-hook-fires-once.sh
 
+      - name: Run community scanner tests (#207)
+        run: ./tests/test-community-scanner.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,12 @@ jobs:
       - name: Run local shepherd tests
         run: ./tests/test-local-shepherd.sh
 
+      - name: Run repo complexity tests (#233)
+        run: ./tests/test-repo-complexity.sh
+
+      - name: Run prompt-hook-fires-once tests (#224)
+        run: ./tests/test-prompt-hook-fires-once.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # E2E test artifacts
 tests/e2e/.cache/
 
+# Generated test fixtures (rebuilt by tests/test-repo-complexity.sh on each run)
+tests/fixtures/complexity/
+
 # Claude Code local state
 .claude/plans/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ node_modules/
 # E2E test artifacts
 tests/e2e/.cache/
 
-# Generated test fixtures (rebuilt by tests/test-repo-complexity.sh on each run)
+# Generated test fixtures (rebuilt by their respective test scripts on each run)
 tests/fixtures/complexity/
+tests/fixtures/community-scanner/
 
 # Claude Code local state
 .claude/plans/

--- a/.reviews/handoff.json
+++ b/.reviews/handoff.json
@@ -1,8 +1,37 @@
 {
-  "review_id": "roadmap-231-phase1-001",
-  "status": "CERTIFIED",
-  "round": 3,
-  "closed_at": "2026-04-24",
-  "pr_number": null,
-  "note": "CERTIFIED 9/10 round 3. Round 1 was 7/10 (2 findings), round 2 was 8/10 (1 finding — broke a test assertion I changed the wording of), round 3 CERTIFIED. Non-blocking notes: ROADMAP.md:278 (#212 historical scope) + :328 (March live-fire audit table) still mention monthly-research — both are historical records, intentionally preserved."
+  "review_id": "community-scanner-001",
+  "status": "PENDING_REVIEW",
+  "round": 1,
+  "mission": "v1.39.0 ships ROADMAP #207 community feature-discovery scanner. New tests/e2e/scan-community.sh extracts /[a-z][a-z0-9-]* slash-command mentions from transcript text (Reddit / HN / Discord / CC GH Discussions) and emits any not in tests/e2e/known-slash-commands.txt as candidates with count + sample context. Replaces the deleted-in-#231 CI scan-community job (zero merged artifacts in 30d, $2-5/run) with a maintainer-runnable offline scan. Aligns with #231 Phase 3 plan.",
+  "success": "(1) Scanner correctly detects unknown /slash-commands in input text. (2) Allowlist (wizard skills + CC native + URL-path false positives) filters known commands out of candidates. (3) Output is valid JSON with scan_date, input_files, candidates[]. (4) Multi-file aggregation, stdin input, dedup + count, sample-context all work. (5) Length-≥4 filter drops /a /ab style noise. (6) No new external dependencies; tests pass deterministically.",
+  "failure": "Scanner misses real new commands (false negatives) or floods output with false positives (regex too permissive, allowlist incomplete). Allowlist file format is fragile (comments break parsing). Sample-context truncation drops the slash-command itself. Path traversal / shell injection via filename arg. Output schema drifts from what the maintainer can pipe through jq. Allowlist comparison is case-sensitive on a case-insensitive corpus.",
+  "files_changed": [
+    "tests/e2e/scan-community.sh",
+    "tests/e2e/known-slash-commands.txt",
+    "tests/test-community-scanner.sh",
+    "CLAUDE_CODE_SDLC_WIZARD.md",
+    "CHANGELOG.md",
+    "SDLC.md",
+    "package.json",
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json"
+  ],
+  "fixes_applied": [],
+  "previous_score": null,
+  "verification_checklist": [
+    "(a) tests/e2e/scan-community.sh awk regex: '/[a-z][a-z0-9-]*' length-≥4 filter. Confirm /a, /ab, /a1 don't surface. Confirm hyphenated commands like /code-review do match (the hyphen is in the char class).",
+    "(b) Allowlist comparison is case-insensitive: scanner lowercases both the matched token AND the allowlist entries. Verify /Help and /HELP both filter out.",
+    "(c) Path-prefix false positives (URL paths) filtered: confirm /dev /usr /var /tmp /etc /bin /lib /opt /home /root /proc /sys /run /mnt /media /srv are all in the allowlist (a real CC feature could collide with one — that's an accepted tradeoff documented in the doc section).",
+    "(d) tests/test-community-scanner.sh: 11 tests cover detection, allowlist filter (CC native + wizard skills), dedup + count, empty-input, JSON shape, stdin, multi-file aggregation, sample-context. Verify all 11 pass and there are no false greens (e.g., a test that passes regardless of scanner correctness).",
+    "(e) Scanner shell-safety: filename args are passed via for-loop with double-quoted '$arg', no eval, no $() on user input. Allowlist + matches are written to mktemp-created temp files in $TMPDIR.",
+    "(f) Output JSON shape: top-level scan_date, input_files (array), candidates (array of {slash, count, sample}). Matches the documented shape in CLAUDE_CODE_SDLC_WIZARD.md → 'Community Feature-Discovery Scanner'.",
+    "(g) CLAUDE_CODE_SDLC_WIZARD.md doc section accurately describes the maintainer procedure (capture transcripts → run scanner → triage `jq .candidates`). No claims that don't hold (e.g. don't claim it auto-uploads to GitHub).",
+    "(h) Allowlist file format: '#' comments and blank lines respected. Verify scanner's grep -vE '^[[:space:]]*(#|$)' filters them correctly without dropping commands.",
+    "(i) Version bump 1.38.0 → 1.39.0 in 5 files: package.json, plugin.json, marketplace.json, SDLC.md (2 occurrences in frontmatter + table), CLAUDE_CODE_SDLC_WIZARD.md (2 occurrences in version comments at top + bottom). Verify no live 1.38.0 references remain (CHANGELOG entry [1.38.0] is historical and stays).",
+    "(j) CHANGELOG.md [1.39.0] entry positioned correctly above [1.38.0]. Doesn't accidentally mention #233 or #224 (those shipped in 1.38.0)."
+  ],
+  "review_instructions": "You are reviewing v1.39.0 of the SDLC Wizard. The diff introduces a community feature-discovery scanner — a bash script that grep's transcript text for /slash-command mentions, dedupes against an allowlist file, and emits a JSON digest of unknown candidates. Be strict. Specifically check: (1) regex correctness (false positives + false negatives, length filter, case handling, hyphen handling); (2) allowlist file format and parsing; (3) shell safety (no injection, no path traversal); (4) test coverage independence (no false greens); (5) doc section accuracy; (6) version-bump consistency. Output each finding with: ID (1, 2, ...), severity (P0/P1/P2), file:line evidence, and a 'certify condition'. End with score (1-10) and CERTIFIED or NOT CERTIFIED.",
+  "preflight_path": ".reviews/preflight-community-scanner-001.md",
+  "artifact_path": ".reviews/community-scanner-001/",
+  "pr_number": null
 }

--- a/.reviews/response.json
+++ b/.reviews/response.json
@@ -1,12 +1,14 @@
 {
-  "review_id": "roadmap-231-phase1-001",
-  "round": 3,
+  "review_id": "mixed-mode-tier-001",
+  "round": 4,
   "responding_to": ".reviews/latest-review.md",
   "responses": [
     {
-      "finding": "1 (recheck) — Test 136 in tests/test-workflow-triggers.sh broke because the doc fix changed 'auto-workflows (weekly/monthly)' to 'auto-workflows weekly-update only'",
+      "finding": "1",
+      "severity": "P1",
       "action": "FIXED",
-      "summary": "Updated tests/test-workflow-triggers.sh test_auto_self_update_no_daily (lines 1911-1927) to match the post-#231-Phase-1 wording. New assertion: plan must mention 'auto-workflows.*weekly-update' AND must NOT mention the legacy '(weekly/monthly)' cadence pair. Rationale: monthly-research removed per #231 Phase 1, so the test should enforce the new reality rather than the pre-delete wording. Also fixed the related 'Both auto-update workflows' line at plans/AUTO_SELF_UPDATE.md:13 (non-blocking note from round 2). Verification: `bash tests/test-workflow-triggers.sh` → 165/165 PASS."
+      "summary": "Test harness false-green eliminated. (a) `invoke_hook` now wraps execution in a subshell that cd's into WORKSPACE before invoking the hook, so _find-sdlc-root.sh's pwd walk-up resolves the workspace's SDLC.md (not the repo root's). (b) Added `invoke_hook_uninstrumented` companion. (c) test_instrumentation_doesnt_break_output replaced 'contains SDLC BASELINE' substring check with byte-identical diff between instrumented and non-instrumented output — any stdout/stderr leak from the instrumentation block now fails. Verified: bash tests/test-prompt-hook-fires-once.sh from /tmp = 6/6 PASS.",
+      "verify_at": "tests/test-prompt-hook-fires-once.sh invoke_hook + invoke_hook_uninstrumented helpers, test_instrumentation_doesnt_break_output diff assertion"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the SDLC Wizard.
 
 ### Added
 
+- **Prompt-hook-fires-once instrumentation** — ROADMAP #224. `hooks/sdlc-prompt-check.sh` now records one tab-separated record (`<ts>\t<pid>\tsdlc-prompt-check`) per post-dedupe invocation when the opt-in env var `SDLC_HOOK_FIRE_LOG` is set. Maintainer can count lines per user prompt to verify CC 2.1.118's double-fire fix in real sessions; >1 line per prompt indicates regression. Unwritable paths fail silently. Procedure documented in `CLAUDE_CODE_SDLC_WIZARD.md` → "Verifying Prompt-Hook-Fires-Once". 6 regression tests in `tests/test-prompt-hook-fires-once.sh` cover the instrumentation contract (counter increments, opt-in semantics, log shape, output stability, error tolerance).
+
 - **Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer)** — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic classifies repos as `simple` or `complex` from filesystem signals (LOC, test count, hook count, workflow count, plus stakes flag for `.env` / `secrets/` / `credentials/`). Setup skill Step 9.5 expanded from binary y/N into a 3-way prompt:
   - **`[N]`** No pin (default, recommended for most repos) — preserves Claude Code auto-mode
   - **`[m]`** Mixed-mode pin `model: "sonnet[1m]"` — suggested for `simple` tier; coder runs on Sonnet, cross-model reviewer always stays at flagship (Opus 4.7 / gpt-5.5 xhigh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.39.0] - 2026-04-24
+
+### Added
+
+- **Community feature-discovery scanner** — ROADMAP #207. New `tests/e2e/scan-community.sh` script extracts `/[a-z][a-z0-9-]*` slash-command mentions from transcript text (Reddit, HN, Discord, CC GitHub Discussions exports) and emits any not in the `tests/e2e/known-slash-commands.txt` allowlist. Output is JSON with `scan_date`, `input_files`, and `candidates: [{slash, count, sample}]` for triage. Maintainer pulls transcripts manually (per ROADMAP #231 Phase 3 plan: "scan-community → port to tests/e2e/scan-community.sh; maintainer runs weekly on Max"); the scanner itself is offline + deterministic. Allowlist seeded with wizard skills (`/sdlc`, `/setup`, `/update`, `/feedback`, `/code-review`, `/less-permission-prompts`, `/claude-automation-recommender`, `/schedule`, `/ultrareview`), CC native commands as of 2.1.118 (`/help`, `/clear`, `/model`, `/effort`, `/usage`, `/cost`, `/stats`, `/compact`, `/resume`, `/init`, `/mcp`, `/plugin`, `/agents`, `/hooks`, `/permissions`, `/sandbox`, `/fast`, `/exit`, `/login`, `/logout`, `/doctor`, `/install`, `/uninstall`, `/settings`), plus common URL-path false positives (`/dev`, `/usr`, `/var`, `/tmp`, `/etc`, `/bin`, `/lib`, `/opt`, `/home`, `/root`, `/proc`, `/sys`, `/run`, `/mnt`, `/media`, `/srv`). Length-≥4 filter drops `/a`, `/ab` style noise. New `tests/test-community-scanner.sh` (11 tests) covers detection, allowlist filtering (CC native + wizard skills), dedup + count, empty-input edge case, JSON shape, stdin input, multi-file aggregation, and sample-context inclusion. Procedure documented in `CLAUDE_CODE_SDLC_WIZARD.md` → "Community Feature-Discovery Scanner". Complements aistupidlevel.info degradation signal and CC changelog diffs — three signals together cover official + community feature surface.
+
 ## [1.38.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.38.0] - 2026-04-24
+
+### Added
+
+- **Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer)** — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic classifies repos as `simple` or `complex` from filesystem signals (LOC, test count, hook count, workflow count, plus stakes flag for `.env` / `secrets/` / `credentials/`). Setup skill Step 9.5 expanded from binary y/N into a 3-way prompt:
+  - **`[N]`** No pin (default, recommended for most repos) — preserves Claude Code auto-mode
+  - **`[m]`** Mixed-mode pin `model: "sonnet[1m]"` — suggested for `simple` tier; coder runs on Sonnet, cross-model reviewer always stays at flagship (Opus 4.7 / gpt-5.5 xhigh)
+  - **`[f]`** Flagship pin `model: "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — suggested for `complex` / stakes-flagged tier; current pre-#233 default
+  Stakes flag (`.env` / `secrets/` / `credentials/`) forces `complex` regardless of size and detects at any depth (e.g. `config/.env`, `app/secrets/`); the coder is doing security-relevant work and the saving isn't worth the risk. Heuristic outputs are advisory — the user always picks the final tier. New `tests/test-repo-complexity.sh` (11 tests) with six fixture repos (`tests/fixtures/complexity/{simple,complex,stakes,nested-stakes,boundary-simple,boundary-complex}-repo`) covers tier classification, nested stakes detection, threshold-boundary cases (29 tests = simple, 30 = complex), JSON shape, missing-dir error path, and the `npx agentic-sdlc-wizard complexity` CLI subcommand. Cross-model review section in `skills/sdlc/SKILL.md` explicitly notes the reviewer **always** runs at flagship regardless of coder pin — weakening the review leg defeats the savings. Update skill Step 7.5 recognizes `sonnet[1m]` as a valid mixed-mode pin (no migration prompt). Wizard doc gets a new "Mixed-Mode Tier" subsection documenting the split, when to use each tier, the prove-it gate (pair-test on 3+ simple repos before recommending mixed-mode as default), and tradeoffs. **Reconciles with #198:** mixed-mode is opt-in per-project via Step 9.5; no-pin remains the default.
+
 ## [1.37.1] - 2026-04-24
 
 ### Fixed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -981,6 +981,52 @@ Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different
 - Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
 - Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
 
+### Community Feature-Discovery Scanner (roadmap #207)
+
+The weekly-update workflow watches Anthropic's official changelog + GitHub releases, but new CC slash-commands (e.g. a hypothetical `/insights`) often surface FIRST on Reddit, HN, or Discord weeks before they hit the changelog. `tests/e2e/scan-community.sh` ports the community-scan job out of CI (deleted per ROADMAP #231) into a maintainer-runnable script: pull transcripts manually, pipe through the scanner, triage the digest.
+
+**What it does:** extracts every `/[a-z][a-z0-9-]*` mention (length ≥ 4) from input text, dedupes against `tests/e2e/known-slash-commands.txt`, and emits a JSON digest with each unknown slash-command's count and one sample line for context.
+
+**Maintainer procedure:**
+
+```bash
+# 1. Capture transcripts. Save Reddit threads, HN comments, Discord exports,
+#    or CC GH Discussions to plain-text files. The scanner doesn't care about
+#    formatting — just the raw text.
+mkdir -p /tmp/community-scan-$(date +%Y-%m-%d)
+cd /tmp/community-scan-*
+# (paste / curl content into reddit.txt, hn.txt, discord.txt, etc.)
+
+# 2. Run the scanner. Multiple files are aggregated into one digest.
+bash /path/to/sdlc-wizard/tests/e2e/scan-community.sh *.txt > digest.json
+
+# 3. Triage. Anything in `candidates` is a slash-command the wizard's
+#    allowlist doesn't recognize — could be a new CC native command, a
+#    third-party plugin, or pure noise.
+jq '.candidates' digest.json
+```
+
+**Output shape:**
+
+```json
+{
+  "scan_date": "2026-04-24",
+  "input_files": ["reddit.txt", "hn.txt"],
+  "candidates": [
+    { "slash": "/insights", "count": 3, "sample": "Did you all see /insights in CC 2.2..." },
+    { "slash": "/newthing",  "count": 1, "sample": "I tried /newthing on a long session..." }
+  ]
+}
+```
+
+**Updating the allowlist:** when triage confirms a candidate is real and the wizard now accounts for it (either as a wizard skill or by documenting CC's native command), append it to `tests/e2e/known-slash-commands.txt` so the next scan stops surfacing it. The file is the single source of truth — no rebuild, no migration.
+
+**Why offline + deterministic:** the previous CI-based scan-community job burned $2-5/run via claude-code-action calls and produced one merged community-pattern PR in 30 days (ROADMAP #231 Phase 1 audit). Replacing it with a local regex scan + maintainer triage gives the same signal at zero API cost; the original `.github/prompts/analyze-community.md` prompt still exists for the LLM-summarization layer if a maintainer wants narrative analysis on top.
+
+**Regression test:** `tests/test-community-scanner.sh` covers detection of new commands, allowlist filtering (CC native + wizard skills), dedup + count behavior, empty-input edge case, JSON shape, stdin input, multi-file aggregation, and sample-context inclusion (11 tests). The fixtures under `tests/fixtures/community-scanner/` are seeded with `/newthing`, `/alpha`, `/beta`, `/gamma` mock mentions; if the scanner regresses the test fails on the missed slash.
+
+---
+
 ### Verifying Prompt-Hook-Fires-Once (roadmap #224)
 
 CC 2.1.118 shipped a fix for `prompt` hooks double-firing when an agent-hook verifier subagent itself made tool calls. The bug would manifest as duplicate `SDLC BASELINE` injections per `UserPromptSubmit` — context bloat plus possible confusion. The dual-channel (project + plugin) double-print is already handled by `dedupe_plugin_or_project` in v1.37.1; this section is the runtime check for the *CC-internal* double-fire case.
@@ -2786,7 +2832,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.38.0 -->
+<!-- SDLC Wizard Version: 1.39.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3848,7 +3894,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.38.0 -->
+<!-- SDLC Wizard Version: 1.39.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -940,6 +940,47 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 
 **Autocompact pairing (important):** If you opt into `opus[1m]`, also set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — otherwise CC's default autocompact fires at ~76K and destroys the headroom you're paying for. Step 9.5 writes both together when you opt in.
 
+### Mixed-Mode Tier (Sonnet coder + Opus reviewer, roadmap #233)
+
+For trivial / blank / config-only / CRUD-style repos, full Opus 4.7 on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
+
+**The split:**
+
+| Layer | Mixed-mode tier | Flagship tier |
+|-------|----------------|---------------|
+| Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
+| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) |
+| Effort floor (CC session) | xhigh; max preferred | xhigh; max preferred |
+
+The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
+
+**When mixed-mode is the right call:**
+- Repo is small (LOC < 10K), few tests (< 30), few hooks (< 5), few workflows (< 5), no `.env` / secrets handling
+- You're on API billing (not Max subscription) and 2× cost on simple repos actually matters
+- Tasks are predominantly mechanical — typo fixes, config tweaks, small CRUD endpoints
+- You're running the SDLC Wizard's setup flow against a sibling repo where the coder doesn't need flagship reasoning
+
+**When to stay flagship:**
+- Stakes-flagged repo: anywhere `.env` / `secrets/` / `credentials/` exists. Force flagship even if LOC is tiny — leaks are catastrophic
+- Architecture work, debugging non-obvious bugs, security review, anything where the *coder's* judgment matters as much as the reviewer's
+- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.7 fits the window better in a single thread
+
+**Auto-detection:** the setup wizard runs `cli/lib/repo-complexity.js` against the target repo and suggests the tier. Stakes flag (`.env` / `secrets/`) forces complex regardless of size. The user always picks the final answer — the heuristic is a hint, not a gate.
+
+**How to opt in (manual):**
+```json
+{
+  "model": "sonnet[1m]"
+}
+```
+Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different compaction characteristics than Opus's; let upstream defaults ride until we benchmark.
+
+**Prove-It Gate (#233 acceptance criterion):** mixed-mode ships only if pair-tested on 3+ simple repos shows Sonnet-coder + Opus-reviewer produces ≥ same SDLC scores as full-Opus baseline. The first version of the heuristic ships v1.38.0; pair-test results land in CHANGELOG before recommending mixed-mode as the default for any tier.
+
+**Tradeoffs (be honest):**
+- Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
+- Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
+
 ---
 
 ## Example Workflow (End-to-End)
@@ -2715,7 +2756,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3777,7 +3818,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -981,6 +981,36 @@ Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different
 - Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
 - Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
 
+### Verifying Prompt-Hook-Fires-Once (roadmap #224)
+
+CC 2.1.118 shipped a fix for `prompt` hooks double-firing when an agent-hook verifier subagent itself made tool calls. The bug would manifest as duplicate `SDLC BASELINE` injections per `UserPromptSubmit` — context bloat plus possible confusion. The dual-channel (project + plugin) double-print is already handled by `dedupe_plugin_or_project` in v1.37.1; this section is the runtime check for the *CC-internal* double-fire case.
+
+`hooks/sdlc-prompt-check.sh` ships an opt-in instrumentation: when the env var `SDLC_HOOK_FIRE_LOG` is set, every post-dedupe invocation appends one tab-separated record (`<unix-ts>\t<pid>\tsdlc-prompt-check`) to that log. Counting lines per prompt tells you whether CC fired the hook once or twice.
+
+**Maintainer procedure (real session):**
+
+```bash
+# 1. Pick a fresh log path
+export SDLC_HOOK_FIRE_LOG="$(mktemp /tmp/sdlc-fire-log.XXXXXX)"
+
+# 2. Restart Claude Code so the env propagates into spawned hooks
+#    (or set it in your shell rc / .envrc and start a fresh session)
+
+# 3. Run a normal SDLC session — including any task that triggers a verifier
+#    subagent (e.g., /code-review, /sdlc with multi-step planning)
+
+# 4. After N user prompts, count log lines:
+wc -l "$SDLC_HOOK_FIRE_LOG"
+#    Expect: N lines. >N indicates the CC double-fire bug regressed.
+
+# 5. Optional: tail the log live in another terminal to watch each fire:
+tail -f "$SDLC_HOOK_FIRE_LOG"
+```
+
+The instrumentation is opt-in — when the env var is unset, no log is written and no overhead is added. Unwritable log paths fail silently so a bad `SDLC_HOOK_FIRE_LOG` value never crashes the hook.
+
+**Regression test:** `tests/test-prompt-hook-fires-once.sh` covers the instrumentation contract (counter increments per invocation, opt-in semantics, log line shape, output stability, unwritable-path tolerance). It does *not* spawn Claude Code — that's a maintainer-runtime check by design. The test asserts the recording mechanism works so the maintainer's real-session count is trustworthy.
+
 ---
 
 ## Example Workflow (End-to-End)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-community-paths.sh && \
    ./tests/test-persist-score-history.sh && \
    ./tests/test-local-shepherd.sh && \
+   ./tests/test-repo-complexity.sh && \
+   ./tests/test-prompt-hook-fires-once.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-local-shepherd.sh && \
    ./tests/test-repo-complexity.sh && \
    ./tests/test-prompt-hook-fires-once.sh && \
+   ./tests/test-community-scanner.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.38.0 -->
+<!-- SDLC Wizard Version: 1.39.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.38.0 |
+| Wizard Version | 1.39.0 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.37.1 -->
+<!-- SDLC Wizard Version: 1.38.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.37.1 |
+| Wizard Version | 1.38.0 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/cli/bin/sdlc-wizard.js
+++ b/cli/bin/sdlc-wizard.js
@@ -3,6 +3,7 @@
 
 const { version } = require('../../package.json');
 const { init, check } = require('../init');
+const { detectComplexity } = require('../lib/repo-complexity');
 
 const args = process.argv.slice(2);
 
@@ -12,7 +13,8 @@ const flags = {
   json: args.includes('--json'),
 };
 
-const command = args.find((a) => !a.startsWith('--'));
+const positional = args.filter((a) => !a.startsWith('--'));
+const command = positional[0];
 
 if (args.includes('--version') || args.includes('-v')) {
   console.log(version);
@@ -24,13 +26,14 @@ if (args.includes('--help') || args.includes('-h') || !command) {
   agentic-sdlc-wizard v${version}
 
   Usage:
-    sdlc-wizard init [options]    Install SDLC wizard into current directory
-    sdlc-wizard check [options]   Check installation health and updates
+    sdlc-wizard init [options]               Install SDLC wizard into current directory
+    sdlc-wizard check [options]              Check installation health and updates
+    sdlc-wizard complexity [path]            Print mixed-mode tier heuristic (roadmap #233)
 
   Options:
     --force       Overwrite existing files (init only)
     --dry-run     Preview changes without writing (init only)
-    --json        Output as JSON (check only)
+    --json        Output as JSON (check / complexity)
     --version     Show version
     --help        Show this help
   `.trim());
@@ -54,6 +57,16 @@ if (command === 'init') {
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);
+  }
+} else if (command === 'complexity') {
+  try {
+    const target = positional[1] || process.cwd();
+    const result = detectComplexity(target);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(0);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(2);
   }
 } else {
   console.error(`Unknown command: ${command}`);

--- a/cli/lib/repo-complexity.js
+++ b/cli/lib/repo-complexity.js
@@ -1,0 +1,167 @@
+// Roadmap #233: repo complexity heuristic for mixed-mode tier selection.
+//
+// Output: { tier: 'simple' | 'complex', score: <number>, signals: [...] }
+//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.7 reviewer)
+//   - 'complex' → setup wizard suggests full flagship (Opus 4.7 everywhere)
+// Cross-model review (Codex / external) always stays at the flagship tier
+// regardless of coder selection — see CLAUDE_CODE_SDLC_WIZARD.md.
+//
+// Classification (matches CLAUDE_CODE_SDLC_WIZARD.md → "Mixed-Mode Tier"):
+//   simple = LOC < 10K AND tests < 30 AND hooks < 5 AND workflows < 5 AND no stakes
+//   complex = ANY high signal OR stakes flag (.env / secrets/ / credentials/ at any depth)
+// `score` is an additive ladder kept for transparency (low=0, mid=1, high=2 per signal).
+//
+// Heuristic is intentionally cheap: a single sync filesystem walk, no parsing.
+// It is a setup-time hint, not a runtime gate; users can override the result.
+
+const fs = require('fs');
+const path = require('path');
+
+const STAKES_FILES = new Set(['.env', '.env.local', '.env.production', '.env.development', '.envrc']);
+const STAKES_DIRS = new Set(['secrets', 'credentials', '.secrets', '.credentials']);
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', 'target',
+  '.next', '.nuxt', 'coverage', '.cache', 'vendor', '__pycache__',
+]);
+const SOURCE_EXTS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
+  '.py', '.go', '.rs', '.rb', '.java', '.kt', '.swift',
+  '.c', '.h', '.cpp', '.hpp', '.cc',
+  '.sh', '.bash', '.zsh',
+]);
+const TEST_PATTERNS = [/\.test\.[jt]sx?$/, /\.spec\.[jt]sx?$/, /_test\.go$/, /test_.*\.py$/, /.*_test\.py$/];
+
+function isTestFile(name, parentDir) {
+  if (TEST_PATTERNS.some((p) => p.test(name))) return true;
+  return parentDir === 'tests' || parentDir === 'test' || parentDir === '__tests__' || parentDir === 'spec';
+}
+
+function walk(rootDir, repoRoot, onFile, onDir, visited) {
+  let entries;
+  try {
+    entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  } catch (_) {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(rootDir, entry.name);
+    if (entry.isSymbolicLink()) continue; // don't follow symlinks (cycle / out-of-tree risk)
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      // Resolve real path for cycle detection.
+      let realPath;
+      try {
+        realPath = fs.realpathSync(full);
+      } catch (_) {
+        continue;
+      }
+      if (visited.has(realPath)) continue;
+      visited.add(realPath);
+      onDir && onDir(full, entry.name);
+      walk(full, repoRoot, onFile, onDir, visited);
+    } else if (entry.isFile()) {
+      onFile(full, entry.name, path.basename(rootDir));
+    }
+  }
+}
+
+function countLines(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (!content) return 0;
+    return content.split('\n').length;
+  } catch (_) {
+    return 0;
+  }
+}
+
+function detectComplexity(repoPath) {
+  if (!fs.existsSync(repoPath)) {
+    throw new Error(`Repo path does not exist: ${repoPath}`);
+  }
+  const stat = fs.statSync(repoPath);
+  if (!stat.isDirectory()) {
+    throw new Error(`Repo path is not a directory: ${repoPath}`);
+  }
+  const repoRoot = path.resolve(repoPath);
+
+  let loc = 0;
+  let testFiles = 0;
+  let hookFiles = 0;
+  let workflowFiles = 0;
+  const stakesHits = [];
+  const visited = new Set([fs.realpathSync(repoRoot)]);
+
+  walk(
+    repoRoot,
+    repoRoot,
+    (filePath, name, parent) => {
+      const ext = path.extname(name).toLowerCase();
+      const rel = path.relative(repoRoot, filePath);
+      if (STAKES_FILES.has(name)) {
+        stakesHits.push(`stakes:file:${rel}`);
+      }
+      if (SOURCE_EXTS.has(ext) || ext === '.yml' || ext === '.yaml') {
+        if (isTestFile(name, parent)) testFiles++;
+        else if (SOURCE_EXTS.has(ext)) loc += countLines(filePath);
+      }
+      if (parent === 'hooks' && filePath.includes(`.claude${path.sep}hooks`) && (ext === '.sh' || ext === '.bash')) {
+        hookFiles++;
+      }
+      if (parent === 'workflows' && filePath.includes(`.github${path.sep}workflows`) && (ext === '.yml' || ext === '.yaml')) {
+        workflowFiles++;
+      }
+    },
+    (dirPath, name) => {
+      if (STAKES_DIRS.has(name)) {
+        const rel = path.relative(repoRoot, dirPath);
+        stakesHits.push(`stakes:dir:${rel || name}/`);
+      }
+    },
+    visited
+  );
+
+  // Bands match docs: LOC<10K / tests<30 / hooks<5 / workflows<5 = "simple band"
+  const signals = [];
+  let highHits = 0;
+  let score = 0;
+
+  function band(value, midThreshold, highThreshold, label) {
+    if (value >= highThreshold) {
+      score += 2;
+      highHits++;
+      signals.push(`${label}:${value} (high → +2)`);
+    } else if (value >= midThreshold) {
+      score += 1;
+      signals.push(`${label}:${value} (mid → +1)`);
+    } else {
+      signals.push(`${label}:${value} (low → +0)`);
+    }
+  }
+
+  band(loc, 1000, 10000, 'loc');
+  band(testFiles, 5, 30, 'tests');
+  band(hookFiles, 3, 5, 'hooks');
+  band(workflowFiles, 2, 5, 'workflows');
+
+  let tier = highHits > 0 ? 'complex' : 'simple';
+  if (stakesHits.length > 0) {
+    tier = 'complex';
+    signals.push(...stakesHits, 'override:stakes-forces-complex');
+  }
+
+  return { tier, score, signals };
+}
+
+module.exports = { detectComplexity };
+
+if (require.main === module) {
+  const target = process.argv[2] || '.';
+  try {
+    const result = detectComplexity(target);
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+  }
+}

--- a/hooks/sdlc-prompt-check.sh
+++ b/hooks/sdlc-prompt-check.sh
@@ -12,6 +12,18 @@ source "$HOOK_DIR/_find-sdlc-root.sh"
 # plugin paths even when the script is sourced or invoked via aliases.
 dedupe_plugin_or_project "${BASH_SOURCE[0]}" || exit 0
 
+# Roadmap #224: opt-in fires-once instrumentation. CC 2.1.118 shipped a fix for
+# prompt hooks double-firing when a verifier subagent itself made tool calls.
+# When SDLC_HOOK_FIRE_LOG is set, append one tab-separated record per real
+# invocation (post-dedupe). Maintainer can compare line count against prompt
+# count to verify the CC fix in real sessions. See CLAUDE_CODE_SDLC_WIZARD.md →
+# "Verifying Prompt-Hook-Fires-Once" for the procedure.
+if [ -n "${SDLC_HOOK_FIRE_LOG:-}" ]; then
+    {
+        printf '%s\t%s\tsdlc-prompt-check\n' "$(date +%s)" "$$" >> "$SDLC_HOOK_FIRE_LOG"
+    } 2>/dev/null || true
+fi
+
 # CWD walk-up finds nearest SDLC project (#173: silent exit for non-SDLC dirs)
 if find_sdlc_root; then
     PROJECT_DIR="$SDLC_ROOT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -230,6 +230,8 @@ PLANNING -> DOCS -> TDD RED -> TDD GREEN -> Tests Pass -> Self-Review
 
 **The core insight:** The review PROTOCOL is universal across domains. Only the review INSTRUCTIONS change. Code review is the default template below. For non-code domains (research, persuasion, medical content), adapt the `review_instructions` and `verification_checklist` fields while keeping the same handoff/dialogue/convergence loop.
 
+**Reviewer always at the flagship tier (roadmap #233):** if the project pins `model: "sonnet[1m]"` (mixed-mode) or any non-flagship coder, the cross-model reviewer **still runs at the flagship**: `codex exec -c 'model_reasoning_effort="xhigh"'` (gpt-5.5) or an Opus 4.7 max equivalent. The whole point of mixed-mode is that adversarial review catches Sonnet's blind spots — weakening the reviewer leg defeats the savings. Don't downscale the review just because the coder is downscaled.
+
 ### Step 0: Write Preflight Self-Review Doc
 
 Before submitting to an external reviewer, document what YOU already checked. This is proven to reduce reviewer findings to 0-1 per round (evidence: anticheat repo preflight discipline).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -198,24 +198,45 @@ Write the shape as:
 
 Present suggestions and let the user confirm.
 
-### Step 9.5: Context Window Configuration (Opt-In)
+### Step 9.5: Context Window + Mixed-Mode Configuration (Opt-In)
 
-The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by default. This preserves Claude Code's built-in model auto-selection (Sonnet for cheap tasks, Opus for hard ones) and the upstream autocompact threshold. Power users who want guaranteed 1M context can opt in during setup.
+The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by default. This preserves Claude Code's built-in model auto-selection (Sonnet for cheap tasks, Opus for hard ones) and the upstream autocompact threshold. Power users can opt into a pin during setup; mixed-mode users (Sonnet coder + Opus reviewer) can pin Sonnet here too.
 
-**Why this is opt-in (issue #198):** A top-level `"model"` in `settings.json` tells Claude Code "the user has explicitly chosen a model" and disables auto-mode for the session. That is a real tradeoff — the pin is only worth it when you actually need the 1M headroom and want to lock to Opus 4.7.
+**Why this is opt-in (issue #198):** A top-level `"model"` in `settings.json` tells Claude Code "the user has explicitly chosen a model" and disables auto-mode for the session. That is a real tradeoff — pinning is only worth it when you actually need the 1M headroom or you've decided mixed-mode tier-splitting is better than per-turn auto-selection.
+
+**Run the complexity heuristic first (roadmap #233):**
+
+```bash
+npx agentic-sdlc-wizard complexity .
+```
+
+The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the result to suggest a default in the prompt below — do NOT override the user's choice. The heuristic flags any `.env` / `secrets/` / `credentials/` at any depth as a stakes signal that forces `complex` regardless of size.
 
 **Ask the user exactly once in Step 9.5:**
 
-> Pin the session to `opus[1m]` (Opus 4.7 with 1M context) and set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`?
+> Detected repo complexity: **{tier}** ({score}, signals: {loc, tests, hooks, workflows, stakes-flag if any}).
 >
-> - **No (default):** Leaves auto-mode enabled. Claude Code picks the model per turn, compaction follows upstream defaults. Recommended for most users.
-> - **Yes:** Long SDLC sessions (plan → TDD → review → CI shepherd on one feature) regularly cross 100K tokens; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.111+ and comfort with losing model auto-selection.
+> How do you want to configure the model for this repo?
 >
-> `[y/N]`
+> - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
+> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.7 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
+> - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.7 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.111+.
+>
+> `[N/m/f]`
 
-**If the user answers No (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
+**If the user answers `N` (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
 
-**If the user answers Yes:** Edit `.claude/settings.json` and add both fields at the top level:
+**If the user answers `m` (mixed-mode):** Edit `.claude/settings.json` and add:
+
+```json
+{
+  "model": "sonnet[1m]"
+}
+```
+
+Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window has different compaction characteristics than Opus; let the upstream default ride. Tell the user explicitly: "Cross-model reviews still run at the flagship — `codex exec -c 'model_reasoning_effort=\"xhigh\"'` (gpt-5.5) or any future Opus-tier reviewer. Mixed-mode is coder-only."
+
+**If the user answers `f` (flagship):** Edit `.claude/settings.json` and add both fields at the top level:
 
 ```json
 {
@@ -226,9 +247,10 @@ The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by 
 }
 ```
 
-Mention the escape hatch either way:
+Mention the escape hatch in all three cases:
 - To opt out later: remove the `model` line (and optionally the `env` block) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
-- For CI pipelines with short tasks, consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.
+- To switch tiers later: edit `.claude/settings.json` and replace the `model` value, or re-run `/setup-wizard` Step 9.5.
+- For CI pipelines with short tasks (flagship only), consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.
 
 This is project-scoped and shared with the team via git.
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -46,9 +46,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.37.1
+Latest:    1.38.0
 
 What changed:
+- [1.38.0] Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer) for simple repos — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI command. Setup Step 9.5 expanded from binary y/N to 3-way (no-pin / mixed / flagship). Cross-model review always stays at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default.
 - [1.37.1] Token-bloat fix: dedupe 2× SDLC BASELINE print when both project + plugin register the same hook (~300 tokens doubled per prompt). 5 hooks gain `dedupe_plugin_or_project()` helper. Codex 2-round 100/100.
 - [1.37.0] `monthly-research.yml` workflow deleted (ROADMAP #231 Phase 1) — 0 merged artifacts in 30d while burning $11-23/month; research happens inline now. `model-effort-check.sh` loud WARNING below xhigh (#217) — max preferred, xhigh floor; duplicate effort nudge in `instructions-loaded-check.sh` removed; single source of truth. Both changes Codex-certified.
 - [1.36.1] Repo renamed `agentic-ai-sdlc-wizard` → `claude-sdlc-wizard` (matches sibling pattern; npm package unchanged); `npm pkg fix` metadata cleanup; slug migration across docs/tests/configs
@@ -133,9 +134,11 @@ If the user is upgrading from a pre-#198 version, check their `.claude/settings.
 
 2. **If only one of the two fields matches** (e.g. `model: "opus[1m]"` but custom autocompact, or vice versa) — treat as intentional customization. Do not prompt.
 
-3. **If `model` is some other value** (e.g. `"sonnet"`, `"opus"`) — treat as user's explicit choice. Do not touch.
+3. **If `model` is `"sonnet[1m]"` (mixed-mode tier, roadmap #233, v1.38.0+)** — treat as user's explicit mixed-mode choice. Do not prompt; this is the supported mixed-mode pin. Mention in the upgrade summary: "Detected mixed-mode tier (Sonnet coder + flagship reviewer). Cross-model review still uses Opus / gpt-5.5 — see CLAUDE_CODE_SDLC_WIZARD.md → 'Mixed-Mode Tier'."
 
-4. **If neither field is set** — user is already on the new default. No action.
+4. **If `model` is some other value** (e.g. `"sonnet"`, `"opus"`) — treat as user's explicit choice. Do not touch.
+
+5. **If neither field is set** — user is already on the new default. No action.
 
 When removing: edit the file in place, drop the `model` key (and the `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` key if nothing else is in `env`, otherwise leave `env` alone). Never touch other keys the user added.
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -46,10 +46,11 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.38.0
+Latest:    1.39.0
 
 What changed:
-- [1.38.0] Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer) for simple repos — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI command. Setup Step 9.5 expanded from binary y/N to 3-way (no-pin / mixed / flagship). Cross-model review always stays at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default.
+- [1.39.0] Community feature-discovery scanner — ROADMAP #207. `tests/e2e/scan-community.sh` extracts unknown `/slash-command` mentions from transcript text (Reddit / HN / Discord exports), dedupes against `tests/e2e/known-slash-commands.txt` allowlist, emits JSON digest of candidates with count + sample. Replaces the deleted CI scan-community job (per #231 Phase 3) with a maintainer-runnable offline scan. 11 quality tests.
+- [1.38.0] Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer) for simple repos — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI command. Setup Step 9.5 expanded from binary y/N to 3-way (no-pin / mixed / flagship). Cross-model review always stays at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default. Plus ROADMAP #224 prompt-hook-fires-once instrumentation (opt-in `SDLC_HOOK_FIRE_LOG`).
 - [1.37.1] Token-bloat fix: dedupe 2× SDLC BASELINE print when both project + plugin register the same hook (~300 tokens doubled per prompt). 5 hooks gain `dedupe_plugin_or_project()` helper. Codex 2-round 100/100.
 - [1.37.0] `monthly-research.yml` workflow deleted (ROADMAP #231 Phase 1) — 0 merged artifacts in 30d while burning $11-23/month; research happens inline now. `model-effort-check.sh` loud WARNING below xhigh (#217) — max preferred, xhigh floor; duplicate effort nudge in `instructions-loaded-check.sh` removed; single source of truth. Both changes Codex-certified.
 - [1.36.1] Repo renamed `agentic-ai-sdlc-wizard` → `claude-sdlc-wizard` (matches sibling pattern; npm package unchanged); `npm pkg fix` metadata cleanup; slug migration across docs/tests/configs

--- a/tests/e2e/known-slash-commands.txt
+++ b/tests/e2e/known-slash-commands.txt
@@ -1,0 +1,66 @@
+# Known slash commands the wizard already accounts for.
+# tests/e2e/scan-community.sh dedupes against this list when surfacing
+# new community-mentioned commands. Lines starting with # are comments.
+# One command per line, with leading slash.
+#
+# Updating: when a new wizard skill or CC release adds a slash command,
+# append it here so the scanner stops flagging it as a candidate. The
+# scanner output's "candidates" field is meant for triage of NEW commands;
+# anything below is either already shipped or already documented.
+
+# Wizard skills (skills/*)
+/sdlc
+/setup
+/update
+/feedback
+
+# Wizard-companion skills / commands (Claude Code native or shipped via plugins)
+/code-review
+/less-permission-prompts
+/claude-automation-recommender
+/schedule
+/ultrareview
+
+# Claude Code native commands (as of CC 2.1.118)
+/help
+/clear
+/model
+/effort
+/usage
+/cost
+/stats
+/compact
+/resume
+/init
+/mcp
+/plugin
+/agents
+/hooks
+/permissions
+/sandbox
+/fast
+/exit
+/login
+/logout
+/doctor
+/install
+/uninstall
+/settings
+
+# Common false-positives (URL paths, code-snippets, etc. that look like commands but aren't)
+/dev
+/usr
+/var
+/tmp
+/etc
+/bin
+/lib
+/opt
+/home
+/root
+/proc
+/sys
+/run
+/mnt
+/media
+/srv

--- a/tests/e2e/scan-community.sh
+++ b/tests/e2e/scan-community.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Roadmap #207: community feature-discovery scanner.
+#
+# Scans transcript text for /slash-command mentions and emits any not in the
+# known-allowlist. Designed to be run by the maintainer on a Max subscription
+# against transcripts pulled from Reddit / HN / Discord / CC GitHub Discussions
+# (per #231 Phase 3 plan: "scan-community → port to tests/e2e/scan-community.sh").
+#
+# Usage:
+#   ./scan-community.sh path/to/transcript.txt [path/to/another.txt ...]
+#   ./scan-community.sh -                       # read stdin
+#
+# Output: JSON to stdout
+#   { "scan_date": "YYYY-MM-DD",
+#     "input_files": [...],
+#     "candidates": [
+#       { "slash": "/newthing",
+#         "count": 3,
+#         "sample": "Reddit r/ClaudeAI: Did you all see /newthing in CC..." }
+#     ] }
+#
+# Exit codes:
+#   0 - scan completed (candidates may be empty)
+#   1 - input not readable / no input given
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ALLOWLIST="$SCRIPT_DIR/known-slash-commands.txt"
+
+if [ "$#" -eq 0 ]; then
+    echo "error: no input given. Usage: $0 path/to/transcript.txt [...] | $0 -" >&2
+    exit 1
+fi
+
+if [ ! -f "$ALLOWLIST" ]; then
+    echo "error: allowlist file missing: $ALLOWLIST" >&2
+    exit 1
+fi
+
+# Working files. Keep these in TMPDIR so test sandboxes that allow $TMPDIR work.
+TMP="${TMPDIR:-/tmp}"
+ALLOW_TMP=$(mktemp "$TMP/scan-allow.XXXXXX")
+INPUT_TMP=$(mktemp "$TMP/scan-input.XXXXXX")
+MATCHES_TMP=$(mktemp "$TMP/scan-matches.XXXXXX")
+trap 'rm -f "$ALLOW_TMP" "$INPUT_TMP" "$MATCHES_TMP" 2>/dev/null' EXIT
+
+# Build the allowlist set (strip comments + blank lines, lowercase).
+/usr/bin/grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | tr '[:upper:]' '[:lower:]' | sort -u > "$ALLOW_TMP"
+
+# Concatenate all inputs into one buffer for scanning.
+input_files=()
+for arg in "$@"; do
+    if [ "$arg" = "-" ]; then
+        cat >> "$INPUT_TMP"
+        input_files+=("(stdin)")
+    elif [ -f "$arg" ]; then
+        # Use redirection rather than `cat "$arg"` so dash-leading filenames
+        # like "-notes.txt" aren't interpreted as cat options.
+        cat < "$arg" >> "$INPUT_TMP"
+        echo "" >> "$INPUT_TMP"  # ensure newline boundary between files
+        input_files+=("$arg")
+    else
+        echo "error: input file not readable: $arg" >&2
+        exit 1
+    fi
+done
+
+# Build input_files JSON array via python.
+input_files_json=$(printf '%s\n' "${input_files[@]}" | python3 -c "
+import sys, json
+print(json.dumps([line.rstrip() for line in sys.stdin if line.strip()]))
+")
+
+SCAN_DATE=$(date +%Y-%m-%d)
+
+# Extract each slash-command + a sample window around it (for context).
+# Pattern: '/' followed by [a-z], then [a-z0-9-]*. Length >= 4 (drop /a, /ab,
+# /a1 noise that's almost always a path fragment or unrelated). Match is done
+# on a lowercased copy of the line so /Help and /HELP normalize to /help and
+# get filtered through the allowlist correctly.
+# Output format: <slash><tab><sample-window>
+# The sample-window is up to 100 chars before + 100 chars after the matched
+# slash command, drawn from the ORIGINAL line (preserving case in the sample
+# even though matching is case-insensitive).
+awk '
+{
+    orig = $0
+    line_lc = tolower($0)
+    s = line_lc
+    offset = 0
+    while (match(s, /\/[a-z][a-z0-9-]*/)) {
+        rstart_in_orig = offset + RSTART
+        token_lc = substr(s, RSTART, RLENGTH)
+        if (length(token_lc) >= 4) {
+            # Extract sample window around the match in the original line.
+            sample_start = rstart_in_orig - 100
+            if (sample_start < 1) sample_start = 1
+            sample_len = RLENGTH + 200
+            sample = substr(orig, sample_start, sample_len)
+            # Strip trailing/leading whitespace and newlines from the sample.
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", sample)
+            printf "%s\t%s\n", token_lc, sample
+        }
+        offset = offset + RSTART + RLENGTH - 1
+        s = substr(s, RSTART + RLENGTH)
+    }
+}
+' "$INPUT_TMP" > "$MATCHES_TMP"
+
+# Build the candidates JSON via python (cleaner than awk/jq for sample context).
+CANDIDATES_JSON=$(ALLOW="$ALLOW_TMP" MATCHES="$MATCHES_TMP" python3 -c "
+import json, os
+
+with open(os.environ['ALLOW']) as f:
+    allow = {ln.strip() for ln in f if ln.strip()}
+
+counts, samples = {}, {}
+with open(os.environ['MATCHES']) as f:
+    for line in f:
+        parts = line.rstrip('\n').split('\t', 1)
+        if len(parts) != 2:
+            continue
+        slash, ctx = parts
+        if slash in allow:
+            continue
+        counts[slash] = counts.get(slash, 0) + 1
+        if slash not in samples:
+            samples[slash] = ctx.strip()[:200]
+
+candidates = sorted(
+    [{'slash': s, 'count': counts[s], 'sample': samples[s]} for s in counts],
+    key=lambda c: (-c['count'], c['slash'])
+)
+print(json.dumps(candidates))
+")
+
+# Final assembly.
+SCAN="$SCAN_DATE" FILES="$input_files_json" CANDS="$CANDIDATES_JSON" python3 -c "
+import json, os
+out = {
+    'scan_date': os.environ['SCAN'],
+    'input_files': json.loads(os.environ['FILES']),
+    'candidates': json.loads(os.environ['CANDS']),
+}
+print(json.dumps(out, indent=2))
+"

--- a/tests/test-community-scanner.sh
+++ b/tests/test-community-scanner.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+# Roadmap #207: community feature-discovery scanner.
+# Surfaces NEW slash-command mentions from external sources (Reddit, HN, Discord
+# transcripts) that the wizard doesn't already know about. Output is a JSON
+# digest the maintainer triages.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCANNER="$SCRIPT_DIR/e2e/scan-community.sh"
+ALLOWLIST="$SCRIPT_DIR/e2e/known-slash-commands.txt"
+FIXTURES="$SCRIPT_DIR/fixtures/community-scanner"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Community Feature-Discovery Scanner Tests (Roadmap #207) ==="
+echo ""
+
+setup_fixtures() {
+    mkdir -p "$FIXTURES"
+    cat > "$FIXTURES/transcript-newthing.txt" <<'EOF'
+Reddit r/ClaudeAI thread, 2026-04-22:
+"Did you all see the new /newthing command in CC 2.1.119? It auto-summarizes
+the last 50 turns. Way better than /compact for context migration."
+
+Reply: "I tried /help to see the full list, /newthing is also there. Slick."
+
+Another reply: "Also /usage now shows token-by-tool breakdown. Not sure when
+that landed but it's been there for a couple releases."
+EOF
+
+    cat > "$FIXTURES/transcript-noise.txt" <<'EOF'
+Just running my normal workflow today. Used /help, /clear, /model, /effort,
+/usage, /compact. Nothing unusual. The wizard's /sdlc skill kept me on track.
+EOF
+
+    cat > "$FIXTURES/transcript-multi.txt" <<'EOF'
+Mentions of /alpha and /beta in this thread. Then /alpha appears again later.
+Also someone mentioned /gamma once. Note: /sdlc is a wizard skill so should be
+filtered.
+EOF
+
+    cat > "$FIXTURES/transcript-empty.txt" <<'EOF'
+This text has no slash commands at all. Just regular prose about the weather.
+EOF
+}
+
+setup_fixtures
+
+# ---- Tests ----
+
+test_scanner_exists() {
+    if [ -x "$SCANNER" ]; then
+        pass "scanner script exists and is executable"
+    else
+        fail "scanner script not found or not executable: $SCANNER"
+    fi
+}
+
+test_allowlist_exists() {
+    if [ -f "$ALLOWLIST" ]; then
+        pass "allowlist file exists"
+    else
+        fail "allowlist file missing: $ALLOWLIST"
+    fi
+}
+
+test_detects_new_slash_command() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-newthing.txt" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+candidates = [c['slash'] for c in d.get('candidates', [])]
+assert '/newthing' in candidates, f'expected /newthing in candidates, got {candidates}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner emits /newthing as a candidate"
+    else
+        fail "scanner missed /newthing. Output: $out"
+    fi
+}
+
+test_filters_known_commands() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-newthing.txt" 2>&1)
+    # /help and /usage should NOT be in candidates (they are well-known)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+candidates = [c['slash'] for c in d.get('candidates', [])]
+assert '/help' not in candidates, f'/help leaked into candidates: {candidates}'
+assert '/usage' not in candidates, f'/usage leaked into candidates: {candidates}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner filters known CC native commands (/help, /usage) from candidates"
+    else
+        fail "scanner failed to filter known commands. Output: $out"
+    fi
+}
+
+test_filters_wizard_skills() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-multi.txt" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+candidates = [c['slash'] for c in d.get('candidates', [])]
+assert '/sdlc' not in candidates, f'/sdlc leaked into candidates (wizard skill): {candidates}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner filters wizard skills (/sdlc) from candidates"
+    else
+        fail "scanner failed to filter wizard skills. Output: $out"
+    fi
+}
+
+test_dedupes_and_counts() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-multi.txt" 2>&1)
+    # /alpha appears twice, /beta once, /gamma once. Each should appear once
+    # in candidates, with appropriate counts.
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+cand_map = {c['slash']: c['count'] for c in d.get('candidates', [])}
+assert cand_map.get('/alpha') == 2, f'/alpha count: {cand_map.get(\"/alpha\")}, expected 2'
+assert cand_map.get('/beta') == 1, f'/beta count: {cand_map.get(\"/beta\")}, expected 1'
+assert cand_map.get('/gamma') == 1, f'/gamma count: {cand_map.get(\"/gamma\")}, expected 1'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner dedupes and counts correctly (/alpha=2, /beta=1, /gamma=1)"
+    else
+        fail "dedup/count failed. Output: $out"
+    fi
+}
+
+test_empty_input_returns_empty_candidates() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-empty.txt" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert d.get('candidates', []) == [], f'expected empty candidates, got {d.get(\"candidates\")}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "empty/no-slash-command input returns empty candidates"
+    else
+        fail "scanner returned non-empty candidates for empty input. Output: $out"
+    fi
+}
+
+test_outputs_valid_json() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-newthing.txt" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+assert 'scan_date' in d, 'missing scan_date'
+assert 'candidates' in d, 'missing candidates'
+assert isinstance(d['candidates'], list), 'candidates is not a list'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "output is valid JSON with scan_date + candidates fields"
+    else
+        fail "output is not valid JSON. Output: $out"
+    fi
+}
+
+test_handles_stdin() {
+    local out
+    out=$(echo "Try /stdintest in this prompt" | bash "$SCANNER" - 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+candidates = [c['slash'] for c in d.get('candidates', [])]
+assert '/stdintest' in candidates, f'expected /stdintest from stdin, got {candidates}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner accepts stdin input via '-' arg"
+    else
+        fail "scanner did not handle stdin. Output: $out"
+    fi
+}
+
+test_handles_multiple_files() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-newthing.txt" "$FIXTURES/transcript-multi.txt" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+candidates = [c['slash'] for c in d.get('candidates', [])]
+assert '/newthing' in candidates and '/alpha' in candidates, f'multi-file scan missed candidates: {candidates}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner aggregates across multiple input files"
+    else
+        fail "multi-file scan failed. Output: $out"
+    fi
+}
+
+test_includes_sample_context() {
+    local out
+    out=$(bash "$SCANNER" "$FIXTURES/transcript-newthing.txt" 2>&1)
+    # Codex round 1 P1: weak assertion. Strengthened to require the slash
+    # itself appears in the sample window (case-insensitive).
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+newthing = next((c for c in d['candidates'] if c['slash'] == '/newthing'), None)
+assert newthing is not None
+assert 'sample' in newthing and len(newthing['sample']) > 0, f'no sample context for /newthing'
+assert '/newthing' in newthing['sample'].lower(), f'slash not in sample: {newthing[\"sample\"]}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner includes sample context that contains the matched slash"
+    else
+        fail "sample context missing or doesn't contain the slash. Output: $out"
+    fi
+}
+
+test_long_line_sample_includes_slash() {
+    # Codex round 1 P1: sample truncation could drop the slash if the line is
+    # very long. Build a fixture with /latecommand at the end of a 400-char line.
+    local long_fix="$FIXTURES/transcript-long.txt"
+    printf '%0.s_' {1..350} > "$long_fix"  # 350 underscores
+    printf ' and finally we use /latecommand here in this thread\n' >> "$long_fix"
+    local out
+    out=$(bash "$SCANNER" "$long_fix" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+late = next((c for c in d['candidates'] if c['slash'] == '/latecommand'), None)
+assert late is not None, '/latecommand not detected at all'
+assert '/latecommand' in late['sample'].lower(), f'/latecommand not in sample window: {late[\"sample\"]}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "long-line sample window contains the matched slash (no truncation drops it)"
+    else
+        fail "sample window truncation regression. Output: $out"
+    fi
+}
+
+test_case_insensitive_extraction() {
+    # Codex round 1 P1: extraction was lowercase-only. /Help and /HELP must
+    # filter out (allowlisted lowercase), /NewThing must surface as /newthing.
+    local case_fix="$FIXTURES/transcript-case.txt"
+    cat > "$case_fix" <<'EOF'
+The user mentioned /Help and /HELP and also brought up /NewThing.
+Note that /newthing also got mentioned with normal casing.
+EOF
+    local out
+    out=$(bash "$SCANNER" "$case_fix" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+slashes = {c['slash']: c['count'] for c in d['candidates']}
+assert '/help' not in slashes, f'/Help/HELP leaked into candidates: {slashes}'
+# /NewThing and /newthing should both contribute to the same /newthing entry
+nt = slashes.get('/newthing', 0)
+assert nt == 2, f'/newthing count expected 2 (case-folded /NewThing + /newthing), got {nt}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "case-insensitive extraction: /Help filters, /NewThing folds into /newthing count=2"
+    else
+        fail "case-insensitive extraction failed. Output: $out"
+    fi
+}
+
+test_dash_leading_filename() {
+    # Codex round 1 P2: cat "$arg" mistakes "-notes.txt" for an option.
+    # Now reading via < "$arg" — verify a dash-leading filename works.
+    local dash_fix="$FIXTURES/-dashnotes.txt"
+    cat > "$dash_fix" <<'EOF'
+This dash-leading file mentions /dashtest as a candidate.
+EOF
+    local out
+    out=$(bash "$SCANNER" "$dash_fix" 2>&1)
+    if echo "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+slashes = [c['slash'] for c in d['candidates']]
+assert '/dashtest' in slashes, f'dash-leading file failed to read; got: {slashes}'
+print('ok')
+" 2>/dev/null | grep -q ok; then
+        pass "scanner reads dash-leading filename (-dashnotes.txt) without treating as option"
+    else
+        fail "dash-leading filename broken. Output: $out"
+    fi
+}
+
+test_scanner_exists
+test_allowlist_exists
+test_detects_new_slash_command
+test_filters_known_commands
+test_filters_wizard_skills
+test_dedupes_and_counts
+test_empty_input_returns_empty_candidates
+test_outputs_valid_json
+test_handles_stdin
+test_handles_multiple_files
+test_includes_sample_context
+test_long_line_sample_includes_slash
+test_case_insensitive_extraction
+test_dash_leading_filename
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All community-scanner tests passed."

--- a/tests/test-prompt-hook-fires-once.sh
+++ b/tests/test-prompt-hook-fires-once.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Roadmap #224: regression test for sdlc-prompt-check.sh "fires exactly once"
+# instrumentation. CC 2.1.118 shipped a fix for prompt hooks double-firing when
+# an agent-hook verifier subagent itself made tool calls. We can't directly
+# unit-test CC's behavior, but we can ship instrumentation that records each
+# hook invocation so the maintainer can verify the fix holds in real sessions.
+#
+# Mechanism: when the env var SDLC_HOOK_FIRE_LOG is set, sdlc-prompt-check.sh
+# appends a single line per invocation: "<unix-ts>\t<pid>\t<source-marker>".
+# Maintainer procedure documented in CLAUDE_CODE_SDLC_WIZARD.md.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/sdlc-prompt-check.sh"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Prompt-Hook-Fires-Once Instrumentation Tests (Roadmap #224) ==="
+echo ""
+
+# Set up an isolated workspace with a complete SDLC project so the hook reaches
+# its main code path (instead of bailing on missing SDLC.md / TESTING.md).
+WORKSPACE="${TMPDIR:-/tmp}/sdlc-fire-test-$$"
+mkdir -p "$WORKSPACE"
+trap 'rm -rf "$WORKSPACE"' EXIT
+echo "# SDLC" > "$WORKSPACE/SDLC.md"
+echo "# Testing" > "$WORKSPACE/TESTING.md"
+LOG="$WORKSPACE/fire.log"
+
+invoke_hook() {
+    # cd into WORKSPACE so _find-sdlc-root.sh's `pwd` walk-up finds *this*
+    # workspace's SDLC.md, not whatever cwd the test is launched from.
+    # Without the cd the test silently exercises the repo root and gives
+    # a false-green when run from a parent dir.
+    (cd "$WORKSPACE" && SDLC_HOOK_FIRE_LOG="$LOG" CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}')
+}
+
+invoke_hook_uninstrumented() {
+    (cd "$WORKSPACE" && CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}')
+}
+
+test_counter_records_first_invocation() {
+    : > "$LOG"
+    invoke_hook > /dev/null
+    local lines
+    lines=$(wc -l < "$LOG" | tr -d ' ')
+    if [ "$lines" = "1" ]; then
+        pass "first invocation records exactly 1 line in log"
+    else
+        fail "first invocation recorded $lines lines (expected 1). Log:"
+        cat "$LOG" | sed 's/^/  /'
+    fi
+}
+
+test_counter_appends_per_invocation() {
+    : > "$LOG"
+    for i in 1 2 3 4 5; do
+        invoke_hook > /dev/null
+    done
+    local lines
+    lines=$(wc -l < "$LOG" | tr -d ' ')
+    if [ "$lines" = "5" ]; then
+        pass "5 invocations record exactly 5 lines (counter increments correctly)"
+    else
+        fail "5 invocations recorded $lines lines (expected 5). Log:"
+        cat "$LOG" | sed 's/^/  /'
+    fi
+}
+
+test_counter_is_opt_in() {
+    rm -f "$LOG"
+    CLAUDE_PROJECT_DIR="$WORKSPACE" bash "$HOOK" <<<'{"prompt":"hello"}' > /dev/null
+    if [ ! -f "$LOG" ]; then
+        pass "no SDLC_HOOK_FIRE_LOG env → no log file created (instrumentation is opt-in)"
+    else
+        fail "log file was created without env var being set: $LOG"
+    fi
+}
+
+test_log_line_shape() {
+    : > "$LOG"
+    invoke_hook > /dev/null
+    local line ts pid marker
+    line=$(head -1 "$LOG")
+    ts=$(printf '%s' "$line" | awk -F'\t' '{print $1}')
+    pid=$(printf '%s' "$line" | awk -F'\t' '{print $2}')
+    marker=$(printf '%s' "$line" | awk -F'\t' '{print $3}')
+    if [[ "$ts" =~ ^[0-9]+$ ]] && [[ "$pid" =~ ^[0-9]+$ ]] && [ -n "$marker" ]; then
+        pass "log line is tab-separated: ts=$ts pid=$pid marker=$marker"
+    else
+        fail "log line shape unexpected. Line: $line"
+    fi
+}
+
+test_instrumentation_doesnt_break_output() {
+    # Codex round 3 P1: weak assertion just checked "SDLC BASELINE: exists".
+    # Strengthen: instrumented stdout/stderr must be byte-identical to the
+    # non-instrumented run. Any leak (instrumentation marker on stdout, extra
+    # stderr noise) would fail the diff.
+    : > "$LOG"
+    local with without
+    with=$(invoke_hook 2>&1)
+    without=$(invoke_hook_uninstrumented 2>&1)
+    if [ "$with" = "$without" ]; then
+        pass "instrumented output is byte-identical to non-instrumented output"
+    else
+        fail "instrumentation altered hook output. Diff:"
+        diff <(printf '%s' "$without") <(printf '%s' "$with") | sed 's/^/  /'
+    fi
+}
+
+test_unwritable_log_does_not_crash() {
+    local bad_log="/this/path/does/not/exist/fire.log"
+    if SDLC_HOOK_FIRE_LOG="$bad_log" CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        bash "$HOOK" <<<'{"prompt":"hello"}' > /dev/null 2>&1; then
+        pass "hook tolerates unwritable SDLC_HOOK_FIRE_LOG path (does not crash)"
+    else
+        fail "hook crashed when SDLC_HOOK_FIRE_LOG was unwritable"
+    fi
+}
+
+test_counter_records_first_invocation
+test_counter_appends_per_invocation
+test_counter_is_opt_in
+test_log_line_shape
+test_instrumentation_doesnt_break_output
+test_unwritable_log_does_not_crash
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All instrumentation tests passed."

--- a/tests/test-repo-complexity.sh
+++ b/tests/test-repo-complexity.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Test cli/lib/repo-complexity.js heuristic
+# Heuristic decides whether a repo is "simple" (good fit for mixed-mode:
+# Sonnet coder + Opus reviewer) or "complex" (full Opus tier recommended).
+#
+# Roadmap #233: introduces repo_complexity signal so setup wizard can suggest
+# mixed-mode for trivial/CRUD repos and reserve flagship Opus 4.7 for
+# fixture-deep, multi-workflow, secrets-touching repos.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../cli/lib/repo-complexity.js"
+FIXTURES="$SCRIPT_DIR/fixtures/complexity"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Repo Complexity Heuristic Tests (Roadmap #233) ==="
+echo ""
+
+# ---- Setup fixtures ----
+
+setup_simple_repo() {
+    local dir="$FIXTURES/simple-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src"
+    cat > "$dir/src/main.js" <<'EOF'
+function add(a, b) { return a + b; }
+module.exports = { add };
+EOF
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "tiny", "version": "0.1.0" }
+EOF
+}
+
+setup_complex_repo() {
+    local dir="$FIXTURES/complex-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests" "$dir/.claude/hooks" "$dir/.claude/skills" "$dir/.github/workflows"
+    # Many test files
+    for i in $(seq 1 35); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    # Many hooks
+    for h in pre-commit pre-push prepare-commit lint-check format-check tdd-check; do
+        echo "#!/bin/bash" > "$dir/.claude/hooks/$h.sh"
+        chmod +x "$dir/.claude/hooks/$h.sh"
+    done
+    # Many workflows
+    for wf in ci pr-review release deploy weekly-update monthly-research; do
+        echo "name: $wf" > "$dir/.github/workflows/$wf.yml"
+    done
+    # Decent LOC
+    for i in $(seq 1 50); do
+        for j in $(seq 1 20); do
+            echo "function fn_${i}_${j}(x) { return x * $j; }"
+        done
+    done > "$dir/src/main.js"
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "complex-repo", "version": "0.1.0" }
+EOF
+}
+
+setup_stakes_repo() {
+    local dir="$FIXTURES/stakes-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src"
+    echo "function noop() {}" > "$dir/src/main.js"
+    # .env file forces complex regardless of size
+    cat > "$dir/.env" <<'EOF'
+API_KEY=fake
+DATABASE_URL=postgres://fake
+EOF
+    cat > "$dir/package.json" <<'EOF'
+{ "name": "stakes-tiny", "version": "0.1.0" }
+EOF
+}
+
+# Codex finding #2: stakes detection must work at any depth.
+setup_nested_stakes_repo() {
+    local dir="$FIXTURES/nested-stakes-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/config" "$dir/app/secrets"
+    echo "function noop() {}" > "$dir/src/main.js"
+    cat > "$dir/config/.env" <<'EOF'
+API_KEY=fake-nested
+EOF
+    cat > "$dir/app/secrets/token.txt" <<'EOF'
+fake-token
+EOF
+}
+
+# Codex finding #3: just-below-threshold repo must classify as simple.
+# Per docs: simple = LOC<10K AND tests<30 AND hooks<5 AND workflows<5 AND no stakes.
+# Hits 4 mid signals; total score=4 but no high signals → simple.
+setup_boundary_simple_repo() {
+    local dir="$FIXTURES/boundary-simple-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests" "$dir/.claude/hooks" "$dir/.github/workflows"
+    # 29 tests (just below high threshold of 30)
+    for i in $(seq 1 29); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    # 4 hooks (just below high threshold of 5)
+    for h in pre-commit pre-push lint format; do
+        echo "#!/bin/bash" > "$dir/.claude/hooks/$h.sh"
+    done
+    # 4 workflows (just below high threshold of 5)
+    for wf in ci pr-review release deploy; do
+        echo "name: $wf" > "$dir/.github/workflows/$wf.yml"
+    done
+    # ~9000 LOC (just below high threshold of 10000)
+    for i in $(seq 1 450); do echo "// line filler $i: const x = $i;"; done > "$dir/src/main.js"
+}
+
+# Boundary complex: bump just one signal over its threshold → must classify as complex.
+setup_boundary_complex_repo() {
+    local dir="$FIXTURES/boundary-complex-repo"
+    rm -rf "$dir"
+    mkdir -p "$dir/src" "$dir/tests"
+    # 30 tests = high → complex
+    for i in $(seq 1 30); do
+        echo "describe('test $i', () => { it('works', () => {}); });" > "$dir/tests/spec-$i.test.js"
+    done
+    echo "function tiny() {}" > "$dir/src/main.js"
+}
+
+setup_simple_repo
+setup_complex_repo
+setup_stakes_repo
+setup_nested_stakes_repo
+setup_boundary_simple_repo
+setup_boundary_complex_repo
+
+# ---- Tests ----
+
+test_lib_exists() {
+    if [ -f "$LIB" ]; then
+        pass "cli/lib/repo-complexity.js exists"
+    else
+        fail "cli/lib/repo-complexity.js not found"
+    fi
+}
+
+test_simple_repo_classified_simple() {
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "simple repo classified as 'simple' (got: $tier)"
+    else
+        fail "simple repo classified as '$tier' (expected 'simple'). Output: $out"
+    fi
+}
+
+test_complex_repo_classified_complex() {
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/complex-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ]; then
+        pass "complex repo classified as 'complex' (got: $tier)"
+    else
+        fail "complex repo classified as '$tier' (expected 'complex'). Output: $out"
+    fi
+}
+
+test_stakes_repo_forces_complex() {
+    local out tier reasons
+    out=$(node "$LIB" "$FIXTURES/stakes-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ] && echo "$out" | /usr/bin/grep -qiE 'env|stake|secret'; then
+        pass "stakes repo (with .env) forced to 'complex' with reason"
+    else
+        fail "stakes repo got '$tier' without env/stakes reason. Output: $out"
+    fi
+}
+
+test_outputs_valid_json() {
+    local out
+    out=$(node "$LIB" "$FIXTURES/simple-repo" 2>&1)
+    if echo "$out" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+        pass "outputs valid JSON"
+    else
+        fail "output is not valid JSON: $out"
+    fi
+}
+
+test_includes_signals() {
+    local out
+    out=$(node "$LIB" "$FIXTURES/complex-repo" 2>&1)
+    if echo "$out" | python3 -c "import sys, json; d=json.load(sys.stdin); assert 'signals' in d and isinstance(d['signals'], list); assert len(d['signals']) > 0; print('ok')" 2>/dev/null | /usr/bin/grep -q ok; then
+        pass "output includes non-empty signals array"
+    else
+        fail "output missing signals or empty. Output: $out"
+    fi
+}
+
+test_handles_missing_dir_gracefully() {
+    local out exit_code
+    out=$(node "$LIB" "/nonexistent-path-12345" 2>&1) || exit_code=$?
+    if [ "${exit_code:-0}" -ne 0 ] || echo "$out" | /usr/bin/grep -qi error; then
+        pass "missing dir is reported as error (exit $exit_code or 'error' in output)"
+    else
+        fail "missing dir did not produce error. Output: $out, exit: ${exit_code:-0}"
+    fi
+}
+
+test_nested_env_forces_complex() {
+    local out tier signals
+    out=$(node "$LIB" "$FIXTURES/nested-stakes-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ] && echo "$out" | /usr/bin/grep -q "config/.env" && echo "$out" | /usr/bin/grep -qE "stakes:dir:.*secrets"; then
+        pass "nested .env (config/.env) and nested secrets/ dir detected and force complex"
+    else
+        fail "nested stakes not detected. tier=$tier. Output: $out"
+    fi
+}
+
+test_boundary_simple_classified_simple() {
+    # Per docs: LOC<10K, tests<30, hooks<5, workflows<5, no stakes → simple
+    # Even if all four signals are mid-band (additive score=4), no high → simple.
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/boundary-simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "boundary-simple repo (29 tests, 4 hooks, 4 workflows, ~9K LOC) → simple"
+    else
+        fail "boundary-simple repo classified as '$tier' (expected 'simple'). Output: $out"
+    fi
+}
+
+test_boundary_complex_classified_complex() {
+    # 30 tests crosses the high threshold → must classify as complex.
+    local out tier
+    out=$(node "$LIB" "$FIXTURES/boundary-complex-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "complex" ]; then
+        pass "boundary-complex repo (30 tests = high threshold) → complex"
+    else
+        fail "boundary-complex repo classified as '$tier' (expected 'complex'). Output: $out"
+    fi
+}
+
+test_cli_complexity_subcommand() {
+    # Codex finding #1: docs reference `npx agentic-sdlc-wizard complexity .` — must work via the CLI bin
+    local cli="$SCRIPT_DIR/../cli/bin/sdlc-wizard.js"
+    local out tier
+    out=$(node "$cli" complexity "$FIXTURES/simple-repo" 2>&1)
+    tier=$(echo "$out" | /usr/bin/grep -oE '"tier"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -1 | /usr/bin/grep -oE '"[a-z]+"$' | tr -d '"')
+    if [ "$tier" = "simple" ]; then
+        pass "CLI subcommand 'complexity' works and returns valid output"
+    else
+        fail "CLI subcommand 'complexity' did not return tier=simple. Output: $out"
+    fi
+}
+
+test_lib_exists
+test_simple_repo_classified_simple
+test_complex_repo_classified_complex
+test_stakes_repo_forces_complex
+test_nested_env_forces_complex
+test_boundary_simple_classified_simple
+test_boundary_complex_classified_complex
+test_cli_complexity_subcommand
+test_outputs_valid_json
+test_includes_signals
+test_handles_missing_dir_gracefully
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
## Summary

- **#207 Community feature-discovery scanner** — `tests/e2e/scan-community.sh` extracts unknown `/[a-z][a-z0-9-]*` slash-command mentions from transcript text (Reddit / HN / Discord exports), dedupes against `tests/e2e/known-slash-commands.txt` allowlist, emits JSON digest of candidates with count + sample. Replaces the deleted CI scan-community job (per ROADMAP #231 Phase 3) with a maintainer-runnable offline scan.

## What's in the allowlist

- Wizard skills: `/sdlc`, `/setup`, `/update`, `/feedback`, `/code-review`, `/less-permission-prompts`, `/claude-automation-recommender`, `/schedule`, `/ultrareview`
- CC native (as of 2.1.118): `/help`, `/clear`, `/model`, `/effort`, `/usage`, `/cost`, `/stats`, `/compact`, `/resume`, `/init`, `/mcp`, `/plugin`, `/agents`, `/hooks`, `/permissions`, `/sandbox`, `/fast`, `/exit`, `/login`, `/logout`, `/doctor`, `/install`, `/uninstall`, `/settings`
- URL-path false positives: `/dev`, `/usr`, `/var`, `/tmp`, `/etc`, `/bin`, `/lib`, `/opt`, `/home`, `/root`, `/proc`, `/sys`, `/run`, `/mnt`, `/media`, `/srv`

Length-≥4 filter drops `/a`/`/ab` style noise.

## Tests

14/14 `tests/test-community-scanner.sh` (NEW): detection, allowlist filter (CC native + wizard skills), case-insensitive extraction, dedup + count, empty-input, JSON shape, stdin input, multi-file aggregation, sample-context inclusion, long-line sample window, dash-leading filename. All other test suites green.

## Cross-model review

Codex 3-round: round 1 6/10 NOT CERTIFIED (5 findings — orphan tests not in CI [fixed in parent commit], case-sensitive extraction, sample truncation, stale 1.38.0 in update skill, dash-leading filename), round 2 8/10 NOT CERTIFIED (5 findings FIXED but git index UU pending), round 3 10/10 CERTIFIED.

## Stacked on top of v1.38.0

This PR depends on #243 (v1.38.0). Merge #243 first; rebase this PR if needed.

## Test plan

- [ ] CI `validate` job passes (depends on #243's CI fix landing)
- [ ] PR review job passes (advisory)
- [ ] Manual: `echo "Try /unknownthing in this prompt" | bash tests/e2e/scan-community.sh -` → expect `/unknownthing` in candidates