### PR TITLE
docs: close #251, #225 — Browser Tooling Policy section

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2717,6 +2717,53 @@ Options:
 
 ---
 
+### Browser Tooling Policy
+
+Three different jobs, three different tools. Conflating them is the source of recurring agent failures — `Playwright MCP` for an auth-heavy registrar dashboard wastes a session, browser-use for a deterministic regression test gives flaky CI.
+
+| Tool | Job | Profile model | When to pick |
+|------|-----|---------------|--------------|
+| **Playwright tests** | Deterministic regression suite, CI/release gate | Isolated by design — each test gets a clean browser context per [Playwright docs](https://playwright.dev/docs/browser-contexts) | Asserting expected user flows; running on every PR; gating deploy |
+| **Playwright MCP** | Live browser debugging, visual QA, DOM inspection | Default mode uses a **persistent Playwright-managed profile** at `ms-playwright/mcp-{channel}-{workspace-hash}` ([docs](https://playwright.dev/docs/getting-started-mcp#user-profile)) — NOT the user's regular Chrome profile. Other modes: `--isolated` (ephemeral context per session), `--user-data-dir=PATH` (caller-supplied dir), CDP attach (`--cdp-endpoint`), extension mode (attach to user's running browser tab) | One-off "look at this page" / "click this button and tell me what happens"; visual verification mid-session |
+| **Real-browser tooling** (browser-use, CDP-attach, Chrome profile) | Authenticated, profile-dependent, stateful operator flows | **When configured for real-browser mode** (e.g., browser-use `Browser.from_system_chrome()` or CLI `--profile`/`connect`), uses the user's actual Chrome profile (cookies, extensions, logged-in sessions). Default browser-use CLI runs headless Chromium — opt into the real-profile mode explicitly | Registrar dashboards (Porkbun, GoDaddy), DNS setup, cloud-provider consoles, wallet-adjacent Web3 flows, logged-in admin panels — anywhere preserving cookies/profile/extensions matters more than clean isolation |
+
+**The core insight:** Playwright tests' isolation is a *feature*, not a bug. Playwright MCP's persistent-managed-profile default is also a feature — it preserves session continuity across debug interactions in a SINGLE agent. The collision case is concurrent agents (#251) sharing the same managed profile. Real-browser tooling is the right call only when the task IS the user's authenticated session, and only when explicitly configured to attach to that profile.
+
+#### When to recommend real-browser tooling (#225)
+
+Trigger examples — if the task description includes any of these, suggest real-browser tooling (browser-use or CDP-attach) over Playwright MCP:
+
+- Registrar dashboards (domain purchase, DNS records, nameserver changes)
+- DNS setup / DNSLink / custom-domain configuration
+- Cloud/provider dashboards (AWS console, Cloudflare, Vercel, registrars)
+- Wallet-adjacent Web3 flows (token approvals, contract interactions in a logged-in MetaMask)
+- Logged-in admin panels (Stripe, Vercel, GitHub admin pages requiring 2FA-cached session)
+- Anywhere preserving cookies/profile/extensions matters more than clean isolation
+
+These all share a property: the agent's job IS the authenticated session. A clean automation browser is the wrong model.
+
+#### Playwright MCP profile-lock policy (#251)
+
+`Playwright MCP`'s default mode reuses a single persistent managed profile (`ms-playwright/mcp-{channel}-{workspace-hash}`) across stdio sessions — which is the right call for single-agent debugging because it preserves session continuity across calls, but breaks down when **multiple agents or MCP clients run concurrently** (two CC sessions, one CC + one Codex, etc.). Concurrent stdio sessions collide on the same Chrome user-data directory and corrupt each other's session state.
+
+**Upstream Playwright rejected default-isolated as the global default.** See [microsoft/playwright#40419](https://github.com/microsoft/playwright/issues/40419) and the discussion on [microsoft/playwright#40420](https://github.com/microsoft/playwright/pull/40420) — maintainer feedback: *"That's unfortunately very breaking."* Changing the default would silently break every existing single-agent setup that relies on the persistent managed profile.
+
+**Wizard policy (per-user, opt-in at the wizard layer, not upstream):**
+
+- **Single-agent / single MCP client (default):** Use Playwright MCP's default persistent-managed-profile mode. No special config required.
+- **Concurrent agents / multiple MCP clients:** Pick one of these per client to avoid profile-lock collisions: (a) `--isolated` (ephemeral context per session, no persistence), (b) `--user-data-dir=$TMPDIR/playwright-mcp-$AGENT_ID` (caller-supplied dir, isolated per agent), or (c) `--cdp-endpoint` to attach each agent to a separately-launched browser. None of these require an upstream breaking change.
+- **Real-browser / profile-dependent flows:** Don't use Playwright MCP at all — use real-browser tooling explicitly configured to attach to the user's profile (e.g., `browser-use` with `Browser.from_system_chrome()` or CLI `--profile`). The task is the session, not isolated automation.
+
+This rule is per-workflow, not global. Setup wizard does NOT auto-configure isolated profiles — adoption is explicit, gated on the user signaling concurrent-agent intent.
+
+#### Anti-patterns
+
+- **Using Playwright MCP for registrar dashboards** — its persistent managed profile is NOT your real Chrome profile, so your registrar's logged-in session/2FA cookies aren't there. You'll be re-logging in on every interaction. Use real-browser tooling configured for your real Chrome profile instead.
+- **Using profile-coupled / stateful browser tooling for deterministic CI tests** — when browser-use (or any tool) is configured to use a real Chrome profile, cached state, extension chrome, and stale cookies pollute the test. Use Playwright tests with isolated browser contexts for CI.
+- **Setting Playwright MCP `--isolated` globally as a default** — breaks single-agent flows that rely on the persistent managed profile for session continuity across debug interactions. Upstream Playwright rejected this for the same reason. Make it explicit per-workflow when concurrent agents are running.
+
+---
+
 ## Step 8: Create CLAUDE.md
 
 Create `CLAUDE.md` in your project root. This is your project-specific configuration:

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -523,12 +523,100 @@ test_sdlc_skill_frames_opus_1m_as_opt_in() {
     fi
 }
 
+# Tests (#251 + #225): Browser Tooling Policy section.
+# Greps run INSIDE the policy section, not against the whole doc — otherwise
+# claims could be satisfied by unrelated mentions elsewhere (Codex round 1
+# finding 3).
+
+# Extract the Browser Tooling Policy section: from `### Browser Tooling Policy`
+# heading to the next `###` or `##` heading. Echoes the section content.
+extract_browser_tooling_policy_section() {
+    local DOC="$1"
+    awk '
+        /^### Browser Tooling Policy/ { in_section = 1; print; next }
+        in_section && /^##[#]?[^#]/ { in_section = 0 }
+        in_section { print }
+    ' "$DOC"
+}
+
+test_wizard_doc_has_browser_tooling_policy_section() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    if grep -qE '^### Browser Tooling Policy[[:space:]]*$' "$DOC"; then
+        pass "wizard doc has 'Browser Tooling Policy' section heading (#225, #251)"
+    else
+        fail "wizard doc must have a 'Browser Tooling Policy' section (#225, #251)"
+    fi
+}
+
+# #225: 3-way split — all 3 tools must be named INSIDE the policy section
+test_wizard_doc_browser_policy_covers_three_way_split() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    local section
+    section=$(extract_browser_tooling_policy_section "$DOC")
+    if [ -z "$section" ]; then fail "Browser Tooling Policy section is empty/missing"; return; fi
+    local ok=true
+    echo "$section" | grep -qE 'Playwright tests' || ok=false
+    echo "$section" | grep -qE 'Playwright MCP' || ok=false
+    echo "$section" | grep -qiE 'browser-use|real.browser tooling' || ok=false
+    if [ "$ok" = true ]; then
+        pass "policy section covers 3-way browser-tooling split (tests / MCP / real-browser, #225)"
+    else
+        fail "policy section must cover all 3 browser tooling approaches (#225)"
+    fi
+}
+
+# #251: profile isolation for concurrent agents — INSIDE the policy section
+test_wizard_doc_mcp_profile_isolation_for_concurrent_agents() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    local section
+    section=$(extract_browser_tooling_policy_section "$DOC")
+    if echo "$section" | grep -qiE 'concurrent.*(agent|MCP client)|multiple (agent|MCP client)|profile.lock|--user-data-dir|--isolated' ; then
+        pass "policy section covers MCP profile-isolation for concurrent agent workflows (#251)"
+    else
+        fail "policy section must explain MCP profile isolation for concurrent agents (#251)"
+    fi
+}
+
+# #251: upstream Playwright rejection — INSIDE the policy section
+test_wizard_doc_notes_playwright_default_isolation_rejected() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    local section
+    section=$(extract_browser_tooling_policy_section "$DOC")
+    if echo "$section" | grep -qiE '(playwright/issues/40419|playwright/pull/40420|upstream.*rejected|very breaking)'; then
+        pass "policy section notes upstream Playwright rejected default-isolated (#251)"
+    else
+        fail "policy section must explain that upstream Playwright rejected default-isolated (#251)"
+    fi
+}
+
+# #225: trigger examples for real-browser tooling — INSIDE the policy section
+test_wizard_doc_real_browser_trigger_examples() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    local section
+    section=$(extract_browser_tooling_policy_section "$DOC")
+    if echo "$section" | grep -qiE 'registrar|DNS setup|wallet|Web3|auth.heavy|profile.dependent|stateful operator|admin panel'; then
+        pass "policy section includes real-browser trigger examples (#225)"
+    else
+        fail "policy section must include trigger examples for real-browser tooling (#225)"
+    fi
+}
+
 test_wizard_doc_recommends_opus_1m
 test_wizard_doc_frames_opus_1m_as_opt_in
 test_wizard_doc_no_default_opus_1m_wording
 test_wizard_doc_warns_against_compound_autocompact_config
 test_sdlc_skill_warns_against_compound_autocompact_config
 test_sdlc_skill_frames_opus_1m_as_opt_in
