### PR TITLE
v1.42.0: AGENTS.md interop detection — phase (a) (#205)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.41.1",
+      "version": "1.42.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.41.1",
+  "version": "1.42.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
       - name: Run MCP-tool hook audit tests (#218)
         run: ./tests/test-mcp-hook-audit.sh
 
+      - name: Run AGENTS.md interop tests (#205)
+        run: ./tests/test-agents-md-interop.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.42.0] - 2026-04-26
+
+### Added
+
+- **AGENTS.md interop detection in setup** (ROADMAP #205, phase a). Setup wizard now scans for `AGENTS.md` (cross-tool agent-instructions standard adopted by Cursor/Continue.dev/Aider, [CC issue #6235](https://github.com/anthropics/claude-code/issues/6235)) during Step 1 auto-scan. If found, new Step 4.5 surfaces a 3-way decision: dual-maintain (default), merge (manual in phase a), or skip. The choice is recorded as a one-line comment in the project's `SDLC.md` for the user's reference — `/update-wizard` does NOT yet parse this metadata (phase d). No wizard-side merge or symlink behavior in v1.42.0 — option B in the prompt is "record intent, copy by hand"; phase (b) will add the copy helper. Phase (d) drift-consistency test also deferred. New `tests/test-agents-md-interop.sh` (7 tests) asserts setup auto-scan, decision step structure, wizard doc reference + phase-scope honesty.
+
 ## [1.41.1] - 2026-04-26
 
 ### Added

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -353,6 +353,22 @@ Claude Code now has built-in auto-memory that persists context across sessions. 
 
 **No changes needed**: The wizard's hooks and skills work alongside auto-memory. Memory stores preferences and context; the wizard enforces process.
 
+### AGENTS.md interop (cross-tool standard, ROADMAP #205)
+
+`AGENTS.md` is the cross-tool agent-instructions standard adopted by Cursor, Continue.dev, Aider, and other agentic IDEs ([CC issue #6235](https://github.com/anthropics/claude-code/issues/6235), 276 comments). It plays the same role as `CLAUDE.md` does for Claude Code, but reads as agent-agnostic.
+
+**Wizard behavior** (v1.42.0, phase a only):
+
+- **Setup skill detects existing AGENTS.md** during Step 1 auto-scan. If found, Step 4.5 surfaces a 3-way decision: dual-maintain (default, recommended), merge (manual in phase a), or skip. The user's choice is recorded as a one-line comment in their project's `SDLC.md` for their own reference. **`/update-wizard` does NOT parse this comment** — that wiring is phase (d) work, not v1.42.0 scope.
+- **No automatic merge / symlink yet** — phase (a) is detection + decision surfacing only. Option B in the prompt is "record your intent, do the copy by hand"; the wizard does not perform any merge in this phase.
+
+**Deferred phases** (not in v1.42.0 scope):
+
+- **Phase (b)**: when generating `CLAUDE.md` fresh (no AGENTS.md exists), offer to ALSO write AGENTS.md (symlinked or content-duplicated). Requires choosing a sync strategy.
+- **Phase (d)**: cross-document-consistency drift test — fail CI if `CLAUDE.md` and `AGENTS.md` drift apart on key sections (Commands, Architecture, etc.).
+
+**Why phase (a) only**: phase (a) ships detection signal value with zero new merge logic. The dual-maintain decision is reversible per-project; users who pick A get a sensible default and can opt up to phase (b) when it ships. Multi-tool sync is a real engineering problem (which file is source of truth? on edit, propagate which way?) that deserves its own design pass before automating.
+
 ### Built-in Commands (v2.1.59-v2.1.76)
 
 New built-in commands available to use alongside the wizard:
@@ -2900,7 +2916,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.41.1 -->
+<!-- SDLC Wizard Version: 1.42.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3962,7 +3978,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.41.1 -->
+<!-- SDLC Wizard Version: 1.42.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-cleanup-period-guidance.sh && \
    ./tests/test-postmortem-lessons.sh && \
    ./tests/test-mcp-hook-audit.sh && \
+   ./tests/test-agents-md-interop.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.41.1 -->
+<!-- SDLC Wizard Version: 1.42.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.41.1 |
+| Wizard Version | 1.42.0 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.41.1",
+  "version": "1.42.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -38,7 +38,7 @@ Scan the project root for:
 - Deployment: Dockerfile, vercel.json, fly.toml, netlify.toml, Procfile, k8s/
 - Design system: tailwind.config.*, .storybook/, theme files, CSS custom properties
 - Branding assets: BRANDING.md, brand/, logos/, style-guide.md, brand-voice.md, tone-of-voice.*
-- Existing docs: README.md, CLAUDE.md, ARCHITECTURE.md
+- Existing docs: README.md, CLAUDE.md, ARCHITECTURE.md, AGENTS.md (cross-tool agent-instructions standard, ROADMAP #205)
 - Scripts in package.json (lint, test, build, typecheck, etc.)
 - Database config files (prisma/, drizzle.config.*, knexfile.*, .env with DB_*)
 - Cache config (redis.conf, .env with REDIS_*)
@@ -107,6 +107,34 @@ Using detected + confirmed values, generate `CLAUDE.md` with:
 - Special notes (infra, deployment)
 
 Reference: See "Step 8" in `CLAUDE_CODE_SDLC_WIZARD.md` for the full template.
+
+### Step 4.5: AGENTS.md Interop Detection (ROADMAP #205, phase a)
+
+`AGENTS.md` is the cross-tool agent-instructions file converged on by Cursor, Continue.dev, Aider, and other agentic IDEs (CC issue #6235, 276 comments). If the user already has `AGENTS.md` in the repo, the wizard's `CLAUDE.md` overlaps in scope; ignoring it leads to drift between the two files.
+
+**Detection** (already in Step 1's auto-scan): does `./AGENTS.md` exist?
+
+**If YES, surface the dual-maintain decision:**
+
+> Detected `AGENTS.md` (cross-tool agent-instructions standard, used by Cursor/Continue.dev/Aider). The wizard's `CLAUDE.md` covers the same ground for Claude Code. Three options:
+>
+> **A.** **Dual-maintain (recommended)**: keep both files. `CLAUDE.md` for Claude Code (loaded into every session), `AGENTS.md` for other tools. Sync manually when changing one — phase (a) does not auto-merge. Future work (phase d) will add a drift-consistency test.
+>
+> **B.** **Merge** (manual in phase a): record your intent to converge on a single source of truth. The wizard does NOT copy content for you in v1.42.0 — phase (b) will add the copy/symlink helper. For now, pick this if you plan to merge by hand and just want the wizard to know.
+>
+> **C.** **Skip**: leave AGENTS.md alone. The wizard generates only `CLAUDE.md`. AGENTS.md will go stale relative to your CC-specific instructions.
+>
+> Pick A, B, or C: `[A/B/C]`
+
+Default if no response: **A** (dual-maintain). Document the user's choice as a one-line comment in their project's `SDLC.md` (e.g. `<!-- AGENTS.md interop: dual-maintain (per ROADMAP #205 phase a) -->`). v1.42.0 does NOT teach `/update-wizard` to parse this metadata key — that's phase (d) work. The comment is for the user's own reference and for whatever future `/update-wizard` version adds AGENTS-aware behavior.
+
+**If NO `AGENTS.md` exists**: skip this step silently. Phase (b) of #205 (offer to ALSO generate AGENTS.md alongside CLAUDE.md) is deferred — not in v1.42.0 scope.
+
+**Phase scope honest summary**:
+- Phase (a) — DONE in v1.42.0: detection + decision surfacing only.
+- Phase (b) — deferred: write/symlink AGENTS.md when generating CLAUDE.md fresh.
+- Phase (c) — partial: this step IS the setup-skill update.
+- Phase (d) — deferred: cross-document-consistency drift test.
 
 ### Step 5: Generate SDLC.md
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -131,9 +131,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.41.1
+Latest:    1.42.0
 
 What changed:
+- [1.42.0] AGENTS.md interop detection — ROADMAP #205 phase (a). Setup wizard auto-scan now lists AGENTS.md (cross-tool agent-instructions standard, CC issue #6235); new Step 4.5 surfaces a 3-way decision (dual-maintain / merge / skip) when AGENTS.md is detected. Phase (b) write-fresh and phase (d) drift-test deferred. 7 quality tests.
 - [1.41.1] MCP-tool hooks audit — ROADMAP #218. Audited all 5 wizard hooks against CC 2.1.118's `type: "mcp_tool"` migration option; conclusion: all stay bash (portability to Codex/OpenCode siblings + exit-code gating semantics rule out MCP). Per-hook rationale documented under "Known CC Gotchas → MCP-tool hooks audit". 7 quality tests.
 - [1.41.0] Post-mortem 2026-04-23 lessons folded into wizard — ROADMAP #221. New "Known CC Gotchas" section documents extended-thinking + caching + idle-session failure mode. Recommended Effort section cites the post-mortem as third-party evidence ("don't rely on CC default — set effort yourself"). Brevity-cap audit clean, regression guard added. 7 quality tests.
 - [1.40.1] cleanupPeriodDays: 30 pinned in template — ROADMAP #225. CC 2.1.117 expanded `cleanupPeriodDays` to also cover `~/.claude/tasks/`. Aggressive defaults could prune in-progress TodoWrite checklists for paused long-running features. Wizard now ships a 30-day floor + documented gotcha. 7 quality tests.

--- a/tests/test-agents-md-interop.sh
+++ b/tests/test-agents-md-interop.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Quality test: ROADMAP #205 phase (a) — setup wizard detects existing AGENTS.md.
+#
+# CC issue #6235 (276 comments) is the cross-tool agent-instructions standard.
+# Cursor, Continue.dev, Aider, and others converge on AGENTS.md as the
+# agent-agnostic parallel to CLAUDE.md. v1.42.0 phase (a): the setup skill's
+# auto-scan now lists AGENTS.md and surfaces a dual-maintain decision when found.
+# Phases (b) symlink/duplicate writing and (d) drift-consistency test deferred.
+#
+# This test asserts the detection + decision documentation; it does NOT assert
+# any merge/symlink behavior because that's not in phase (a) scope.
+
+set -e
+
+SETUP="${SETUP:-skills/setup/SKILL.md}"
+WIZARD="${WIZARD:-CLAUDE_CODE_SDLC_WIZARD.md}"
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+if [ ! -f "$SETUP" ]; then
+    echo "FAIL: $SETUP not found"
+    exit 1
+fi
+
+# Test 1: setup skill auto-scan mentions AGENTS.md
+auto_scan=$(awk '/^### Step 1: Auto-Scan/,/^### Step 2:/' "$SETUP")
+if echo "$auto_scan" | grep -qE "AGENTS\.md"; then
+    pass "Setup auto-scan lists AGENTS.md"
+else
+    fail "Setup Step 1 (Auto-Scan) must include AGENTS.md in scanned files"
+fi
+
+# Test 2: setup skill has a dedicated AGENTS.md decision step or subsection
+agents_section=$(awk '
+  /AGENTS\.md.*[Dd]etect|AGENTS\.md.*[Ii]nterop|AGENTS\.md interop|Step.*AGENTS/ { flag=1 }
+  /^### Step / && flag && !/AGENTS/ { flag=0 }
+  /^## / && flag { flag=0 }
+  flag { print }
+' "$SETUP")
+if [ -n "$agents_section" ]; then
+    pass "Setup skill has an AGENTS.md decision/interop section"
+else
+    fail "Setup skill must have a step that handles detected AGENTS.md (decision: dual-maintain / merge / link)"
+fi
+
+# Test 3: setup decision includes the dual-maintain option
+if echo "$agents_section" | grep -qiE "dual.maintain|both.*files|maintain.*both|sync.*claude.*agents|sync.*agents.*claude"; then
+    pass "Setup decision describes dual-maintain option"
+else
+    fail "Setup decision must surface the dual-maintain option (keep both AGENTS.md and CLAUDE.md in sync)"
+fi
+
+# Test 4: wizard doc references the AGENTS.md interop pattern
+if grep -qE "AGENTS\.md" "$WIZARD"; then
+    pass "Wizard doc references AGENTS.md"
+else
+    fail "Wizard doc must reference AGENTS.md interop standard"
+fi
+
+# Test 5: wizard's AGENTS.md subsection (specifically) cites CC #6235 or names
+# the cross-tool adopters. Scoped via awk to avoid false-greens elsewhere in the
+# doc (e.g., "across tool boundaries" / "cross-tool structured state").
+agents_doc_section=$(awk '
+  /^### AGENTS\.md interop/ { flag=1; next }
+  /^### / && flag { flag=0 }
+  /^## / && flag { flag=0 }
+  flag { print }
+' "$WIZARD")
+if [ -n "$agents_doc_section" ] && echo "$agents_doc_section" | grep -qE "#6235|Cursor|Continue\.dev|Aider"; then
+    pass "Wizard AGENTS.md subsection cites CC #6235 or names cross-tool adopters"
+else
+    fail "Wizard AGENTS.md subsection must cite CC #6235 or name Cursor/Continue.dev/Aider as cross-tool adopters"
+fi
+
+# Test 6: phase (a) scope is honest — must mention what's deferred
+agents_doc=$(awk '
+  /AGENTS\.md/ && /[Dd]etect|[Ii]nterop|[Pp]hase|standard/ { flag=1 }
+  /^## / && flag { flag=0 }
+  flag { print }
+' "$WIZARD")
+if echo "$agents_doc" | grep -qiE "phase.*a|phase\(a\)|deferred|future|symlink|drift.test"; then
+    pass "Wizard documents phase (a) scope honestly (defers symlink/drift-test phases)"
+else
+    fail "Wizard must be honest about phase (a) scope — note that symlink writing + drift-test are deferred"
+fi
+
+# Test 7: CHANGELOG [1.42.0] entry mentions #205
+if grep -qE "^## \[1\.42\.0\]" CHANGELOG.md; then
+    cl_entry=$(awk '/^## \[1\.42\.0\]/,/^## \[1\.41\.1\]/' CHANGELOG.md | sed '$d')
+    if echo "$cl_entry" | grep -qE "#205|AGENTS\.md"; then
+        pass "CHANGELOG [1.42.0] mentions #205 or AGENTS.md"
+    else
+        fail "CHANGELOG [1.42.0] must reference #205 or AGENTS.md"
+    fi
+else
+    fail "CHANGELOG [1.42.0] entry missing"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary
ROADMAP #205 phase (a): setup wizard detects existing AGENTS.md and surfaces a 3-way decision (dual-maintain default / merge / skip). Phase (a) is detection + decision recording only — no wizard-side merge or symlink behavior. Phase (b) write-fresh and phase (d) drift-test deferred.

## Codex Review
- Round 1: 6/10 NOT CERTIFIED. 3 P1 findings (SDLC.md metadata claim false, Option B contradicted detection-only scope, test 5 false-greened).
- Round 2: 10/10 CERTIFIED.

## Test plan
- [x] tests/test-agents-md-interop.sh — 7/7 (mutation-verified)
- [x] All other suites green