### PR TITLE
fix(ci): close #227 — stop legacy score-history.txt churn in weekly-update

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -654,13 +654,13 @@ jobs:
           echo "verdict=$VERDICT" >> $GITHUB_OUTPUT
           echo "Verdict: $VERDICT"
 
-      - name: Update CUSUM drift tracking
-        run: |
-          SCORE="${{ steps.phase-a.outputs.score }}"
-          if [ -n "$SCORE" ] && [ "$SCORE" != "0" ]; then
-            ./tests/e2e/cusum.sh --add "$SCORE" || true
-            ./tests/e2e/cusum.sh --status
-          fi
+      # CUSUM drift tracking via `cusum.sh --add` was removed (#227): the
+      # legacy `score-history.txt` path it appends to is tracked by git, so
+      # every weekly run opened a PR whose only diff was a side-file append —
+      # pure noise (per Codex finding PR213-02 on auto-PR #213, 2026-04-23).
+      # Canonical history lives in `score-history.jsonl` written via the CI
+      # Tier 2 persist step in ci.yml. The version-test PR body already cites
+      # Phase A score directly; standalone drift reporting here added no value.
 
       - name: Post version test results to PR
         uses: marocchino/sticky-pull-request-comment@v3
@@ -1127,12 +1127,10 @@ jobs:
           echo "verdict=$VERDICT" >> $GITHUB_OUTPUT
           echo "Verdict: $VERDICT"
 
-      - name: Update CUSUM
-        run: |
-          SCORE="${{ steps.baseline.outputs.score }}"
-          if [ -n "$SCORE" ] && [ "$SCORE" != "0" ]; then
-            ./tests/e2e/cusum.sh --add "$SCORE" || true
-          fi
+      # CUSUM update via `cusum.sh --add` was removed (#227): same reason as
+      # the version-test job above — appends to legacy `score-history.txt`
+      # which is tracked, creating PR-only-diff noise. Score is captured in
+      # the verdict step output and reflected in the PR body below.
 
       - name: Create PR with results
         id: create-community-pr

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -2579,6 +2579,27 @@ test_skill_no_autofix_bot
 test_ci_max_score_not_hardcoded
 test_ci_gated_expressions_reference_real_outputs
 
+# Test (#227): weekly-update.yml must NOT call `cusum.sh --add` because it
+# appends to legacy score-history.txt, creating PR noise on every run
+# (per Codex finding PR213-02). The canonical history is score-history.jsonl
+# written elsewhere via --add-json.
+test_weekly_update_does_not_call_legacy_cusum_add() {
+    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "weekly-update.yml not found"
+        return
+    fi
+    # Match `cusum.sh --add ` (with space, NOT --add-json — that's the new path)
+    # The legacy --add writes to .txt; --add-json writes to .jsonl (canonical).
+    if grep -nE 'cusum\.sh[[:space:]]+--add[[:space:]]' "$WORKFLOW"; then
+        fail "#227: weekly-update.yml still calls 'cusum.sh --add' (legacy .txt write — PR-noise source)"
+    else
+        pass "#227: weekly-update.yml does not call legacy 'cusum.sh --add' (no PR noise from score-history.txt)"
+    fi
+}
+
+test_weekly_update_does_not_call_legacy_cusum_add
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"


### PR DESCRIPTION
## Summary

Closes #227. Two `cusum.sh --add` calls in weekly-update.yml appended to legacy `score-history.txt` (tracked file), creating PR-only-diff noise on every weekly run. Removed both calls; canonical history (`score-history.jsonl`) is unaffected.

Per Codex consult this session: prefer "stop the .txt write" over "close PRs with only that diff" (simpler, no API edge cases).

## Test plan

- [x] **New regression test** `test_weekly_update_does_not_call_legacy_cusum_add` — greps for `cusum.sh --add ` (legacy form, NOT --add-json) and fails if reintroduced
- [x] `tests/test-workflow-triggers.sh`: PASS
- [x] No regressions: test-cli, test-hooks, test-doc-consistency, test-docs-usability, test-self-update, test-plugin, test-install-script, test-setup-path, test-token-spike, test-codex-progress-wrapper all green
- [x] YAML still valid (python3 yaml.safe_load)
- [x] Doc-only/CI-only change to a workflow whose cron is already disabled (#231 Phase 1)

Codex skipped (low-risk YAML edit; the test gate is the regression guard).

Closes #227