### PR TITLE
chore(ci): zero-API weekly-update — delete check-updates Claude-ranker (v1.54.0, ROADMAP #231 Phase 3d)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.53.0",
+      "version": "1.54.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,10 +1,13 @@
 name: Weekly Update
 
-# NOTE: cron disabled as of ROADMAP #212 (Option 1). This workflow has 9
-# `anthropics/claude-code-action@v1` blocks that burn API credits every run.
-# Full migration to local-shepherd-based simulation is tracked as a #212
-# follow-up. Until then: manual-only via workflow_dispatch, and only when
-# you have API credit budget.
+# NOTE: cron is currently disabled (per ROADMAP #212 Option 1). After ROADMAP
+# #231 Phase 3a/3b/3c/3d (v1.51.0–v1.54.0), this workflow has ZERO
+# `anthropics/claude-code-action@v1` blocks — all API-burning logic was
+# deleted (version-test, prove-it-test, community-e2e-test, scan-community,
+# and the in-job Claude release-ranker). Only the cheap GH-API release
+# detection + auto-update PR creation remains. Cron can be safely re-enabled
+# now (~$0.30/run); leaving it manual-dispatch until a deliberate Phase 4
+# decision.
 
 on:
   # schedule disabled — see note above. Manual via workflow_dispatch only.
@@ -135,128 +138,29 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build analysis prompt
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        id: build-prompt
-        run: |
-          # Assemble analysis prompt from template + release context
-          RELEASE_COUNT="${{ steps.latest-release.outputs.release_count }}"
-          {
-            cat .github/prompts/analyze-release.md
-            echo ""
-            echo "## Release(s) to Analyze"
-            echo ""
-            if [ "$RELEASE_COUNT" -gt 1 ]; then
-              echo "**Versions:** $RELEASE_COUNT releases from ${{ steps.last-version.outputs.version }} to ${{ steps.latest-release.outputs.latest_version }}"
-            else
-              echo "**Version:** ${{ steps.latest-release.outputs.latest_version }}"
-            fi
-            echo "**Latest Date:** ${{ steps.latest-release.outputs.release_date }}"
-            echo "**URL:** ${{ steps.latest-release.outputs.release_url }}"
-            echo ""
-            echo "**Release Notes:**"
-            cat /tmp/release_body.md
-          } > /tmp/analysis_prompt.md
-
-          # Pass assembled prompt as multi-line output
-          {
-            echo "prompt<<PROMPT_EOF"
-            cat /tmp/analysis_prompt.md
-            echo "PROMPT_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Analyze release with Claude
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        id: analyze
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: "--bare"
-
-      - name: Extract analysis from execution output
+      # ROADMAP #231 Phase 3d (v1.54.0): the in-CI Claude release-ranker was
+      # deleted. The original chain was: Build analysis prompt → Analyze with
+      # claude-code-action@v1 → Extract from execution output → Parse JSON.
+      # That chain made one Anthropic API call per release detection, with no
+      # signal load-bearing on the auto-update PR (relevance label is advisory).
+      #
+      # Replacement: write a placeholder analysis.json with relevance=UNKNOWN
+      # and a summary that tells the maintainer to run analyze-release.md
+      # locally on Max. The PR still gets created; the relevance label is
+      # filled in when the maintainer reviews.
+      - name: Generate placeholder analysis (Claude-ranker moved to manual on-Max)
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
         run: |
-          # claude-code-action saves Claude's response to this file
-          OUTPUT_FILE="${RUNNER_TEMP:-/tmp}/claude-execution-output.json"
-
-          if [ ! -f "$OUTPUT_FILE" ]; then
-            echo "::warning::No execution output file found"
-            echo '{"relevance":"LOW","summary":"Analysis unavailable"}' > /tmp/analysis.json
-            exit 0
-          fi
-
-          # The execution output format varies:
-          # - Array: [{role:"assistant",content:[{type:"text",text:"..."}]}, ...]
-          # - Object: {result:"...", output:"...", ...}
-          IS_ARRAY=$(jq -r 'if type == "array" then "true" else "false" end' "$OUTPUT_FILE" 2>/dev/null || echo "false")
-          echo "Output format: is_array=$IS_ARRAY"
-
-          if [ "$IS_ARRAY" = "true" ]; then
-            # Array of conversation messages — find the last assistant text
-            RESPONSE_TEXT=$(jq -r '
-              [.[] | select(type == "object")] |
-              [.[] | select(.role == "assistant" or .type == "result")] |
-              last |
-              if .content then
-                (if (.content | type) == "array" then
-                  [.content[] | select(.type == "text") | .text] | join("")
-                else
-                  .content
-                end)
-              elif .text then .text
-              elif .result then .result
-              else empty
-              end
-            ' "$OUTPUT_FILE" 2>/dev/null || echo "")
-          else
-            # Direct object with .result or .output
-            RESPONSE_TEXT=$(jq -r '.result // .output // empty' "$OUTPUT_FILE" 2>/dev/null || echo "")
-          fi
-
-          if [ -z "$RESPONSE_TEXT" ]; then
-            echo "::warning::Could not extract text (is_array=$IS_ARRAY)"
-            echo "::warning::First 3 items: $(jq -c '.[0:3] | [.[] | keys]' "$OUTPUT_FILE" 2>/dev/null || echo "N/A")"
-            echo '{"relevance":"LOW","summary":"Analysis extraction failed"}' > /tmp/analysis.json
-            exit 0
-          fi
-
-          echo "Response text length: ${#RESPONSE_TEXT}"
-
-          # The response text contains JSON (possibly wrapped in markdown code blocks)
-          echo "$RESPONSE_TEXT" | sed -n '/^```json/,/^```$/p' | sed '1d;$d' > /tmp/analysis.json 2>/dev/null
-
-          # If no code block, try raw text as JSON
-          if [ ! -s /tmp/analysis.json ]; then
-            echo "$RESPONSE_TEXT" > /tmp/analysis.json
-          fi
-
-          # Validate it's parseable JSON
-          if ! jq empty /tmp/analysis.json 2>/dev/null; then
-            echo "::warning::Not valid JSON, extracting JSON object from text"
-            # Find a line containing a JSON object with relevance key
-            echo "$RESPONSE_TEXT" | python3 -c "
-          import sys, json, re
-          text = sys.stdin.read()
-          # Try to find JSON block in text
-          match = re.search(r'\{[^{}]*\"relevance\"[^{}]*\}', text, re.DOTALL)
-          if not match:
-              # Try multi-line JSON
-              match = re.search(r'\{.*?\"relevance\".*?\}', text, re.DOTALL)
-          if match:
-              try:
-                  obj = json.loads(match.group())
-                  print(json.dumps(obj))
-              except:
-                  print(json.dumps({'relevance':'LOW','summary':'JSON parse failed'}))
-          else:
-              print(json.dumps({'relevance':'LOW','summary':'No JSON found in response'}))
-          " > /tmp/analysis.json
-          fi
-
-          echo "Analysis extracted successfully"
-          jq -r '.relevance // "unknown"' /tmp/analysis.json
+          cat > /tmp/analysis.json <<'JSONEOF'
+          {
+            "relevance": "UNKNOWN",
+            "summary": "Run `claude --print --allowedTools 'WebFetch,Read,Bash' \"$(cat .github/prompts/analyze-release.md)\\n\\n## Release(s) to Analyze\\n\\nVersion: <ver>, URL: <url>\\n\\nRelease Notes:\\n<paste-from-PR-body>\"` locally on Max to generate a real relevance/summary. The auto-update PR is still useful as a notification + the version file bump.",
+            "plugin_check": {"replaces_custom": []}
+          }
+          JSONEOF
+          # Legacy "Extract" step preserved as a no-op shim — the chain below
+          # reads /tmp/analysis.json which we just wrote above.
+          echo "Placeholder analysis written. Maintainer should run analyze-release.md locally."
 
       - name: Parse analysis result
         if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
@@ -298,10 +202,11 @@ jobs:
 
           # Determine relevance indicator
           case "$RELEVANCE" in
-            HIGH)   INDICATOR="HIGH - Action recommended" ;;
-            MEDIUM) INDICATOR="MEDIUM - Review suggested" ;;
-            LOW)    INDICATOR="LOW - Informational only" ;;
-            *)      INDICATOR="$RELEVANCE" ;;
+            HIGH)    INDICATOR="HIGH - Action recommended" ;;
+            MEDIUM)  INDICATOR="MEDIUM - Review suggested" ;;
+            LOW)     INDICATOR="LOW - Informational only" ;;
+            UNKNOWN) INDICATOR="UNKNOWN - run local analysis (see below)" ;;
+            *)       INDICATOR="$RELEVANCE" ;;
           esac
 
           cat > /tmp/pr_body.md << PREOF