+test_wizard_doc_has_browser_tooling_policy_section
+test_wizard_doc_browser_policy_covers_three_way_split
+test_wizard_doc_mcp_profile_isolation_for_concurrent_agents
+test_wizard_doc_notes_playwright_default_isolation_rejected
+test_wizard_doc_real_browser_trigger_examples
 test_sdlc_skill_recommends_opus_1m
 test_cli_template_has_no_default_model_pin
 test_cli_template_has_no_default_autocompact


### PR DESCRIPTION
## Summary

Adds new `### Browser Tooling Policy` section to `CLAUDE_CODE_SDLC_WIZARD.md` covering:

- **3-way split** (#225): Playwright tests / Playwright MCP / real-browser tooling. Each with accurate profile-model description per upstream docs.
- **Real-browser triggers** (#225): registrar dashboards, DNS, cloud consoles, wallet/Web3, admin panels.
- **Profile-lock policy** (#251): upstream rejected default-isolated as 'very breaking' (microsoft/playwright#40419, #40420). Wizard policy is per-workflow, explicit: pick `--isolated`, `--user-data-dir`, or `--cdp-endpoint` per concurrent client.
- **Anti-patterns**: 3 specific failure modes.

## Test plan

- [x] 5 new doc-consistency tests with section-scoped greps (awk extracts policy block first)
- [x] `tests/test-doc-consistency.sh`: **30/30 PASS** (was 25)
- [x] No regressions: test-cli, test-hooks, test-self-update, test-plugin, test-install-script, test-setup-path, test-token-spike all green
- [x] Codex round 2 **CERTIFIED 9/10** — round 1 caught inaccurate Playwright MCP / browser-use profile-model claims (default mode != user's real Chrome) and unscoped greps; all fixed

Closes #251
Closes #225