### PR TITLE
feat(observability): token bloat audit phase 2 — session-load inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Run Codex progress wrapper tests (#259)
         run: ./tests/test-codex-progress-wrapper.sh
 
+      - name: Run session-load audit tests (token bloat phase 2)
+        run: ./tests/test-audit-session-load.sh
+
       - name: Run compliance tests
         run: ./tests/test-compliance.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-stats.sh && ./tests/test-hooks.sh && \
    ./tests/test-token-spike.sh && \
    ./tests/test-codex-progress-wrapper.sh && \
+   ./tests/test-audit-session-load.sh && \
    ./tests/test-compliance.sh && ./tests/test-sdp-calculation.sh && \
    ./tests/test-evaluate-bugs.sh && ./tests/test-score-analytics.sh && \
    ./tests/test-prove-it.sh && ./tests/test-self-update.sh && \
@@ -170,6 +171,7 @@ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
 ./tests/test-hooks.sh
 ./tests/test-token-spike.sh
 ./tests/test-codex-progress-wrapper.sh
+./tests/test-audit-session-load.sh
 ./tests/test-compliance.sh
 ./tests/test-sdp-calculation.sh
 ./tests/test-evaluate-bugs.sh

--- a/scripts/audit-session-load.sh
+++ b/scripts/audit-session-load.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Inventory every asset that gets loaded into a CC session and rank by
+# character count. Output: sorted table with trim-candidate flags (>5K tokens
+# ≈ 20000 chars per OpenAI's 4-chars-per-token rule of thumb).
+#
+# Token bloat audit phase 2 (ROADMAP "Next Up" item 8 follow-up):
+# Phase 1 (DONE 2026-04-24) fixed the smoking gun — dual-channel hook
+# registration causing 2× SDLC BASELINE injections. Phase 2 is observability:
+# a mechanical inventory of every file/output that hits a session, so trim
+# candidates surface before they bloat the context budget.
+#
+# Usage:
+#   scripts/audit-session-load.sh           # human-readable table
+#   scripts/audit-session-load.sh --json    # machine-readable
+#
+# What's inventoried (when present at $ROOT):
+#   - CLAUDE.md / SDLC.md / TESTING.md / ARCHITECTURE.md / MEMORY.md
+#   - All hooks/*.sh (script size, NOT runtime stdout — that's separately
+#     gated by the existing brevity-cap tests in tests/test-hooks.sh)
+#   - All skills/*/SKILL.md
+#
+# Output columns: SIZE_CHARS, EST_TOKENS (chars/4), TYPE, FLAG, PATH
+# FLAG = "OK" if <5K tokens, "TRIM" if >=5K tokens.
+#
+# Trim threshold rationale: 5000 tokens ≈ 20000 chars. CLAUDE.md alone
+# routinely runs 8-12K chars in active projects; >20K chars is genuinely
+# excessive and worth surgery.
+
+set -e
+
+ROOT="${SDLC_AUDIT_ROOT:-${1:-$PWD}}"
+# If the first arg is a flag, treat ROOT as cwd.
+case "${1:-}" in
+    --json|--help|-h) ROOT="${SDLC_AUDIT_ROOT:-$PWD}" ;;
+esac
+
+JSON_MODE=0
+for arg in "$@"; do
+    [ "$arg" = "--json" ] && JSON_MODE=1
+    [ "$arg" = "--help" ] || [ "$arg" = "-h" ] && {
+        sed -n '1,30p' "$0" | grep -E '^#' | sed 's/^# *//'
+        exit 0
+    }
+done
+
+# Trim threshold in tokens (chars/4). 5000 tokens = 20000 chars.
+THRESHOLD_TOKENS="${SDLC_AUDIT_THRESHOLD_TOKENS:-5000}"
+THRESHOLD_CHARS=$(( THRESHOLD_TOKENS * 4 ))
+
+# Collect inventory entries as TSV: SIZE_CHARS\tTYPE\tPATH
+ENTRIES=""
+
+add_entry() {
+    local path="$1" type="$2"
+    [ -f "$path" ] || return 0
+    local size
+    size=$(wc -c < "$path" 2>/dev/null | tr -d ' ')
+    [ -z "$size" ] && size=0
+    # Use printf to avoid echo's interpretation of backslashes
+    ENTRIES=$(printf '%s\n%s\t%s\t%s' "$ENTRIES" "$size" "$type" "$path")
+}
+
+# Project-level instruction docs
+for f in CLAUDE.md SDLC.md TESTING.md ARCHITECTURE.md MEMORY.md; do
+    add_entry "$ROOT/$f" "instructions"
+done
+
+# Hook scripts (file size — runtime stdout is gated separately)
+if [ -d "$ROOT/hooks" ]; then
+    for h in "$ROOT/hooks"/*.sh; do
+        [ -f "$h" ] && add_entry "$h" "hook"
+    done
+fi
+# Also check .claude/hooks/ if separate (consumer install path)
+if [ -d "$ROOT/.claude/hooks" ] && [ "$ROOT/.claude/hooks" != "$ROOT/hooks" ]; then
+    for h in "$ROOT/.claude/hooks"/*.sh; do
+        [ -f "$h" ] && add_entry "$h" "hook"
+    done
+fi
+
+# Skill markdown
+if [ -d "$ROOT/skills" ]; then
+    for s in "$ROOT/skills"/*/SKILL.md; do
+        [ -f "$s" ] && add_entry "$s" "skill"
+    done
+fi
+
+# Strip leading newline from accumulator
+ENTRIES=$(printf '%s' "$ENTRIES" | sed '/^$/d')
+
+if [ -z "$ENTRIES" ]; then
+    if [ "$JSON_MODE" = "1" ]; then
+        echo '{"entries": [], "total_chars": 0, "total_tokens_est": 0, "trim_candidates": []}'
+    else
+        echo "No session-loaded assets found at $ROOT"
+    fi
+    exit 0
+fi
+
+# Sort by size descending
+SORTED=$(printf '%s\n' "$ENTRIES" | sort -rn -t$'\t' -k1)
+
+if [ "$JSON_MODE" = "1" ]; then
+    # Emit JSON for tooling / CI consumers
+    {
+        echo '{'
+        echo '  "entries": ['
+        first=1
+        total_chars=0
+        trim_count=0
+        printf '%s\n' "$SORTED" | while IFS=$'\t' read -r size type path; do
+            [ -z "$size" ] && continue
+            tokens=$(( size / 4 ))
+            flag="OK"
+            [ "$size" -ge "$THRESHOLD_CHARS" ] && flag="TRIM"
+            [ "$first" = "0" ] && echo ','
+            printf '    {"size_chars": %s, "tokens_est": %d, "type": "%s", "flag": "%s", "path": "%s"}' \
+                "$size" "$tokens" "$type" "$flag" "$path"
+            first=0
+        done
+        echo ''
+        echo '  ],'
+        # Recompute totals (subshell scoping)
+        total_chars=$(printf '%s\n' "$SORTED" | awk -F'\t' '{s += $1} END {print s+0}')
+        total_tokens=$(( total_chars / 4 ))
+        trim_count=$(printf '%s\n' "$SORTED" | awk -F'\t' -v t="$THRESHOLD_CHARS" '$1 >= t {n++} END {print n+0}')
+        printf '  "total_chars": %s,\n' "$total_chars"
+        printf '  "total_tokens_est": %s,\n' "$total_tokens"
+        printf '  "threshold_tokens": %s,\n' "$THRESHOLD_TOKENS"
+        printf '  "trim_candidate_count": %s\n' "$trim_count"
+        echo '}'
+    }
+else
+    # Human-readable table
+    printf '%-10s %-10s %-12s %-6s %s\n' "SIZE_CHARS" "EST_TOKENS" "TYPE" "FLAG" "PATH"
+    printf '%-10s %-10s %-12s %-6s %s\n' "----------" "----------" "------------" "------" "----"
+    printf '%s\n' "$SORTED" | while IFS=$'\t' read -r size type path; do
+        [ -z "$size" ] && continue
+        tokens=$(( size / 4 ))
+        flag="OK"
+        [ "$size" -ge "$THRESHOLD_CHARS" ] && flag="TRIM"
+        # Strip $ROOT prefix so paths are relative for readability
+        rel="${path#${ROOT}/}"
+        printf '%-10s %-10s %-12s %-6s %s\n' "$size" "$tokens" "$type" "$flag" "$rel"
+    done
+    echo ""
+    total_chars=$(printf '%s\n' "$SORTED" | awk -F'\t' '{s += $1} END {print s+0}')
+    total_tokens=$(( total_chars / 4 ))
+    trim_count=$(printf '%s\n' "$SORTED" | awk -F'\t' -v t="$THRESHOLD_CHARS" '$1 >= t {n++} END {print n+0}')
+    printf 'Total: %s chars (~%s tokens). %s trim candidates (>=%s tokens).\n' \
+        "$total_chars" "$total_tokens" "$trim_count" "$THRESHOLD_TOKENS"
+fi