@@ -311,31 +216,30 @@ jobs:
           **Relevance:** $INDICATOR
           **Release URL:** ${{ steps.latest-release.outputs.release_url }}
 
-          ### Summary
-          PREOF
+          ### Local Analysis (ROADMAP #231 Phase 3d, v1.54.0+)
 
-          # Append summary from file (sanitized)
-          jq -r '.summary // "No summary"' /tmp/analysis.json >> /tmp/pr_body.md
+          The CI Claude-ranker was deleted in v1.54.0 (#231 Phase 3d) — no API spend on every release. To get HIGH/MEDIUM/LOW relevance, run locally on Max:
+
+          \`\`\`bash
+          gh release view ${{ steps.latest-release.outputs.latest_version }} --repo anthropics/claude-code --json body --jq .body > /tmp/release_notes.md
+          claude --print --allowedTools "Read,Bash" \\
+            "\$(cat .github/prompts/analyze-release.md)\\n\\n## Release to Analyze\\n\\n**Version:** ${{ steps.latest-release.outputs.latest_version }}\\n**URL:** ${{ steps.latest-release.outputs.release_url }}\\n\\n**Release Notes:**\\n\$(cat /tmp/release_notes.md)"
+          \`\`\`
+
+          Update the PR body with the relevance verdict before merging.
+          PREOF
 
           cat >> /tmp/pr_body.md << 'PREOF'
 
           ### Why This PR Exists
 
-          All Claude Code releases get a PR for visibility. The relevance level helps you prioritize:
+          All Claude Code releases get a PR for visibility. Run the local analyze command (above) to get the relevance:
           - **HIGH**: Contains changes that directly affect SDLC enforcement
           - **MEDIUM**: Contains useful improvements worth reviewing
           - **LOW**: Routine update, merge at your convenience
 
-          ### Relevance Analysis
-          ```json
-          PREOF
-
-          cat /tmp/analysis.json >> /tmp/pr_body.md
-
-          cat >> /tmp/pr_body.md << 'PREOF'
-          ```
-
           ### Review Checklist
+          - [ ] Ran local analyze-release.md — relevance set
           - [ ] Aligns with KISS principle
           - [ ] Actually needed for SDLC enforcement
           - [ ] No over-engineering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.54.0] - 2026-04-29
+
+### Removed
+
+- **In-CI Claude-ranker steps in `.github/workflows/weekly-update.yml`** (~150 lines: Build analysis prompt + Analyze release with Claude + Extract from output + parse). Closes ROADMAP #231 Phase 3d. Replaced with a 12-line placeholder step that writes a stub `/tmp/analysis.json` with `relevance: "UNKNOWN"` and a summary linking the maintainer to the manual command. The auto-update PR body now surfaces the on-Max invocation:
+
+  ```bash
+  gh release view <version> --repo anthropics/claude-code --json body --jq .body > /tmp/release_notes.md
+  claude --print --allowedTools "Read,Bash" \
+    "$(cat .github/prompts/analyze-release.md)\n\n## Release\n\nVersion: <ver>\n\nNotes:\n$(cat /tmp/release_notes.md)"
+  ```
+
+### Phase 3 cumulative (after this release)
+
+- **weekly-update.yml is now zero-API-spend.** No `claude-code-action@v1` calls in the workflow at all. Cron burn down from $25-55/week (pre-Phase 1) to $0/week. Only ~$0.30/run for the GH API release detection itself.
+- 5 jobs/workflows deleted: monthly-research workflow (Phase 1), prove-it-test job (Phase 2), version-test job (Phase 3a), community-e2e-test job (Phase 3b), scan-community job (Phase 3c). Plus the in-job analysis chain in check-updates (Phase 3d).
+- Phase 4 next: shrink weekly-update.yml further (currently 285 lines after Phase 3d) or fold detection into the session-start hook.
+
+### Changed
+
+- `tests/test-workflow-triggers.sh`: 2 tests updated. Test 54 inverted to assert no `uses: anthropics/claude-code-action` directive remains (regression check). Test 109 stubbed (the deleted analysis step's `--bare` flag check is moot).
+
+### Files
+
+- `.github/workflows/weekly-update.yml` (-99 lines net: -150 deleted ranker chain, +51 placeholder + maintainer-instructions PR body)
+- `tests/test-workflow-triggers.sh` (2 tests)
+- Version bump 1.53.0 → 1.54.0
+
 ## [1.53.0] - 2026-04-29
 
 ### Removed
@@ -1076,4 +1104,3 @@ The wizard now tracks completed steps in SDLC.md metadata comments. Old users ru
 - Self-review workflow
 - Testing Diamond philosophy
 - Mini-retro after tasks
-

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2974,7 +2974,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.53.0 -->
+<!-- SDLC Wizard Version: 1.54.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4039,7 +4039,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.53.0 -->
+<!-- SDLC Wizard Version: 1.54.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.53.0 -->
+<!-- SDLC Wizard Version: 1.54.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.53.0 |
+| Wizard Version | 1.54.0 |
 | Last Updated | 2026-04-27 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.53.0
+Latest:    1.54.0
 
 What changed:
+- [1.54.0] delete check-updates Claude-ranker (#231 Phase 3d) — weekly-update.yml is now zero-API-spend; auto-update PR body links the manual analyze-release.md command
 - [1.53.0] delete scan-community cron (#231 Phase 3c) — manual `claude --print` invocation of analyze-community.md
 - [1.52.0] delete community-e2e-test cron (#231 Phase 3b) — manual local-shepherd review of scan-community digest
 - [1.51.0] delete version-test cron (#231 Phase 3a) — manual local-Max replacement via npm i + local-shepherd

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -704,7 +704,9 @@ if 'outputs.response' in content:
     fi
 }
 
-# Test 54: weekly-update must extract analysis from execution output file
+# Test 54: n/a per #231 Phase 3d — Claude-ranker step deleted, no execution
+# output file to extract from. Replaced with regression check that the
+# placeholder analysis step writes /tmp/analysis.json.
 test_weekly_update_extracts_from_output_file() {
     WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
 
@@ -713,21 +715,30 @@ test_weekly_update_extracts_from_output_file() {
         return
     fi
 
-    python3 -c "
+    # Regression: no `uses: anthropics/claude-code-action` directive should
+    # remain (Phase 3d removed it). Comments mentioning the old action are OK.
+    # Two YAML step forms must both be caught:
+    #   "      - uses: anthropics/claude-code-action@v1"  (compact form)
+    #   "      uses: anthropics/claude-code-action@v1"   (continuation under -name:)
+    # Use Python YAML parsing to catch both reliably (Codex round 1 P1).
+    USES_CHECK=$(python3 -c "
 import yaml
 with open('$WORKFLOW') as f:
     wf = yaml.safe_load(f)
 for job_name, job in wf.get('jobs', {}).items():
     for step in job.get('steps', []):
-        run = step.get('run', '')
-        if 'claude-execution-output.json' in run and 'analysis' in step.get('name', '').lower():
-            print('READS_OUTPUT_FILE')
-" > /tmp/output_file_check.txt 2>&1
-
-    if grep -q "READS_OUTPUT_FILE" /tmp/output_file_check.txt; then
-        pass "weekly-update extracts analysis from execution output file"
+        uses = step.get('uses', '')
+        if 'anthropics/claude-code-action' in uses:
+            print('RESURRECTED:' + job_name + '/' + (step.get('name') or step.get('id') or 'unnamed'))
+print('OK')
+" 2>&1)
+    if echo "$USES_CHECK" | grep -q "RESURRECTED:"; then
+        DETAIL=$(echo "$USES_CHECK" | grep "RESURRECTED:" | sed 's/RESURRECTED://')
+        fail "weekly-update.yml has resurrected claude-code-action step: $DETAIL — Phase 3d removed all API spend"
+    elif grep -q "tmp/analysis.json" "$WORKFLOW"; then
+        pass "weekly-update writes /tmp/analysis.json placeholder (Phase 3d Claude-ranker deleted)"
     else
-        fail "weekly-update does not read claude-execution-output.json for analysis (result will be empty)"
+        fail "weekly-update should write /tmp/analysis.json placeholder (Phase 3d expected)"
     fi
 }
 
@@ -1236,17 +1247,9 @@ test_bare_pr_review() {
     fi
 }
 
-# Test 109: weekly-update.yml analysis step uses --bare
+# Test 109: n/a per #231 Phase 3d — "Analyze release with Claude" step deleted.
 test_bare_weekly_update_analysis() {
-    local WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
-
-    # The "Analyze release with Claude" step should have --bare
-    # Check that the step's claude-code-action invocation includes --bare
-    if sed -n '/name: Analyze release with Claude/,/name:/p' "$WORKFLOW" | grep -q '\-\-bare'; then
-        pass "weekly-update.yml analysis step uses --bare"
-    else
-        fail "weekly-update.yml 'Analyze release with Claude' should use --bare"
-    fi
+    pass "test_bare_weekly_update_analysis n/a per #231 Phase 3d (Claude-ranker step deleted)"
 }
 
 # Test 110: DELETED — monthly-research.yml removed per ROADMAP #231 Phase 1


### PR DESCRIPTION
## Summary

- **Deleted**: ~150-line Claude-ranker chain from check-updates job (Build prompt → Analyze → Extract → Parse). Replaced with 12-line placeholder.
- **Result**: weekly-update.yml has **ZERO** claude-code-action@v1 blocks. Phase 3 done.
- **Replacement**: auto-update PR body links the maintainer to a manual on-Max command using analyze-release.md.

## Phase 3 cumulative (after this release)

5 jobs/workflows deleted across 4 phases + this in-job chain:
- Phase 1: monthly-research workflow (519 lines)
- Phase 2: prove-it-test job (251 lines)
- Phase 3a: version-test job (319 lines)
- Phase 3b: community-e2e-test job (231 lines)
- Phase 3c: scan-community job (252 lines)
- Phase 3d (this PR): check-updates Claude-ranker chain (~150 lines)

**Cron burn: $25-55/week → ~$0.30/run** (just the GH-API release detection itself).

## Codex review (NOT CERTIFIED 7/10 → CERTIFIED 10/10)

Round 1 found:
- **P1**: Test 54 grep `^\s*uses:` didn't catch `- uses:` (with leading dash). Mutation-injected resurrected step passed test 54 vacuously.
- **P2**: Top-of-file workflow comment still claimed "9 claude-code-action blocks burning credits"
- **P2**: CHANGELOG cumulative count off-by-one (4 → 5)

Round 2 fixes (CERTIFIED):
- Test 54 rewritten to use Python YAML parsing — iterates every step in every job, catches both `- uses:` and `uses:` forms. Mutation-verified.
- weekly-update.yml header rewritten with phase-by-phase deletion summary.
- CHANGELOG count corrected to 5.

## Test plan

- [x] All 45 test scripts pass (CI runs 54)
- [x] YAML validation
- [x] Codex CERTIFIED 10/10 (round 2)
- [x] Mutation-verified Test 54 (both `- uses:` and `uses:` forms)
- [ ] CI green (validate)
- [ ] Merge after CI green
- [ ] Tag v1.54.0 + npm publish

## Files

- `.github/workflows/weekly-update.yml` (-99 net lines: header rewritten, ranker chain replaced)
- `tests/test-workflow-triggers.sh` (Test 54 → YAML parsing, Test 109 stubbed)
- Version bumps to 1.54.0

Closes ROADMAP #231 Phase 3d. Phase 4 (final shrink/delete decision) remains.