### PR TITLE
v1.40.1: cleanupPeriodDays: 30 pinned + smart-merge (#225)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,9 @@ jobs:
       - name: Run update-skill CLI version tests (#232)
         run: ./tests/test-update-skill-cli-version.sh
 
+      - name: Run cleanup-period guidance tests (#225)
+        run: ./tests/test-cleanup-period-guidance.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/fixtures/community-scanner/
 
 # Claude Code local state
 .claude/plans/
+.claude/hooks/
 
 # Review artifacts (local Codex/cross-model reviews)
 .reviews/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.40.1] - 2026-04-26
+
+### Added
+
+- **`cleanupPeriodDays: 30` pinned in template settings** (ROADMAP #225). CC 2.1.117 expanded `cleanupPeriodDays` to also cover `~/.claude/tasks/` — the directory where the Tasks system persists in-progress TodoWrite state. With aggressive defaults (some CC versions defaulted to 7 days), SDLC checklists for paused long-running features could be silently pruned. `cli/templates/settings.json` now ships `"cleanupPeriodDays": 30` as a top-level field. `CLAUDE_CODE_SDLC_WIZARD.md` documents the gotcha + override path. New `tests/test-cleanup-period-guidance.sh` (7 tests) asserts template default + wizard rationale don't regress.
+
 ## [1.40.0] - 2026-04-25
 
 ### Added

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -311,6 +311,14 @@ If you notice Claude Code producing shallow outputs despite `effort: high`, add 
 
 **Rollback if issues**: Set `CLAUDE_CODE_ENABLE_TASKS=false` environment variable.
 
+#### Known CC gotcha: `cleanupPeriodDays` and TodoWrite retention (CC 2.1.117+)
+
+CC 2.1.117 expanded the `cleanupPeriodDays` setting to also cover `~/.claude/tasks/` — the directory where the Tasks system persists in-progress TodoWrite state across sessions. If `cleanupPeriodDays` is too low (CC's default has been as aggressive as 7 days in some versions), an SDLC checklist for a paused long-running feature can be silently pruned out from under you.
+
+**Wizard pins a safe default**: `cli/templates/settings.json` ships `"cleanupPeriodDays": 30`. The wizard's SDLC skill makes TodoWrite step 1 of every task, so the floor matters. Recommendation: keep it at **30 or higher** if you ever pause work for more than a week. If a task list disappears mid-cycle, check this setting first.
+
+**To override**: set `cleanupPeriodDays` to a higher number in your project's `.claude/settings.json`. The CLI's smart-merge preserves user overrides on `init --force`.
+
 ### Skill Arguments with $ARGUMENTS (v2.1.19+)
 
 **What changed**: Skills can now accept parameters via `$ARGUMENTS` placeholder.
@@ -2832,7 +2840,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.40.0 -->
+<!-- SDLC Wizard Version: 1.40.1 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3894,7 +3902,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.40.0 -->
+<!-- SDLC Wizard Version: 1.40.1 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-community-scanner.sh && \
    ./tests/test-update-skill-step-7-7.sh && \
    ./tests/test-update-skill-cli-version.sh && \
+   ./tests/test-cleanup-period-guidance.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.40.0 -->
+<!-- SDLC Wizard Version: 1.40.1 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.40.0 |
+| Wizard Version | 1.40.1 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/cli/init.js
+++ b/cli/init.js
@@ -78,6 +78,15 @@ function mergeSettings(existingPath, templatePath, force) {
       existing.model = template.model;
     }
 
+    // Merge cleanupPeriodDays (ROADMAP #225): only set the template default when
+    // the user has not chosen a value. NEVER overwrite under --force — retention
+    // policy is a user preference (they may want >30 for long pauses, or <30 for
+    // disk-tight setups). The wizard's job is to provide a safe floor on fresh
+    // installs, not to clobber an explicit choice.
+    if ('cleanupPeriodDays' in template && !('cleanupPeriodDays' in existing)) {
+      existing.cleanupPeriodDays = template.cleanupPeriodDays;
+    }
+
     // Merge env field
     if (template.env) {
       if (!existing.env || typeof existing.env !== 'object' || Array.isArray(existing.env)) {

--- a/cli/templates/settings.json
+++ b/cli/templates/settings.json
@@ -1,4 +1,5 @@
 {
+  "cleanupPeriodDays": 30,
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -131,9 +131,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.40.0
+Latest:    1.40.1
 
 What changed:
+- [1.40.1] cleanupPeriodDays: 30 pinned in template — ROADMAP #225. CC 2.1.117 expanded `cleanupPeriodDays` to also cover `~/.claude/tasks/`. Aggressive defaults could prune in-progress TodoWrite checklists for paused long-running features. Wizard now ships a 30-day floor + documented gotcha. 7 quality tests.
 - [1.40.0] CLI version detection in /update-wizard — ROADMAP #232. New Step 1.5 detects locally installed `agentic-sdlc-wizard` CLI version (npm ls + npx cache inspection, both with semver-aware ordering), compares to `registry.npmjs.org/agentic-sdlc-wizard/latest`, and surfaces a 3-way upgrade choice BEFORE drift detection: A) refresh CLI cache only (default, safest), B) `init --force` re-init with explicit non-settings overwrite warning, C) skip. Closes the gap where in-session file updates landed but the user's stale npx cache kept running an old CLI. Mirrors `claude update` UX. 8 quality tests, mutation-verified.
 - [1.39.1] Step 7.7 hoist — dead-plugin cleanup now runs even when wizard versions match. Previously `/update-wizard` exited at "you're up to date" before reaching Step 7.7, so users on the latest wizard with a stale `~/.claude/settings.json` plugin registration were never offered cleanup. New `tests/test-update-skill-step-7-7.sh` (8 quality tests) guards the ordering.
 - [1.39.0] Community feature-discovery scanner — ROADMAP #207. `tests/e2e/scan-community.sh` extracts unknown `/slash-command` mentions from transcript text (Reddit / HN / Discord exports), dedupes against `tests/e2e/known-slash-commands.txt` allowlist, emits JSON digest of candidates with count + sample. Replaces the deleted CI scan-community job (per #231 Phase 3) with a maintainer-runnable offline scan. 14 quality tests.

--- a/tests/test-cleanup-period-guidance.sh
+++ b/tests/test-cleanup-period-guidance.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Quality test: cleanupPeriodDays ≥ 30 in template + wizard doc warns about retention.
+#
+# ROADMAP #225: CC 2.1.117 changed `cleanupPeriodDays` to also cover `~/.claude/tasks/`.
+# The SDLC skill uses `TodoWrite` as step 1 of every task, persisted under that dir.
+# An aggressive retention policy (e.g. 7 days, default in some CC versions) could
+# prune in-progress SDLC checklists from paused long-running features. Wizard pins
+# the setting to a safe explicit default in cli/templates/settings.json AND documents
+# the gotcha in CLAUDE_CODE_SDLC_WIZARD.md.
+
+set -e
+
+TEMPLATE="${TEMPLATE:-cli/templates/settings.json}"
+WIZARD="${WIZARD:-CLAUDE_CODE_SDLC_WIZARD.md}"
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "FAIL: $TEMPLATE not found"
+    exit 1
+fi
+if [ ! -f "$WIZARD" ]; then
+    echo "FAIL: $WIZARD not found"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1: cli/templates/settings.json has cleanupPeriodDays as a top-level field.
+# ---------------------------------------------------------------------------
+if jq -e '.cleanupPeriodDays' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "cli/templates/settings.json defines cleanupPeriodDays"
+else
+    fail "cli/templates/settings.json must define cleanupPeriodDays as top-level field"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: cleanupPeriodDays >= 30 (safe floor for TodoWrite retention).
+# ---------------------------------------------------------------------------
+period=$(jq -r '.cleanupPeriodDays // empty' "$TEMPLATE" 2>/dev/null)
+if [ -n "$period" ] && [ "$period" -ge 30 ] 2>/dev/null; then
+    pass "cleanupPeriodDays ($period) >= 30 (safe floor for TodoWrite retention)"
+else
+    fail "cleanupPeriodDays must be >= 30 — got '$period'"
+fi
+
+# ---------------------------------------------------------------------------
+# Tests 3-5 must scope to the new "Known CC gotcha" subsection inside Tasks
+# System. Generic grep over the whole wizard doc false-greens because earlier
+# Tasks System paragraphs already mention TodoWrite. Extract the cleanupPeriodDays
+# subsection by header range.
+# ---------------------------------------------------------------------------
+gotcha_section=$(awk '
+  /^#### Known CC gotcha:.*cleanupPeriodDays/ { flag=1; next }
+  /^### / && flag { flag=0 }
+  /^#### / && flag { flag=0 }
+  flag { print }
+' "$WIZARD")
+
+# Test 3: subsection exists AND mentions cleanupPeriodDays.
+if [ -n "$gotcha_section" ] && echo "$gotcha_section" | grep -qE "cleanupPeriodDays"; then
+    pass "Wizard 'Known CC gotcha' subsection references cleanupPeriodDays"
+else
+    fail "Wizard must have a 'Known CC gotcha' subsection that references cleanupPeriodDays"
+fi
+
+# Test 4: subsection mentions the >= 30 recommendation.
+if echo "$gotcha_section" | grep -qE "cleanupPeriodDays.*30|30.*cleanupPeriodDays|>=.*30|at least 30|30 or higher"; then
+    pass "Wizard subsection recommends cleanupPeriodDays >= 30"
+else
+    fail "Wizard subsection must recommend a >= 30 retention floor explicitly"
+fi
+
+# Test 5: subsection explains WHY (TodoWrite/tasks would be pruned).
+if echo "$gotcha_section" | grep -qiE "TodoWrite|tasks.*pruned|tasks.*lost|in-progress.*pruned|persistent.*tasks|tasks/.*directory|~/.claude/tasks"; then
+    pass "Wizard subsection explains retention rationale (TodoWrite/tasks lost if too low)"
+else
+    fail "Wizard subsection must explain WHY 30+ days matters (TodoWrite persistence under ~/.claude/tasks/)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: Template settings.json still parses as valid JSON.
+# ---------------------------------------------------------------------------
+if jq empty "$TEMPLATE" 2>/dev/null; then
+    pass "cli/templates/settings.json is valid JSON"
+else
+    fail "cli/templates/settings.json must be valid JSON"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: All 5 template hook events preserved (regression guard).
+# ---------------------------------------------------------------------------
+if jq -e '
+  .hooks.UserPromptSubmit and
+  .hooks.PreToolUse and
+  .hooks.InstructionsLoaded and
+  .hooks.SessionStart and
+  .hooks.PreCompact
+' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "Template hooks block preserved (all 5 events: UserPromptSubmit, PreToolUse, InstructionsLoaded, SessionStart, PreCompact)"
+else
+    fail "Template hooks block regressed — must keep all 5 hook events (UserPromptSubmit, PreToolUse, InstructionsLoaded, SessionStart, PreCompact)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -578,6 +578,49 @@ FIXTURE
     rm -rf "$d"
 }
 
+# Test 29.1: cleanupPeriodDays default applied when missing from existing settings (#225)
+test_cleanup_period_default_applied() {
+    local d
+    d=$(make_temp)
+    mkdir -p "$d/.claude"
+    cat > "$d/.claude/settings.json" << 'FIXTURE'
+{
+  "allowedTools": ["Read"]
+}
+FIXTURE
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    local val
+    val=$(jq -r '.cleanupPeriodDays // empty' "$d/.claude/settings.json" 2>/dev/null)
+    if [ "$val" = "30" ]; then
+        pass "cleanupPeriodDays default (30) applied when missing"
+    else
+        fail "cleanupPeriodDays default should be applied when missing — got '$val'"
+    fi
+    rm -rf "$d"
+}
+
+# Test 29.2: cleanupPeriodDays user override preserved on init --force (#225)
+test_cleanup_period_user_override_preserved() {
+    local d
+    d=$(make_temp)
+    mkdir -p "$d/.claude"
+    cat > "$d/.claude/settings.json" << 'FIXTURE'
+{
+  "cleanupPeriodDays": 90,
+  "allowedTools": ["Read"]
+}
+FIXTURE
+    (cd "$d" && node "$CLI" init --force > /dev/null 2>&1)
+    local val
+    val=$(jq -r '.cleanupPeriodDays // empty' "$d/.claude/settings.json" 2>/dev/null)
+    if [ "$val" = "90" ]; then
+        pass "cleanupPeriodDays user override (90) preserved under --force"
+    else
+        fail "cleanupPeriodDays user override should be preserved under --force — got '$val' (expected 90)"
+    fi
+    rm -rf "$d"
+}
+
 # Test 30: init removes obsolete .claude/skills/testing/ on fresh install
 test_upgrade_removes_obsolete_testing() {
     local d
@@ -643,6 +686,8 @@ test_merge_invalid_json_fallback
 test_merge_force_invalid_json
 test_merge_idempotent
 test_merge_force_updates_hooks
+test_cleanup_period_default_applied
+test_cleanup_period_user_override_preserved
 test_upgrade_removes_obsolete_testing
 test_upgrade_removes_testing_on_skip_path
 


### PR DESCRIPTION
## Summary
- ROADMAP #225: CC 2.1.117 expanded `cleanupPeriodDays` to also cover `~/.claude/tasks/` where TodoWrite state persists. Aggressive defaults could prune in-progress SDLC checklists. Wizard now ships `cleanupPeriodDays: 30` as a safe floor and documents the gotcha.
- `cli/init.js mergeSettings` now preserves user overrides on this field — never overwrites under `--force` (retention policy is a user preference).
- 7 new quality tests (mutation-verified) + 2 new CLI merge tests (72 total).

## Codex Review
- Round 1: 5/10 NOT CERTIFIED (4 P1/P2 findings: merge missing field, false-green test 5, incomplete hook check, untracked artifacts).
- Round 2: 9/10 CERTIFIED. All 4 fixes verified.

## Test plan
- [x] tests/test-cleanup-period-guidance.sh — 7/7 (mutation-verified)
- [x] tests/test-cli.sh — 72/72 (2 new merge tests)
- [x] tests/test-doc-consistency.sh — 22/22
- [x] All other test suites green

## Files changed (14)
- cli/init.js — mergeSettings handles cleanupPeriodDays
- cli/templates/settings.json — ships `"cleanupPeriodDays": 30`
- CLAUDE_CODE_SDLC_WIZARD.md — Known CC gotcha subsection
- tests/test-cleanup-period-guidance.sh — new (7 tests)
- tests/test-cli.sh — +2 merge tests
- .github/workflows/ci.yml + CONTRIBUTING.md — wire test
- .gitignore — exclude .claude/hooks/ (CC runtime artifact)
- package.json, plugin.json, marketplace.json, SDLC.md, CLAUDE_CODE_SDLC_WIZARD.md, skills/update/SKILL.md — version 1.40.0 → 1.40.1
- CHANGELOG.md — [1.40.1] entry