### PR TITLE
v1.40.0: CLI version detection in /update-wizard (#232)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.39.1",
+      "version": "1.40.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,9 @@ jobs:
       - name: Run update-skill Step 7.7 hoist tests (v1.39.1)
         run: ./tests/test-update-skill-step-7-7.sh
 
+      - name: Run update-skill CLI version tests (#232)
+        run: ./tests/test-update-skill-cli-version.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.40.0] - 2026-04-25
+
+### Added
+
+- **CLI version detection in /update-wizard** (ROADMAP #232). New Step 1.5 detects the locally installed `agentic-sdlc-wizard` CLI version (via `npm ls -g` for global installs and `~/.npm/_npx` cache inspection for npx users), compares to the npm registry latest at `registry.npmjs.org/agentic-sdlc-wizard/latest`, and surfaces a one-shot `npx -y agentic-sdlc-wizard@latest init --force` upgrade BEFORE running drift detection or per-file updates. Closes the gap where `/update-wizard` patched in-session project files but the user's stale npx cache kept running an old CLI on `init`/`check`/`complexity` invocations. Mirrors `claude update` UX (one-shot CLI + skill sync). Honors the `check-only` flag in report-only mode (no auto-upgrade). Graceful fallback when the CLI is undetectable (custom install, offline). New `tests/test-update-skill-cli-version.sh` (8 quality tests) covers step structure, both detection paths, the registry endpoint, the upgrade command, ordering before per-file plan, `check-only` precedence, fallback wording, and the changelog entry itself.
+
 ## [1.39.1] - 2026-04-25
 
 ### Fixed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2832,7 +2832,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.39.1 -->
+<!-- SDLC Wizard Version: 1.40.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3894,7 +3894,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.39.1 -->
+<!-- SDLC Wizard Version: 1.40.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-prompt-hook-fires-once.sh && \
    ./tests/test-community-scanner.sh && \
    ./tests/test-update-skill-step-7-7.sh && \
+   ./tests/test-update-skill-cli-version.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.39.1 -->
+<!-- SDLC Wizard Version: 1.40.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.39.1 |
+| Wizard Version | 1.40.0 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -31,6 +31,91 @@ If no version comment exists, treat as `0.0.0` (first-time setup — suggest run
 
 Also note the completed steps from `<!-- Completed Steps: ... -->`.
 
+### Step 1.5: Check CLI Version (ROADMAP #232)
+
+The wizard files in the user's project (skills, hooks, settings.json) are one half of the install. The other half is the **npm CLI** (`agentic-sdlc-wizard`) — the binary that powers `npx agentic-sdlc-wizard init`, `check`, and `complexity`. If the user ran `npx agentic-sdlc-wizard init` months ago, their npx cache (or global install) can be stuck on an old version even after `/update-wizard` patches the project files in-session. This step closes that gap: detect the locally installed CLI version, compare to the npm registry latest, and surface a one-shot upgrade BEFORE running drift detection or per-file updates.
+
+**Detection — try both paths, in order:**
+
+1. **Global install** (rare but possible): `npm ls -g agentic-sdlc-wizard --json --depth=0 2>/dev/null | jq -r '.dependencies["agentic-sdlc-wizard"].version // empty'` — emits the version if globally installed, empty otherwise.
+
+2. **npx cache** (the common case): find every `package.json` in npx's cache layout, extract `.version`, then pick the largest by semver. Do NOT use `sort -u | tail -1` — that's lexicographic and treats `1.9.0 > 1.10.0`. Use Node's built-in semver-aware compare:
+
+   ```bash
+   find ~/.npm/_npx -maxdepth 4 -name 'package.json' -path '*agentic-sdlc-wizard*' 2>/dev/null \
+     | xargs -I{} jq -r '.version' {} 2>/dev/null \
+     | node -e "
+       let max = '';
+       require('readline').createInterface({input: process.stdin}).on('line', v => {
+         if (!v) return;
+         if (!max || cmp(v, max) > 0) max = v;
+       }).on('close', () => process.stdout.write(max));
+       function cmp(a, b) {
+         const [ab, ap] = a.split('-'), [bb, bp] = b.split('-');
+         const an = ab.split('.').map(Number), bn = bb.split('.').map(Number);
+         for (let i = 0; i < 3; i++) if (an[i] !== bn[i]) return an[i] - bn[i];
+         if (ap && !bp) return -1; if (!ap && bp) return 1;
+         if (ap && bp) return ap < bp ? -1 : ap > bp ? 1 : 0;
+         return 0;
+       }
+     "
+   ```
+
+   This reads each found version on its own line, compares pairwise with semver semantics (numeric major.minor.patch, plus prerelease tags ordered as `1.40.0-beta.1 < 1.40.0`), and prints the maximum. Empty input prints empty.
+
+If both paths return empty, the user may be running from a custom install or has never used `npx`. Treat as **undetectable** — note it in your update report but do not block the rest of the flow. Skip the CLI bump prompt, continue to Step 2.
+
+**Registry comparison:**
+
+```bash
+curl -fsS "https://registry.npmjs.org/agentic-sdlc-wizard/latest" | jq -r '.version'
+```
+
+This is the same endpoint the registry serves; the response is a single JSON object with `version` set to the published latest tag. Cache the result (it's also used in Step 3 for the wizard version comparison).
+
+**Compare with semver-aware logic** — `sort -V` does NOT correctly order prereleases (it places `1.40.0-beta.1` *after* `1.40.0`, but semver requires the opposite). Use the same Node `cmp()` helper from the npx-cache step:
+
+```bash
+node -e "
+  const a = process.argv[1], b = process.argv[2];
+  function cmp(a, b) { /* same body as above */ }
+  process.exit(cmp(a, b) < 0 ? 0 : cmp(a, b) > 0 ? 1 : 2);
+" "$INSTALLED" "$LATEST"
+# Exit 0 = installed < latest (behind); 1 = installed > latest; 2 = equal
+```
+
+**Surface based on the result:**
+
+- `installed == latest` → silent, continue to Step 2.
+- `installed < latest` → surface the gap with the upgrade options below.
+- `installed > latest` (rare — pre-release or local dev install) → silent, continue.
+
+**Upgrade options when behind:** be honest about what each does. Recommend the safer path by default.
+
+  > Your locally installed `agentic-sdlc-wizard` CLI is at **{installed}**, but npm has **{latest}**. The in-session `/update-wizard` will refresh this project's files via Step 6's per-file plan, but your `npx` cache will keep the old CLI on disk for `npx agentic-sdlc-wizard check`/`init`/`complexity` calls.
+  >
+  > Pick one:
+  >
+  > **A. Refresh just the CLI cache (recommended).** Doesn't touch your project files. Then `/update-wizard`'s per-file plan handles the rest with diffs:
+  > ```bash
+  > npx -y agentic-sdlc-wizard@latest --version
+  > ```
+  >
+  > **B. One-shot CLI + project re-init.** Refreshes the CLI AND overwrites *non-settings* managed files (skills, hooks, templates) with the latest versions. `settings.json` is smart-merged (custom hooks + permissions preserved); other managed files are NOT smart-merged — local edits to them are lost unless committed to git or backed up. Use this if you don't have local skill/hook customizations:
+  > ```bash
+  > npx -y agentic-sdlc-wizard@latest init --force
+  > ```
+  >
+  > **C. Skip the CLI bump entirely.** Keep the stale CLI; this session's file updates apply but `npx agentic-sdlc-wizard check` will keep using the old drift logic.
+  >
+  > Pick A, B, or C: `[A/B/C]`
+
+  If A: prompt the user to run the one-liner in their shell, then re-invoke `/update-wizard`. If B: same, with the warning about non-settings overwrite. If C: log the choice and continue with in-session file updates only. Default (no response) → A.
+
+**`check-only` precedence:** if the user passed `check-only`, Step 1.5 runs in report-only mode — print the gap if found, but do NOT prompt and do NOT run `init --force`. The check-only contract is "tell me what's drifted, don't change anything," and that supersedes the CLI bump path.
+
+**Why this lives at Step 1.5, not later:** subsequent steps shell out to `npx agentic-sdlc-wizard check` (Step 4) and rely on the CLI's drift heuristics. If the CLI is stale, Step 4 reports based on the OLD definition of "managed files" and may miss new templates entirely. Detecting + surfacing CLI staleness up front lets the user choose whether to refresh first.
+
 ### Step 2: Fetch Latest CHANGELOG
 
 Use WebFetch to fetch the CHANGELOG:
@@ -46,9 +131,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.39.1
+Latest:    1.40.0
 
 What changed:
+- [1.40.0] CLI version detection in /update-wizard — ROADMAP #232. New Step 1.5 detects locally installed `agentic-sdlc-wizard` CLI version (npm ls + npx cache inspection, both with semver-aware ordering), compares to `registry.npmjs.org/agentic-sdlc-wizard/latest`, and surfaces a 3-way upgrade choice BEFORE drift detection: A) refresh CLI cache only (default, safest), B) `init --force` re-init with explicit non-settings overwrite warning, C) skip. Closes the gap where in-session file updates landed but the user's stale npx cache kept running an old CLI. Mirrors `claude update` UX. 8 quality tests, mutation-verified.
 - [1.39.1] Step 7.7 hoist — dead-plugin cleanup now runs even when wizard versions match. Previously `/update-wizard` exited at "you're up to date" before reaching Step 7.7, so users on the latest wizard with a stale `~/.claude/settings.json` plugin registration were never offered cleanup. New `tests/test-update-skill-step-7-7.sh` (8 quality tests) guards the ordering.
 - [1.39.0] Community feature-discovery scanner — ROADMAP #207. `tests/e2e/scan-community.sh` extracts unknown `/slash-command` mentions from transcript text (Reddit / HN / Discord exports), dedupes against `tests/e2e/known-slash-commands.txt` allowlist, emits JSON digest of candidates with count + sample. Replaces the deleted CI scan-community job (per #231 Phase 3) with a maintainer-runnable offline scan. 14 quality tests.
 - [1.38.0] Mixed-mode tier (Sonnet 4.6 coder + Opus 4.7 reviewer) for simple repos — ROADMAP #233. New `cli/lib/repo-complexity.js` heuristic + `npx agentic-sdlc-wizard complexity .` CLI command. Setup Step 9.5 expanded from binary y/N to 3-way (no-pin / mixed / flagship). Cross-model review always stays at flagship regardless of coder pin. Reconciles with #198: mixed-mode is opt-in per-project; no-pin remains the default. Plus ROADMAP #224 prompt-hook-fires-once instrumentation (opt-in `SDLC_HOOK_FIRE_LOG`).

--- a/tests/test-update-skill-cli-version.sh
+++ b/tests/test-update-skill-cli-version.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Quality test: /update-wizard must detect stale local CLI before in-session file updates.
+#
+# ROADMAP #232: previously /update-wizard fetched the latest wizard files from GitHub raw
+# and patched in-session, but the user's local npx-cached CLI (the thing that runs `check`,
+# `init`, etc.) could remain on an old version forever. Symptom: user sees "you're up to
+# date" on wizard files, but their `npx agentic-sdlc-wizard ...` is still 1.30.0 missing
+# the latest drift heuristics. v1.40.0 adds a dedicated CLI version step that fetches the
+# npm registry latest, compares to whatever is actually installed locally, and offers a
+# one-shot upgrade BEFORE running drift detection or per-file updates.
+
+set -e
+
+SKILL="${SKILL:-skills/update/SKILL.md}"
+CHANGELOG="${CHANGELOG:-CHANGELOG.md}"
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+if [ ! -f "$SKILL" ]; then
+    echo "FAIL: $SKILL not found"
+    exit 1
+fi
+
+# Extract the CLI Version step BLOCK first — every body assertion below must scope to
+# this block, not the whole skill, to prevent CHANGELOG-sample false-greens (AUDIT-001).
+cli_step_block=$(awk '
+  /^### Step [0-9]+(\.[0-9]+)?: .*CLI Version/ { flag=1; next }
+  /^### Step [0-9]/ && flag { flag=0 }
+  flag { print }
+' "$SKILL")
+
+# ---------------------------------------------------------------------------
+# Test 1: A dedicated CLI version step exists.
+# ---------------------------------------------------------------------------
+if grep -qE "^### Step [0-9]+(\.[0-9]+)?: .*CLI Version" "$SKILL"; then
+    pass "Skill has a CLI Version check step"
+else
+    fail "Skill missing dedicated CLI version check step"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Step body references the npm registry latest endpoint.
+# Scoped to the Step 1.5 block (AUDIT-001 fix).
+# ---------------------------------------------------------------------------
+if [ -n "$cli_step_block" ] && echo "$cli_step_block" | grep -qE "registry\.npmjs\.org/agentic-sdlc-wizard"; then
+    pass "CLI step body references npm registry latest endpoint"
+else
+    fail "CLI step body must fetch registry version from registry.npmjs.org/agentic-sdlc-wizard"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Step body describes BOTH detection paths (npm ls + npx cache).
+# Scoped to the Step 1.5 block.
+# ---------------------------------------------------------------------------
+has_npm_ls=$(echo "$cli_step_block" | grep -cE "npm ls.*agentic-sdlc-wizard" || true)
+has_npx_cache=$(echo "$cli_step_block" | grep -cE "_npx" || true)
+if [ "$has_npm_ls" -gt 0 ] && [ "$has_npx_cache" -gt 0 ]; then
+    pass "CLI step body describes both detection paths (npm ls + npx cache)"
+else
+    fail "CLI step body must describe both 'npm ls' (global install) AND '_npx' cache inspection (npx users)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Step body recommends the one-shot upgrade command.
+# Scoped to the Step 1.5 block (AUDIT-001 fix).
+# ---------------------------------------------------------------------------
+if echo "$cli_step_block" | grep -qE "npx.*-y.*agentic-sdlc-wizard@latest"; then
+    pass "CLI step body recommends one-shot upgrade with npx -y agentic-sdlc-wizard@latest"
+else
+    fail "CLI step body must recommend 'npx -y agentic-sdlc-wizard@latest' as part of the upgrade path"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: CLI version check runs BEFORE the per-file update plan, by ACTUAL
+# LINE NUMBER (AUDIT-002 fix — numeric step parsing alone is insufficient).
+# Verify Step 1.5 line number sits strictly between Step 1 and Step 2 lines.
+# ---------------------------------------------------------------------------
+cli_line=$(grep -nE "^### Step [0-9]+(\.[0-9]+)?: .*CLI Version" "$SKILL" | head -1 | cut -d: -f1)
+step1_line=$(grep -nE "^### Step 1: " "$SKILL" | head -1 | cut -d: -f1)
+step2_line=$(grep -nE "^### Step 2: " "$SKILL" | head -1 | cut -d: -f1)
+step6_line=$(grep -nE "^### Step 6: " "$SKILL" | head -1 | cut -d: -f1)
+if [ -n "$cli_line" ] && [ -n "$step1_line" ] && [ -n "$step2_line" ] && [ -n "$step6_line" ] \
+    && [ "$cli_line" -gt "$step1_line" ] \
+    && [ "$cli_line" -lt "$step2_line" ] \
+    && [ "$cli_line" -lt "$step6_line" ]; then
+    pass "CLI step at line $cli_line sits between Step 1 (line $step1_line) and Step 2 (line $step2_line) and well before Step 6 (line $step6_line)"
+else
+    fail "CLI step ordering wrong by line number — must be between Step 1 and Step 2 (and well before Step 6 / per-file plan)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: Step honors check-only — must NOT execute the upgrade automatically;
+# must just report the gap when check-only is set.
+# ---------------------------------------------------------------------------
+if echo "$cli_step_block" | grep -qE "check-only"; then
+    pass "CLI step honors check-only flag (no auto-upgrade)"
+else
+    fail "CLI step must explicitly honor check-only (report-only, no automatic init --force)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Step warns/notes when the CLI cannot be detected (offline, custom install).
+# Otherwise a missing detection silently turns into "you're current" — false negative.
+# ---------------------------------------------------------------------------
+if echo "$cli_step_block" | grep -qiE "cannot detect|detection fail|unknown|skip|fallback"; then
+    pass "CLI step has graceful fallback for undetectable installs"
+else
+    fail "CLI step must describe what to do when local CLI version cannot be detected (graceful fallback)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: CHANGELOG [1.40.0] entry documents the CLI version detection feature.
+# ---------------------------------------------------------------------------
+if grep -qE "^## \[1\.40\.0\]" "$CHANGELOG"; then
+    cl_entry=$(awk '/^## \[1\.40\.0\]/,/^## \[1\.39\.1\]/' "$CHANGELOG" | sed '$d')
+    if echo "$cl_entry" | grep -qiE "CLI version|stale CLI|npx cache|registry\.npmjs"; then
+        pass "CHANGELOG [1.40.0] documents CLI version detection"
+    else
+        fail "CHANGELOG [1.40.0] must mention the CLI version detection (CLI version / npx cache / registry)"
+    fi
+else
+    fail "CHANGELOG must have a [1.40.0] entry"
+fi
+
+# Negative control: removing the CLI step from a temp copy must fail tests 1, 2, 3, 4, 5, 6, 7.
+# Mutation test runs in cross-model review.
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary
- ROADMAP #232: /update-wizard now detects the locally installed agentic-sdlc-wizard CLI version (npm ls + npx cache, both with semver-aware ordering) and surfaces a 3-way upgrade prompt before in-session file updates. Mirrors `claude update` UX.
- Closes the gap where in-session file updates landed but the user's stale npx cache kept running an old CLI binary on `init`/`check`/`complexity` calls.
- Honest about `--force` behavior — non-settings managed files get overwritten under --force, only settings.json is smart-merged. Default option is the safest (CLI cache refresh only, no project file changes).

## Codex Review
- Round 1: 5/10 NOT CERTIFIED. 5 P1 findings (test mutation control, ordering test false-green, prerelease semver, lexicographic cache sort, --force claim).
- Round 2: 10/10 CERTIFIED. All 5 fixes verified via mutation tests.

## Test plan
- [x] tests/test-update-skill-cli-version.sh — 8 quality tests, mutation-verified (Step 1.5 removed → 1-7 fail; Step 5.5 placement → test 5 fails)
- [x] tests/test-update-skill-step-7-7.sh — 8/8 (v1.39.1 still works)
- [x] tests/test-doc-consistency.sh — 22/22 (version bump consistent)
- [x] tests/test-hooks.sh, test-cli.sh, test-version-logic.sh, test-compliance.sh, test-community-scanner.sh, test-prompt-hook-fires-once.sh, test-repo-complexity.sh, test-plugin.sh — all green
- [x] Codex CERTIFIED 10/10 round 2

## Files changed
- skills/update/SKILL.md — new Step 1.5 with semver-aware comparison + 3-way prompt
- tests/test-update-skill-cli-version.sh — new (8 tests)
- .github/workflows/ci.yml + CONTRIBUTING.md — wire test
- package.json, plugin.json, marketplace.json, SDLC.md, CLAUDE_CODE_SDLC_WIZARD.md — version 1.39.1 → 1.40.0
- CHANGELOG.md — [1.40.0] entry