--- a/tests/test-audit-session-load.sh
+++ b/tests/test-audit-session-load.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Quality tests for scripts/audit-session-load.sh — token bloat audit phase 2.
+# Tests use isolated fixture directories (no real repo state) so the "trim
+# candidate" detection can be proven against known sizes.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT="$SCRIPT_DIR/../scripts/audit-session-load.sh"
+
+PASSED=0
+FAILED=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+make_temp() { mktemp -d "${TMPDIR:-/tmp}/audit-session-load-XXXXXX"; }
+
+# Fixture builder: writes a session-loadable file at $1 with $2 chars of 'A'
+make_file_with_size() {
+    local path="$1" size="$2"
+    mkdir -p "$(dirname "$path")"
+    awk -v n="$size" 'BEGIN { for (i = 0; i < n; i++) printf "A"; }' > "$path"
+}
+
+echo "=== Token bloat audit phase 2 — quality tests ==="
+echo ""
+
+test_audit_exists_and_executable() {
+    if [ -x "$AUDIT" ]; then
+        pass "scripts/audit-session-load.sh exists and is executable"
+    else
+        fail "audit script missing or not executable: $AUDIT"
+    fi
+}
+
+test_audit_flags_oversized_skill_as_trim_candidate() {
+    local d
+    d=$(make_temp)
+    make_file_with_size "$d/skills/sdlc/SKILL.md" 25000
+    make_file_with_size "$d/hooks/tiny.sh" 100
+    local output
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" 2>&1)
+    rm -rf "$d"
+    if echo "$output" | awk '$4 == "TRIM" && $5 ~ /sdlc\/SKILL\.md/' | grep -q TRIM; then
+        pass "audit flags 25K-char SKILL.md as TRIM candidate (proves >=5K-token detection)"
+    else
+        fail "audit should flag oversized skill as TRIM, got: $output"
+    fi
+}
+
+test_audit_does_not_flag_small_files() {
+    local d
+    d=$(make_temp)
+    make_file_with_size "$d/CLAUDE.md" 1000
+    make_file_with_size "$d/SDLC.md" 500
+    local output
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" 2>&1)
+    rm -rf "$d"
+    if echo "$output" | grep -q "TRIM"; then
+        fail "audit should NOT flag <5K-token files as TRIM, got: $output"
+    else
+        pass "audit does not flag <5K-token files (250-token CLAUDE.md stays OK)"
+    fi
+}
+
+test_audit_threshold_boundary_inclusive() {
+    local d
+    d=$(make_temp)
+    make_file_with_size "$d/CLAUDE.md" 20000
+    local output
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" 2>&1)
+    rm -rf "$d"
+    if echo "$output" | awk '$4 == "TRIM" && $5 ~ /CLAUDE\.md/' | grep -q TRIM; then
+        pass "audit flags file AT threshold (20000 chars / 5000 tokens) as TRIM (inclusive)"
+    else
+        fail "threshold should be inclusive (>=5000 tokens flags), got: $output"
+    fi
+}
+
+test_audit_json_output_includes_trim_count() {
+    local d output
+    d=$(make_temp)
+    make_file_with_size "$d/skills/sdlc/SKILL.md" 25000
+    make_file_with_size "$d/CLAUDE.md" 500
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" --json 2>&1)
+    rm -rf "$d"
+    if echo "$output" | grep -q '"trim_candidate_count": 1' \
+        && echo "$output" | grep -q '"flag": "TRIM"' \
+        && echo "$output" | grep -q '"flag": "OK"'; then
+        pass "audit --json emits trim_candidate_count + per-entry flags"
+    else
+        fail "audit --json should emit machine-readable trim count, got: $output"
+    fi
+}
+
+test_audit_threshold_override() {
+    local d output
+    d=$(make_temp)
+    make_file_with_size "$d/CLAUDE.md" 10000
+    output=$(SDLC_AUDIT_ROOT="$d" SDLC_AUDIT_THRESHOLD_TOKENS=1000 "$AUDIT" 2>&1)
+    rm -rf "$d"
+    if echo "$output" | awk '$4 == "TRIM" && $5 ~ /CLAUDE\.md/' | grep -q TRIM; then
+        pass "audit respects SDLC_AUDIT_THRESHOLD_TOKENS override (1000-token threshold flags 2500-token file)"
+    else
+        fail "audit should honor threshold override, got: $output"
+    fi
+}
+
+test_audit_empty_repo_no_crash() {
+    local d output rc=0
+    d=$(make_temp)
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" 2>&1) || rc=$?
+    rm -rf "$d"
+    if [ "$rc" -eq 0 ] && echo "$output" | grep -qiE 'no session-loaded assets|0 trim'; then
+        pass "audit on empty repo exits cleanly (rc=0, sane message)"
+    else
+        fail "audit should handle empty repo gracefully (rc=$rc, got: $output)"
+    fi
+}
+
+test_audit_ranks_by_size_descending() {
+    local d output
+    d=$(make_temp)
+    make_file_with_size "$d/CLAUDE.md" 1000
+    make_file_with_size "$d/SDLC.md" 5000
+    make_file_with_size "$d/TESTING.md" 3000
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" 2>&1)
+    rm -rf "$d"
+    local first second third
+    first=$(echo "$output" | awk 'NR==3 {print $5}')
+    second=$(echo "$output" | awk 'NR==4 {print $5}')
+    third=$(echo "$output" | awk 'NR==5 {print $5}')
+    if [[ "$first" == *SDLC.md* ]] \
+        && [[ "$second" == *TESTING.md* ]] \
+        && [[ "$third" == *CLAUDE.md* ]]; then
+        pass "audit ranks entries by size descending (5K SDLC > 3K TESTING > 1K CLAUDE)"
+    else
+        fail "audit should rank by size DESC (got order: $first, $second, $third)"
+    fi
+}
+
+test_audit_exists_and_executable
+test_audit_flags_oversized_skill_as_trim_candidate
+test_audit_does_not_flag_small_files
+test_audit_threshold_boundary_inclusive
+test_audit_json_output_includes_trim_count
+test_audit_threshold_override
+test_audit_empty_repo_no_crash
+test_audit_ranks_by_size_descending
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+if [ "$FAILED" -gt 0 ]; then exit 1; fi
+echo "All token bloat audit tests passed!"


### PR DESCRIPTION
## Summary

Phase 2 of the token-bloat audit (ROADMAP "Next Up" item 8). Phase 1 fixed the smoking gun (dual-channel hook dedupe). Phase 2 is observability: an inventory tool that ranks every session-loaded asset by char count and flags anything ≥5K tokens as a TRIM candidate.

**Findings on running against the wizard repo:**
- `skills/sdlc/SKILL.md`: 12.4K tokens (TRIM)
- `skills/update/SKILL.md`: 8.6K tokens (TRIM)
- All other assets under threshold

No trimming in this PR — that's a follow-up. Per Codex consult: behavior-change items deserve their own PRs in fresh context.

## Test plan

- [x] **8 quality tests** in `tests/test-audit-session-load.sh` using fixtures of known size — proves the ≥5K-token detection works (NOT just that the script exists)
- [x] Covers: oversized flagged TRIM, small not flagged, threshold inclusive boundary, --json output, SDLC_AUDIT_THRESHOLD_TOKENS override, empty-repo no crash, descending sort
- [x] CI wired (`ci.yml` + `CONTRIBUTING.md` test list)
- [x] No regressions: all 12 monitored test scripts green
- [x] Codex skipped (mechanical read-only tool, low risk per its own consult earlier this session)