### PR TITLE
v1.42.1: skip Claude PR review on wizard self-PRs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.42.0",
+      "version": "1.42.1",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
       - name: Run AGENTS.md interop tests (#205)
         run: ./tests/test-agents-md-interop.sh
 
+      - name: Run self-PR review skip tests
+        run: ./tests/test-self-pr-review-skip.sh
+
   # Clean up old bot comments on PR push (keeps PRs tidy)
   # Also runs on workflow_dispatch (no-op) so branch protection doesn't block auto-merge.
   cleanup-old-comments:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,7 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     # Review on open (non-draft) / ready_for_review / needs-review label
     # Skip draft PRs on open - they'll be reviewed when marked ready
+    #
+    # Self-PR skip (BaseInfinity/claude-sdlc-wizard): the maintainer keeps
+    # ANTHROPIC_API_KEY's credit balance dead as an "API canary" — any unexpected
+    # API draw is detected by failed CI. claude-code-action@v1 needs that key with
+    # positive balance, so this job has been failing with "Credit balance is too low"
+    # on every self-PR. The wizard uses Codex for cross-model review on its own
+    # PRs (see SDLC skill), so the Claude PR review is redundant on self-repo.
+    # Consumers using pr-review.yml in their own projects WILL run this normally —
+    # the skip only fires when github.repository matches the wizard repo exactly.
     if: |
+      github.repository != 'BaseInfinity/claude-sdlc-wizard' &&
       ((github.event.action == 'opened' && github.event.pull_request.draft != true) ||
        github.event.action == 'synchronize' ||
        github.event.action == 'ready_for_review' ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.42.1] - 2026-04-26
+
+### Fixed
+
+- **Skip Claude PR review on wizard self-PRs** (CI hygiene). The `review` job in `pr-review.yml` calls `claude-code-action@v1` which requires `ANTHROPIC_API_KEY` with positive credit balance. The wizard maintainer keeps that key's balance dead as an "API canary" so unexpected API draws fail CI. Result: every wizard self-PR's `review` job was failing with "Credit balance is too low" — seven PRs (v1.39.0–v1.42.0) shipped to main with red CI, normalizing red and masking any real review failure. Fixed: workflow `if:` gate now skips the review job when `github.repository == 'BaseInfinity/claude-sdlc-wizard'`. Consumer projects using `pr-review.yml` are unaffected — the skip only fires on the wizard's own repo. The wizard uses Codex (`codex exec` xhigh) for cross-model review on its own PRs, so the Claude PR review is redundant on self-repo. Documented in `CI_CD.md` → "Self-PR Skip on the Wizard Repo". New `tests/test-self-pr-review-skip.sh` (6 tests) prevents regression.
+
 ## [1.42.0] - 2026-04-26
 
 ### Added

--- a/CI_CD.md
+++ b/CI_CD.md
@@ -227,6 +227,16 @@ The SDLC skill's CI feedback loops (`.claude/skills/sdlc/SKILL.md`) run during a
 6. Label auto-removed -> Ready for next round
 ```
 
+### Self-PR Skip on the Wizard Repo (v1.42.1+)
+
+The `review` job is **skipped on `BaseInfinity/claude-sdlc-wizard` self-PRs** — the workflow's `if:` gate checks `github.repository != 'BaseInfinity/claude-sdlc-wizard'`.
+
+**Why**: the wizard maintainer keeps `ANTHROPIC_API_KEY` credit balance dead as an "API canary" — any unexpected API draw is detected by failed CI. `claude-code-action@v1` needs that key with positive balance, so self-PRs were failing every run with "Credit balance is too low". Seven PRs (v1.39.0–v1.42.0) shipped to main with the review job red, normalizing red CI and masking any real review failure that might have appeared.
+
+**Why this is safe**: the wizard uses Codex (`codex exec` with `model_reasoning_effort=xhigh`) for cross-model review during the SDLC skill's review phase. Claude PR review is redundant on self-repo. Consumers using `pr-review.yml` in their own projects WILL run this job normally — the skip only fires when the workflow runs on the wizard's own repo.
+
+**Recovery for new failures**: if claude-code-action ever has a real issue affecting consumers (not just our dead canary), the consumer projects' runs will surface it. We rely on consumer signal + Codex reviews on self-repo to catch problems.
+
 ### Smart Features
 - **Skips trivial PRs**: Docs-only, config-only changes skip review
 - **Waits for CI**: No point reviewing broken code

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2916,7 +2916,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.42.0 -->
+<!-- SDLC Wizard Version: 1.42.1 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3978,7 +3978,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.42.0 -->
+<!-- SDLC Wizard Version: 1.42.1 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-postmortem-lessons.sh && \
    ./tests/test-mcp-hook-audit.sh && \
    ./tests/test-agents-md-interop.sh && \
+   ./tests/test-self-pr-review-skip.sh && \
    ./tests/e2e/run-simulation.sh && \
    ./tests/e2e/test-deterministic-checks.sh && \
    ./tests/e2e/test-scenario-rotation.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.42.0 -->
+<!-- SDLC Wizard Version: 1.42.1 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.42.0 |
+| Wizard Version | 1.42.1 |
 | Last Updated | 2026-04-24 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -131,9 +131,10 @@ Parse all CHANGELOG entries between the user's installed version and the latest.
 
 ```
 Installed: 1.24.0
-Latest:    1.42.0
+Latest:    1.42.1
 
 What changed:
+- [1.42.1] CI hygiene fix — skip Claude PR review on wizard self-PRs. 7 self-PRs (v1.39.0–v1.42.0) had shipped with red `review` job (API canary firing on dead credit balance). Treated as "expected" but red normalizes red. Workflow `if:` now skips review on `BaseInfinity/claude-sdlc-wizard` repo only; consumer projects unaffected. 7 quality tests, mutation-verified (== inversion fails).
 - [1.42.0] AGENTS.md interop detection — ROADMAP #205 phase (a). Setup wizard auto-scan now lists AGENTS.md (cross-tool agent-instructions standard, CC issue #6235); new Step 4.5 surfaces a 3-way decision (dual-maintain / merge / skip) when AGENTS.md is detected. Phase (b) write-fresh and phase (d) drift-test deferred. 7 quality tests.
 - [1.41.1] MCP-tool hooks audit — ROADMAP #218. Audited all 5 wizard hooks against CC 2.1.118's `type: "mcp_tool"` migration option; conclusion: all stay bash (portability to Codex/OpenCode siblings + exit-code gating semantics rule out MCP). Per-hook rationale documented under "Known CC Gotchas → MCP-tool hooks audit". 7 quality tests.
 - [1.41.0] Post-mortem 2026-04-23 lessons folded into wizard — ROADMAP #221. New "Known CC Gotchas" section documents extended-thinking + caching + idle-session failure mode. Recommended Effort section cites the post-mortem as third-party evidence ("don't rely on CC default — set effort yourself"). Brevity-cap audit clean, regression guard added. 7 quality tests.

--- a/tests/test-self-pr-review-skip.sh
+++ b/tests/test-self-pr-review-skip.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Quality test: pr-review.yml skips Claude PR review on the wizard's own self-PRs.
+#
+# The `review` job runs claude-code-action@v1 which requires ANTHROPIC_API_KEY
+# with a positive credit balance. The wizard maintainer runs an "API canary" —
+# keeping the credit balance dead so unexpected API draws are detected. That
+# means the review job has been failing on every wizard self-PR with
+# "Credit balance is too low".
+#
+# The wizard uses Codex for cross-model review on its own PRs (see SDLC skill),
+# so the Claude PR review is redundant on self-repo. Consumers using pr-review.yml
+# in their own projects benefit from the Claude PR review and SHOULD have it run.
+#
+# Fix: skip the review job when the workflow runs in BaseInfinity/claude-sdlc-wizard.
+# Consumers' forks/copies of pr-review.yml run normally.
+#
+# Lessons learned (from 7 self-PRs merged with red review job in v1.39.0–v1.42.0):
+# - Red CI normalizes red — a NEW review failure (e.g., real bug detected) would
+#   look identical to the canary failure and be missed.
+# - "Required check is green so I can merge" is not the same as "all checks green".
+# - SDLC: ALL TESTS MUST PASS BEFORE COMMIT — no exceptions, including non-required.
+
+set -e
+
+WORKFLOW="${WORKFLOW:-.github/workflows/pr-review.yml}"
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+if [ ! -f "$WORKFLOW" ]; then
+    echo "FAIL: $WORKFLOW not found"
+    exit 1
+fi
+
+# Test 1: Workflow has the EXACT NEGATIVE comparison `github.repository != 'BaseInfinity/claude-sdlc-wizard'`.
+# A literal `==` would invert the semantics (skip consumers, run on self) — must catch that.
+# Use single-line grep with the actual operator embedded in the pattern.
+if grep -qE "github\.repository[[:space:]]*!=[[:space:]]*['\"]BaseInfinity/claude-sdlc-wizard['\"]" "$WORKFLOW"; then
+    pass "Workflow uses exact negative comparison: github.repository != 'BaseInfinity/claude-sdlc-wizard'"
+else
+    fail "Workflow must use exact: github.repository != 'BaseInfinity/claude-sdlc-wizard' — verify operator and string both"
+fi
+
+# Test 1b: Negative control — explicitly fail if `==` operator is used (would skip consumers).
+if grep -qE "github\.repository[[:space:]]*==[[:space:]]*['\"]BaseInfinity/claude-sdlc-wizard['\"]" "$WORKFLOW"; then
+    fail 'Workflow uses == instead of != — this would skip CONSUMERS and run on the wizard self-repo (inverted semantics)'
+else
+    pass 'No inverted github.repository == comparison (consumer projects safe)'
+fi
+
+# Test 2: The skip condition lives on the `review` job (not just one step).
+# Workflow-level skip is more reliable than step-level — no half-runs.
+review_job_block=$(awk '
+  /^  review:/ { flag=1; next }
+  /^  [a-z][a-z-]*:/ && flag { flag=0 }
+  flag { print }
+' "$WORKFLOW" | head -30)
+
+if echo "$review_job_block" | grep -qE "github\.repository.*BaseInfinity/claude-sdlc-wizard"; then
+    pass "Skip condition is on the review job's if: gate (no half-runs)"
+else
+    fail "Skip condition must be in the review job's if: block, near the top"
+fi
+
+# Test 3: Workflow YAML still parses (don't break the file with the edit).
+if python3 -c "import yaml; yaml.safe_load(open('$WORKFLOW'))" 2>/dev/null; then
+    pass "Workflow YAML still parses"
+else
+    fail "Workflow YAML broken after the edit"
+fi
+
+# Test 4: Audit policy documented in CI_CD.md.
+if grep -qE "self.PR.*skip|skip.*self.PR|API canary.*review|claude-code-action.*self" CI_CD.md 2>/dev/null; then
+    pass "CI_CD.md documents the self-PR skip policy"
+else
+    fail "CI_CD.md must document why review is skipped on self-PRs (API canary, Codex supersedes)"
+fi
+
+# Test 5: CHANGELOG mentions the fix.
+if grep -qE "^## \[1\.42\.1\]" CHANGELOG.md 2>/dev/null; then
+    cl_entry=$(awk '/^## \[1\.42\.1\]/,/^## \[1\.42\.0\]/' CHANGELOG.md | sed '$d')
+    if echo "$cl_entry" | grep -qiE "review.*skip|self.PR|API canary|red.*CI"; then
+        pass "CHANGELOG [1.42.1] documents the CI fix"
+    else
+        fail "CHANGELOG [1.42.1] must reference the review skip / canary fix"
+    fi
+else
+    fail "CHANGELOG [1.42.1] entry missing"
+fi
+
+# Test 6: Negative control — the review step itself still calls claude-code-action
+# (we're skipping execution, not removing the workflow). Consumers should still get the review.
+if grep -qE "uses: anthropics/claude-code-action" "$WORKFLOW"; then
+    pass "Workflow still wires claude-code-action (consumer projects benefit)"
+else
+    fail "Workflow must still call claude-code-action — only the SELF-repo runs are skipped"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary
User call-out: 7 wizard self-PRs (v1.39.0–v1.42.0) shipped to main with the `review` job RED. I was treating "API canary firing" as safe-to-merge — wrong. Red is red, even if expected.

Fix: `pr-review.yml` review job now skips when `github.repository == 'BaseInfinity/claude-sdlc-wizard'`. Exact-string match — consumer projects unaffected. Wizard uses Codex on self-repo, so Claude PR review is redundant here.

## Codex Review
- Round 1: 7/10 NOT CERTIFIED (2 P1: test missed == inversion, test file untracked).
- Round 2: 10/10 CERTIFIED.

## Test plan
- [x] tests/test-self-pr-review-skip.sh — 7/7 (mutation-verified: `!=` → `==` fails tests 1 + 1b)
- [x] All other suites green