### PR TITLE
chore(ci): shrink weekly-update.yml dead code (v1.55.0, ROADMAP #231 Phase 4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.54.0",
+      "version": "1.55.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,281 +1,154 @@
 name: Weekly Update
 
-# NOTE: cron is currently disabled (per ROADMAP #212 Option 1). After ROADMAP
-# #231 Phase 3a/3b/3c/3d (v1.51.0–v1.54.0), this workflow has ZERO
-# `anthropics/claude-code-action@v1` blocks — all API-burning logic was
-# deleted (version-test, prove-it-test, community-e2e-test, scan-community,
-# and the in-job Claude release-ranker). Only the cheap GH-API release
-# detection + auto-update PR creation remains. Cron can be safely re-enabled
-# now (~$0.30/run); leaving it manual-dispatch until a deliberate Phase 4
-# decision.
+# Detect new claude-code releases and open an auto-update PR with the
+# version-file bump. Zero Anthropic API spend — the in-CI Claude-ranker
+# was deleted in #231 Phase 3d (v1.54.0). To get HIGH/MEDIUM/LOW
+# relevance, the maintainer runs the manual analyze-release command
+# documented in the auto-update PR body locally on Max.
+#
+# Cron stays disabled (#212 Option 1); workflow_dispatch only.
 
 on:
   # schedule disabled — see note above. Manual via workflow_dispatch only.
-  # - cron: '0 9 * * 1'
+  # - cron: '0 9 * * 1'  # Monday 09:00 UTC (kept commented as documentation
+  #                         and so cron-collision tests can read the
+  #                         intended slot vs other workflows like
+  #                         weekly-api-update.yml at 10:00 UTC Monday).
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
-  # issues: write was needed by the deleted scan-community job's digest issue
-  # creation step (#231 Phase 3c, v1.53.0). Dropped — auto-update PR creation
-  # only needs contents+pull-requests+actions.
   actions: write
-
-env:
-  # VERSION_SCENARIO was used by the deleted version-test job (#231 Phase 3a).
-  # Retained here as a no-op marker until the next workflow refactor; harmless.
-  VERSION_SCENARIO: version-upgrade
 
 jobs:
   check-updates:
     runs-on: ubuntu-latest
 
     outputs:
-      needs_update: ${{ steps.check-update.outputs.needs_update }}
-      latest_version: ${{ steps.latest-release.outputs.latest_version }}
-      skip: ${{ steps.existing-pr.outputs.skip }}
-      has_overlap: ${{ steps.parse.outputs.has_overlap }}
-      overlap_paths: ${{ steps.parse.outputs.overlap_paths }}
+      needs_update: ${{ steps.detect.outputs.needs_update }}
+      latest_version: ${{ steps.detect.outputs.latest_version }}
+      skip: ${{ steps.detect.outputs.skip }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Read last checked version
-        id: last-version
-        run: |
-          if [ -f .github/last-checked-version.txt ]; then
-            VERSION=$(cat .github/last-checked-version.txt | tr -d '\n')
-          else
-            VERSION="v0.0.0"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Last checked version: $VERSION"
-
-      - name: Fetch Claude Code releases
-        id: latest-release
+      - name: Detect new release
+        id: detect
         env:
           GH_TOKEN: ${{ github.token }}
-          LAST_VERSION: ${{ steps.last-version.outputs.version }}
         run: |
-          # Fetch recent releases (one API call, covers any realistic weekly gap)
-          RELEASES_JSON=$(gh api "repos/anthropics/claude-code/releases?per_page=100" 2>/dev/null) || {
+          set -euo pipefail
+
+          # Read last-checked version (default to v0.0.0 on first run)
+          if [ -f .github/last-checked-version.txt ]; then
+            LAST=$(cat .github/last-checked-version.txt | tr -d '\n')
+          else
+            LAST="v0.0.0"
+          fi
+          echo "Last checked: $LAST"
+
+          # Fetch the most recent release
+          RELEASES_JSON=$(gh api "repos/anthropics/claude-code/releases?per_page=1" 2>/dev/null) || {
             echo "::error::Failed to fetch Claude Code releases from GitHub API"
             exit 1
           }
-
-          # Extract latest version (first entry = most recent)
-          LATEST_VERSION=$(echo "$RELEASES_JSON" | jq -r '.[0].tag_name')
-          if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
+          LATEST=$(echo "$RELEASES_JSON" | jq -r '.[0].tag_name')
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
             echo "::error::Could not parse tag_name from releases JSON"
             exit 1
           fi
+          DATE=$(echo "$RELEASES_JSON" | jq -r '.[0].published_at // "unknown"')
+          URL=$(echo "$RELEASES_JSON" | jq -r '.[0].html_url // ""')
 
-          RELEASE_DATE=$(echo "$RELEASES_JSON" | jq -r '.[0].published_at // "unknown"')
-          RELEASE_URL=$(echo "$RELEASES_JSON" | jq -r '.[0].html_url // ""')
-
-          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
-          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
-
-          # Filter to releases newer than last-checked-version (jq semver comparison)
-          echo "$RELEASES_JSON" | jq --arg last "$LAST_VERSION" '
-            [.[] | select(.tag_name != $last) | select(
-              (.tag_name | ltrimstr("v") | split(".") | map(tonumber)) as $ver |
-              ($last | ltrimstr("v") | split(".") | map(tonumber)) as $chk |
-              ($ver[0] > $chk[0]) or
-              ($ver[0] == $chk[0] and $ver[1] > $chk[1]) or
-              ($ver[0] == $chk[0] and $ver[1] == $chk[1] and $ver[2] > $chk[2])
-            )] | reverse
-          ' > /tmp/new_releases.json
-
-          RELEASE_COUNT=$(jq 'length' /tmp/new_releases.json)
-          echo "release_count=$RELEASE_COUNT" >> $GITHUB_OUTPUT
-          echo "Found $RELEASE_COUNT new release(s) since $LAST_VERSION"
-          echo "Latest version: $LATEST_VERSION ($RELEASE_DATE)"
-
-          # Build combined release body for analysis
-          if [ "$RELEASE_COUNT" -eq 0 ]; then
-            echo "" > /tmp/release_body.md
-          elif [ "$RELEASE_COUNT" -eq 1 ]; then
-            # Single release: plain body (backward compatible)
-            jq -r '.[0].body // ""' /tmp/new_releases.json > /tmp/release_body.md
-          else
-            # Multiple releases: numbered sections, oldest-first
-            jq -r '
-              to_entries | .[] |
-              "## Release \(.key + 1): \(.value.tag_name) (\(.value.published_at // "unknown"))\n\(.value.body // "(no release notes)")\n\n---\n"
-            ' /tmp/new_releases.json > /tmp/release_body.md
-          fi
-
-      - name: Check if update needed
-        id: check-update
-        run: |
-          LAST="${{ steps.last-version.outputs.version }}"
-          LATEST="${{ steps.latest-release.outputs.latest_version }}"
+          echo "latest_version=$LATEST" >> $GITHUB_OUTPUT
+          echo "release_date=$DATE" >> $GITHUB_OUTPUT
+          echo "release_url=$URL" >> $GITHUB_OUTPUT
 
           if [ "$LAST" = "$LATEST" ]; then
-            echo "No new release. Last: $LAST, Latest: $LATEST"
             echo "needs_update=false" >> $GITHUB_OUTPUT
-          else
-            echo "New release found! $LAST -> $LATEST"
-            echo "needs_update=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Up to date ($LATEST)"
+            exit 0
           fi
+          echo "needs_update=true" >> $GITHUB_OUTPUT
+          echo "New release: $LAST -> $LATEST"
 
-      - name: Check for existing PR for this version
-        if: steps.check-update.outputs.needs_update == 'true'
-        id: existing-pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.latest-release.outputs.latest_version }}"
-          EXISTING=$(gh pr list --head "auto-update/claude-code-${VERSION}" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          # Skip if a PR for this version already exists
+          BRANCH="auto-update/claude-code-${LATEST}"
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -n "$EXISTING" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "PR #$EXISTING already exists for $VERSION - skipping"
+            echo "PR #$EXISTING already exists for $LATEST — skipping"
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      # ROADMAP #231 Phase 3d (v1.54.0): the in-CI Claude release-ranker was
-      # deleted. The original chain was: Build analysis prompt → Analyze with
-      # claude-code-action@v1 → Extract from execution output → Parse JSON.
-      # That chain made one Anthropic API call per release detection, with no
-      # signal load-bearing on the auto-update PR (relevance label is advisory).
-      #
-      # Replacement: write a placeholder analysis.json with relevance=UNKNOWN
-      # and a summary that tells the maintainer to run analyze-release.md
-      # locally on Max. The PR still gets created; the relevance label is
-      # filled in when the maintainer reviews.
-      - name: Generate placeholder analysis (Claude-ranker moved to manual on-Max)
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        run: |
-          cat > /tmp/analysis.json <<'JSONEOF'
-          {
-            "relevance": "UNKNOWN",
-            "summary": "Run `claude --print --allowedTools 'WebFetch,Read,Bash' \"$(cat .github/prompts/analyze-release.md)\\n\\n## Release(s) to Analyze\\n\\nVersion: <ver>, URL: <url>\\n\\nRelease Notes:\\n<paste-from-PR-body>\"` locally on Max to generate a real relevance/summary. The auto-update PR is still useful as a notification + the version file bump.",
-            "plugin_check": {"replaces_custom": []}
-          }
-          JSONEOF
-          # Legacy "Extract" step preserved as a no-op shim — the chain below
-          # reads /tmp/analysis.json which we just wrote above.
-          echo "Placeholder analysis written. Maintainer should run analyze-release.md locally."
-
-      - name: Parse analysis result
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        id: parse
-        run: |
-          # Read from file (safe) instead of shell variable interpolation
-          RELEVANCE=$(jq -r '.relevance // "LOW"' /tmp/analysis.json 2>/dev/null || echo "LOW")
-          SUMMARY=$(jq -r '.summary // "Unable to parse summary"' /tmp/analysis.json 2>/dev/null || echo "Unable to parse summary")
-
-          echo "relevance=$RELEVANCE" >> $GITHUB_OUTPUT
-
-          # Safely encode summary for output (escape newlines)
-          SAFE_SUMMARY=$(echo "$SUMMARY" | tr '\n' ' ' | head -c 500)
-          echo "summary=$SAFE_SUMMARY" >> $GITHUB_OUTPUT
-
-          # Parse overlap signal from replaces_custom
-          OVERLAP_PATHS=$(jq -c '.plugin_check.replaces_custom // []' /tmp/analysis.json 2>/dev/null || echo "[]")
-          OVERLAP_COUNT=$(echo "$OVERLAP_PATHS" | jq 'length' 2>/dev/null || echo "0")
-          if [ "$OVERLAP_COUNT" -gt 0 ]; then
-            echo "has_overlap=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_overlap=false" >> $GITHUB_OUTPUT
-          fi
-          echo "overlap_paths=$OVERLAP_PATHS" >> $GITHUB_OUTPUT
-
-          echo "Relevance: $RELEVANCE"
-          echo "Summary: $SAFE_SUMMARY"
-          echo "Overlap: $OVERLAP_COUNT path(s)"
-
       - name: Update version file
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        run: |
-          echo "${{ steps.latest-release.outputs.latest_version }}" > .github/last-checked-version.txt
-
-      - name: Build PR body
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
-        run: |
-          RELEVANCE="${{ steps.parse.outputs.relevance }}"
-
-          # Determine relevance indicator
-          case "$RELEVANCE" in
-            HIGH)    INDICATOR="HIGH - Action recommended" ;;
-            MEDIUM)  INDICATOR="MEDIUM - Review suggested" ;;
-            LOW)     INDICATOR="LOW - Informational only" ;;
-            UNKNOWN) INDICATOR="UNKNOWN - run local analysis (see below)" ;;
-            *)       INDICATOR="$RELEVANCE" ;;
-          esac
-
-          cat > /tmp/pr_body.md << PREOF
-          ## Auto-Update: Claude Code ${{ steps.latest-release.outputs.latest_version }}
-
-          **Release:** ${{ steps.latest-release.outputs.latest_version }} (${{ steps.latest-release.outputs.release_date }})
-          **Relevance:** $INDICATOR
-          **Release URL:** ${{ steps.latest-release.outputs.release_url }}
-
-          ### Local Analysis (ROADMAP #231 Phase 3d, v1.54.0+)
-
-          The CI Claude-ranker was deleted in v1.54.0 (#231 Phase 3d) — no API spend on every release. To get HIGH/MEDIUM/LOW relevance, run locally on Max:
-
-          \`\`\`bash
-          gh release view ${{ steps.latest-release.outputs.latest_version }} --repo anthropics/claude-code --json body --jq .body > /tmp/release_notes.md
-          claude --print --allowedTools "Read,Bash" \\
-            "\$(cat .github/prompts/analyze-release.md)\\n\\n## Release to Analyze\\n\\n**Version:** ${{ steps.latest-release.outputs.latest_version }}\\n**URL:** ${{ steps.latest-release.outputs.release_url }}\\n\\n**Release Notes:**\\n\$(cat /tmp/release_notes.md)"
-          \`\`\`
-
-          Update the PR body with the relevance verdict before merging.
-          PREOF
-
-          cat >> /tmp/pr_body.md << 'PREOF'
-
-          ### Why This PR Exists
-
-          All Claude Code releases get a PR for visibility. Run the local analyze command (above) to get the relevance:
-          - **HIGH**: Contains changes that directly affect SDLC enforcement
-          - **MEDIUM**: Contains useful improvements worth reviewing
-          - **LOW**: Routine update, merge at your convenience
-
-          ### Review Checklist
-          - [ ] Ran local analyze-release.md — relevance set
-          - [ ] Aligns with KISS principle
-          - [ ] Actually needed for SDLC enforcement
-          - [ ] No over-engineering
-          - [ ] If replacing custom code, removal is clean
-
-          ---
-          *Generated by weekly-update workflow. You always decide what merges.*
-          PREOF
+        if: steps.detect.outputs.needs_update == 'true' && steps.detect.outputs.skip != 'true'
+        run: echo "${{ steps.detect.outputs.latest_version }}" > .github/last-checked-version.txt
 
       - name: Close stale auto-update PRs
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
+        if: steps.detect.outputs.needs_update == 'true' && steps.detect.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find open PRs with auto-update label (will be superseded by new one)
+          # Older auto-update PRs are superseded; close them with a comment
           STALE_PRS=$(gh pr list --label "auto-update" --state open --json number --jq '.[].number' 2>/dev/null || echo "")
-
           for pr in $STALE_PRS; do
-            echo "Closing stale PR #$pr (superseded by ${{ steps.latest-release.outputs.latest_version }})"
-            gh pr close "$pr" --comment "Superseded by newer version update: ${{ steps.latest-release.outputs.latest_version }}" || true
+            echo "Closing stale PR #$pr"
+            gh pr close "$pr" --comment "Superseded by ${{ steps.detect.outputs.latest_version }}" || true
           done
 
-      - name: Create PR for all updates
+      - name: Create auto-update PR
         id: create-update-pr
-        if: steps.check-update.outputs.needs_update == 'true' && steps.existing-pr.outputs.skip != 'true'
+        if: steps.detect.outputs.needs_update == 'true' && steps.detect.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update last-checked-version to ${{ steps.latest-release.outputs.latest_version }}"
-          title: "[${{ steps.parse.outputs.relevance }}] Auto-Update: Claude Code ${{ steps.latest-release.outputs.latest_version }}"
-          body-path: /tmp/pr_body.md
-          branch: auto-update/claude-code-${{ steps.latest-release.outputs.latest_version }}
+          commit-message: "chore: update last-checked-version to ${{ steps.detect.outputs.latest_version }}"
+          title: "[UNKNOWN] Auto-Update: Claude Code ${{ steps.detect.outputs.latest_version }}"
+          branch: auto-update/claude-code-${{ steps.detect.outputs.latest_version }}
+          delete-branch: true
           labels: |
             auto-update
-            relevance-${{ steps.parse.outputs.relevance }}
-          delete-branch: true
+            relevance-UNKNOWN
+          body: |
+            ## Auto-Update: Claude Code ${{ steps.detect.outputs.latest_version }}
+
+            **Release:** ${{ steps.detect.outputs.latest_version }} (${{ steps.detect.outputs.release_date }})
+            **Relevance:** UNKNOWN — run local analysis (see below)
+            **Release URL:** ${{ steps.detect.outputs.release_url }}
+
+            ### Local Analysis (#231 Phase 3d, v1.54.0+)
+
+            The CI Claude-ranker was deleted — no API spend on every release. To get HIGH/MEDIUM/LOW relevance, run locally on Max:
+
+            ```bash
+            gh release view ${{ steps.detect.outputs.latest_version }} --repo anthropics/claude-code --json body --jq .body > /tmp/release_notes.md
+            claude --print --allowedTools "Read,Bash" \
+              "$(cat .github/prompts/analyze-release.md)\n\n## Release to Analyze\n\n**Version:** ${{ steps.detect.outputs.latest_version }}\n**URL:** ${{ steps.detect.outputs.release_url }}\n\n**Release Notes:**\n$(cat /tmp/release_notes.md)"
+            ```
+
+            Update the PR title prefix and `relevance-*` label with the verdict before merging.
+
+            ### Why This PR Exists
+
+            All Claude Code releases get a PR for visibility. The relevance verdict comes from the local analyze command above:
+            - **HIGH**: Changes that directly affect SDLC enforcement
+            - **MEDIUM**: Useful improvements worth reviewing
+            - **LOW**: Routine update, merge at your convenience
+
+            ### Review Checklist
+            - [ ] Ran local analyze-release.md — relevance set
+            - [ ] Aligns with KISS principle
+            - [ ] Actually needed for SDLC enforcement
+            - [ ] No over-engineering
+            - [ ] If replacing custom code, removal is clean
+
+            ---
+            *Generated by weekly-update workflow. You always decide what merges.*
 
       - name: Trigger CI on new PR
         if: steps.create-update-pr.outputs.pull-request-number
@@ -285,4 +158,4 @@ jobs:
           # GITHUB_TOKEN PRs don't trigger pull_request events (anti-loop protection).
           # Dispatch CI manually so auto-update PRs get checked.
           echo "Dispatching CI for PR #${{ steps.create-update-pr.outputs.pull-request-number }}..."
-          gh workflow run ci.yml --ref auto-update/claude-code-${{ steps.latest-release.outputs.latest_version }} || true
+          gh workflow run ci.yml --ref auto-update/claude-code-${{ steps.detect.outputs.latest_version }} || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.55.0] - 2026-04-29
+
+### Removed
+
+- **Dead leftovers in `.github/workflows/weekly-update.yml`** — closes ROADMAP #231 Phase 4. After Phase 3d, the workflow still carried code that was wired to nothing:
+  - `env.VERSION_SCENARIO` — flagged as a "no-op marker" since Phase 3a (version-test deleted)
+  - `outputs.has_overlap` / `outputs.overlap_paths` job-level outputs — set by the placeholder analysis step but consumed by no downstream job (prove-it-test was already deleted in Phase 2)
+  - `Generate placeholder analysis` step — wrote `/tmp/analysis.json` with `relevance: "UNKNOWN"` purely so the next step could parse it back out
+  - `Parse analysis result` step — read the placeholder and wrote outputs that are now hardcoded
+  - `Build PR body` step + the `case "$RELEVANCE"` switch — relevance is always `UNKNOWN` post-Phase-3d, so the case statement and templated title/label collapsed to a literal `[UNKNOWN]` / `relevance-UNKNOWN`
+
+### Changed
+
+- `.github/workflows/weekly-update.yml`: 289 → 161 lines (-44%). Steps consolidated: 10 → 5 operational (6 YAML steps including checkout). Detection + version compare + existing-PR check fold into one `detect` step. PR body inlined as a `body: |` block on the create-pull-request action (was a separate Build PR body step writing /tmp/pr_body.md). The disabled cron line stays as a documented comment, but cron-collision tests now use Python YAML parsing (Codex round 1 P1) so they only compare ACTIVE schedules.
+- `tests/test-workflow-triggers.sh`: Test 17 updated to grep for the new pattern (`gh pr list --head` + `skip=true`) since the dedicated `existing-pr` step ID was consolidated. Test 54 simplified — the placeholder is gone, so the regression check is now just "no `claude-code-action@v1` directive resurrects." 3 new Phase 4 regression tests added (`test_weekly_update_no_dead_version_scenario_env`, `_no_has_overlap_output`, `_no_overlap_paths_output`).
+
+### Phase 3 + Phase 4 cumulative
+
+- weekly-update.yml has shrunk from ~1670 lines (pre-Phase 3) to 161 lines (-90%). Five jobs/workflows + one in-job ranker chain + Phase 4 dead-code removed. Zero `claude-code-action@v1` references. Cron burn $25-55/week → $0/week.
+- ROADMAP #231 closes here. Detection-only workflow stays at ~150 lines as documented in the Phase 4 plan; folding into the session-start hook would lose the GitHub PR audit trail (which is the only place the maintainer sees a new release while away from a session).
+
+### Files
+
+- `.github/workflows/weekly-update.yml` (-128 lines net)
+- `tests/test-workflow-triggers.sh` (+86 lines: 3 new regression tests, 2 tests updated)
+- Version bump 1.54.0 → 1.55.0
+
 ## [1.54.0] - 2026-04-29
 
 ### Removed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2974,7 +2974,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.54.0 -->
+<!-- SDLC Wizard Version: 1.55.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4039,7 +4039,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.54.0 -->
+<!-- SDLC Wizard Version: 1.55.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.54.0 -->
+<!-- SDLC Wizard Version: 1.55.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,8 +7,8 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.54.0 |
-| Last Updated | 2026-04-27 |
+| Wizard Version | 1.55.0 |
+| Last Updated | 2026-04-29 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |
 | Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.54.0
+Latest:    1.55.0
 
 What changed:
+- [1.55.0] shrink weekly-update.yml dead code (#231 Phase 4) — delete env.VERSION_SCENARIO + has_overlap/overlap_paths outputs + placeholder/parse steps; 289 → 161 lines (-44%)
 - [1.54.0] delete check-updates Claude-ranker (#231 Phase 3d) — weekly-update.yml is now zero-API-spend; auto-update PR body links the manual analyze-release.md command
 - [1.53.0] delete scan-community cron (#231 Phase 3c) — manual `claude --print` invocation of analyze-community.md
 - [1.52.0] delete community-e2e-test cron (#231 Phase 3b) — manual local-shepherd review of scan-community digest

--- a/tests/test-api-feature-detection.sh
+++ b/tests/test-api-feature-detection.sh
@@ -75,19 +75,131 @@ test_workflow_has_dispatch() {
 
 # Stagger from weekly-update.yml (09:00 UTC) — api watcher at 10:00 UTC Monday.
 # Prevents both workflows hitting GH API + Anthropic at the same minute.
+#
+# Implementation note (Codex round 1, ROADMAP #231 Phase 4): grep-based parsing
+# false-greens because grep matches commented-out cron lines too. We use Python
+# YAML parsing so only ACTIVE schedules are compared. If weekly-update.yml has
+# no active schedule (which it doesn't post-#212 Option 1), the test passes
+# trivially — there's no collision to detect.
 test_workflow_cron_staggered() {
     if [ ! -f "$WORKFLOW" ]; then fail "skip: workflow missing"; return; fi
     local other="$REPO_ROOT/.github/workflows/weekly-update.yml"
-    local api_cron release_cron
-    api_cron=$(grep -oE "cron: *['\"][^'\"]+['\"]" "$WORKFLOW" | head -1)
-    release_cron=$(grep -oE "cron: *['\"][^'\"]+['\"]" "$other" | head -1)
-    if [ -z "$api_cron" ] || [ -z "$release_cron" ]; then
-        fail "could not read both cron values"; return
+
+    local result
+    result=$(python3 -c "
+import yaml
+def active_crons(path):
+    try:
+        with open(path) as f:
+            wf = yaml.safe_load(f)
+    except Exception:
+        return []
+    on = wf.get(True, wf.get('on', {}))
+    if not isinstance(on, dict):
+        return []
+    sched = on.get('schedule', []) or []
+    return [s.get('cron', '') for s in sched if isinstance(s, dict) and s.get('cron')]
+
+api_crons = active_crons('$WORKFLOW')
+release_crons = active_crons('$other')
+if not api_crons:
+    print('SKIP:no_api_cron')
+elif not release_crons:
+    print('SKIP:no_active_release_cron')
+else:
+    overlap = set(api_crons) & set(release_crons)
+    if overlap:
+        print('FAIL:collision:' + ','.join(overlap))
+    else:
+        print('PASS:api=' + ','.join(api_crons) + ' release=' + ','.join(release_crons))
+" 2>&1)
+
+    case "$result" in
+        SKIP:no_api_cron)
+            pass "skipped: weekly-api-update.yml has no active cron"
+            ;;
+        SKIP:no_active_release_cron)
+            pass "skipped: weekly-update.yml has no active cron (no collision possible)"
+            ;;
+        FAIL:collision:*)
+            fail "api cron collides with weekly-update cron — stagger to avoid burst (${result#FAIL:collision:})"
+            ;;
+        PASS:*)
+            pass "api cron staggers from release cron (${result#PASS:})"
+            ;;
+        *)
+            fail "could not parse cron values: $result"
+            ;;
+    esac
+}
+
+# Regression test for Codex round 1 P1: confirm the stagger test ACTUALLY
+# detects an active-vs-active cron collision (the original grep version
+# false-greened because it matched commented cron lines).
+#
+# We synthesize a temporary workflow file that has an ACTIVE schedule
+# matching weekly-api-update.yml's cron, then verify the YAML-parsing logic
+# above produces a FAIL: result. This proves the stagger test isn't a
+# silent no-op.
+test_workflow_cron_collision_detected() {
+    if [ ! -f "$WORKFLOW" ]; then fail "skip: workflow missing"; return; fi
+
+    local api_cron
+    api_cron=$(python3 -c "
+import yaml
+with open('$WORKFLOW') as f:
+    wf = yaml.safe_load(f)
+on = wf.get(True, wf.get('on', {}))
+sched = on.get('schedule', []) if isinstance(on, dict) else []
+crons = [s.get('cron') for s in sched if isinstance(s, dict) and s.get('cron')]
+print(crons[0] if crons else '')
+" 2>/dev/null)
+
+    if [ -z "$api_cron" ]; then
+        # If the api watcher itself has no cron, the regression target doesn't
+        # apply — pass trivially (the staggered test would also skip).
+        pass "n/a: weekly-api-update.yml has no active cron to collide with"
+        return
     fi
-    if [ "$api_cron" != "$release_cron" ]; then
-        pass "api cron staggers from release cron ($api_cron vs $release_cron)"
+
+    local tmpdir
+    tmpdir=$(mktemp -d -t cron-collision-test.XXXXXX)
+    trap "rm -rf '$tmpdir'" RETURN
+
+    # Synthesize a fake "release" workflow with the SAME active cron as the api watcher
+    cat > "$tmpdir/release.yml" <<EOF
+name: Fake Release
+on:
+  schedule:
+    - cron: '$api_cron'
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+EOF
+
+    local result
+    result=$(python3 -c "
+import yaml
+def active_crons(path):
+    with open(path) as f:
+        wf = yaml.safe_load(f)
+    on = wf.get(True, wf.get('on', {}))
+    if not isinstance(on, dict): return []
+    sched = on.get('schedule', []) or []
+    return [s.get('cron', '') for s in sched if isinstance(s, dict) and s.get('cron')]
+
+api = active_crons('$WORKFLOW')
+rel = active_crons('$tmpdir/release.yml')
+overlap = set(api) & set(rel)
+print('COLLISION' if overlap else 'NO_COLLISION')
+" 2>&1)
+
+    if [ "$result" = "COLLISION" ]; then
+        pass "stagger test correctly detects active-vs-active cron collision"
     else
-        fail "api cron collides with weekly-update cron — stagger to avoid burst"
+        fail "stagger test failed to detect synthesized active cron collision: $result"
     fi
 }
 
@@ -618,6 +730,7 @@ test_workflow_parses_yaml
 test_workflow_has_cron
 test_workflow_has_dispatch
 test_workflow_cron_staggered
+test_workflow_cron_collision_detected
 test_workflow_targets_platform_claude_com
 test_workflow_uses_md_source
 test_workflow_has_issues_write_permission

--- a/tests/test-workflow-triggers.sh
+++ b/tests/test-workflow-triggers.sh
@@ -250,7 +250,10 @@ test_cleanup_labeled_guard() {
     fi
 }
 
-# Test 17: Weekly-update workflow checks for existing PR before creating
+# Test 17: Weekly-update workflow checks for existing PR before creating.
+# Phase 4 (#231) consolidated the dedicated `existing-pr` step into the
+# combined `detect` step. The check now greps for the actual pattern
+# (`gh pr list --head` + `skip` output write) rather than a step ID.
 test_weekly_existing_pr_check() {
     WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
 
@@ -259,10 +262,10 @@ test_weekly_existing_pr_check() {
         return
     fi
 
-    if grep -q "existing-pr" "$WORKFLOW" && grep -q "skip" "$WORKFLOW"; then
+    if grep -q 'gh pr list --head' "$WORKFLOW" && grep -q 'skip=true' "$WORKFLOW"; then
         pass "weekly-update.yml checks for existing PR before creating"
     else
-        fail "weekly-update.yml missing existing PR check"
+        fail "weekly-update.yml missing existing PR check (gh pr list --head + skip output)"
     fi
 }
 
@@ -734,11 +737,13 @@ print('OK')
 " 2>&1)
     if echo "$USES_CHECK" | grep -q "RESURRECTED:"; then
         DETAIL=$(echo "$USES_CHECK" | grep "RESURRECTED:" | sed 's/RESURRECTED://')
-        fail "weekly-update.yml has resurrected claude-code-action step: $DETAIL — Phase 3d removed all API spend"
-    elif grep -q "tmp/analysis.json" "$WORKFLOW"; then
-        pass "weekly-update writes /tmp/analysis.json placeholder (Phase 3d Claude-ranker deleted)"
+        fail "weekly-update.yml has RESURRECTED claude-code-action step: $DETAIL — Phase 3d removed all API spend"
     else
-        fail "weekly-update should write /tmp/analysis.json placeholder (Phase 3d expected)"
+        # Phase 4 (#231) eliminated the /tmp/analysis.json placeholder (it was
+        # consumed by nothing once the relevance label became hardcoded
+        # UNKNOWN). Regression check is now just: no claude-code-action@v1
+        # directive resurrects.
+        pass "weekly-update.yml has no claude-code-action@v1 directive (Phase 3d/4 zero-API-spend)"
     fi
 }
 
@@ -1087,6 +1092,94 @@ test_weekly_update_version_test_needs_check_updates
 test_weekly_update_community_e2e_needs_scan
 test_weekly_update_has_issues_permission
 test_weekly_update_single_cron
+
+# ============================================
+# #231 Phase 4: weekly-update.yml shrink regression checks
+# ============================================
+# After Phase 3d, several leftovers were dead-weight: the VERSION_SCENARIO
+# env var (used by the deleted version-test job), and the has_overlap /
+# overlap_paths job-level outputs (set by the now-deleted analysis chain
+# but consumed by nobody). Phase 4 deletes these. Tests here are
+# regression checks — they fail if the dead code resurrects.
+
+# Test 92a: VERSION_SCENARIO env block must NOT exist (dead since Phase 3a)
+test_weekly_update_no_dead_version_scenario_env() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "weekly-update.yml not found"
+        return
+    fi
+
+    # Use Python YAML so we look at the actual top-level env, not a comment
+    python3 -c "
+import yaml
+with open('$WORKFLOW') as f:
+    wf = yaml.safe_load(f)
+env = wf.get('env', {}) or {}
+if 'VERSION_SCENARIO' in env:
+    print('FOUND')
+" > /tmp/version_scenario_check.txt 2>&1
+
+    if grep -q "FOUND" /tmp/version_scenario_check.txt; then
+        fail "weekly-update.yml still has VERSION_SCENARIO env var (#231 Phase 4: dead since version-test deleted)"
+    else
+        pass "weekly-update.yml has no dead VERSION_SCENARIO env (Phase 4)"
+    fi
+}
+
+# Test 92b: has_overlap job output must NOT exist (consumed by nothing post-3d)
+test_weekly_update_no_has_overlap_output() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "weekly-update.yml not found"
+        return
+    fi
+
+    python3 -c "
+import yaml
+with open('$WORKFLOW') as f:
+    wf = yaml.safe_load(f)
+for job_name, job in wf.get('jobs', {}).items():
+    outputs = job.get('outputs', {}) or {}
+    if 'has_overlap' in outputs:
+        print('FOUND:' + job_name)
+" > /tmp/has_overlap_check.txt 2>&1
+
+    if grep -q "FOUND:" /tmp/has_overlap_check.txt; then
+        fail "weekly-update.yml still has has_overlap job output (#231 Phase 4: dead since prove-it-test deleted)"
+    else
+        pass "weekly-update.yml has no dead has_overlap output (Phase 4)"
+    fi
+}
+
+# Test 92c: overlap_paths job output must NOT exist (same reason as has_overlap)
+test_weekly_update_no_overlap_paths_output() {
+    WORKFLOW="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if [ ! -f "$WORKFLOW" ]; then
+        fail "weekly-update.yml not found"
+        return
+    fi
+
+    python3 -c "
+import yaml
+with open('$WORKFLOW') as f:
+    wf = yaml.safe_load(f)
+for job_name, job in wf.get('jobs', {}).items():
+    outputs = job.get('outputs', {}) or {}
+    if 'overlap_paths' in outputs:
+        print('FOUND:' + job_name)
+" > /tmp/overlap_paths_check.txt 2>&1
+
+    if grep -q "FOUND:" /tmp/overlap_paths_check.txt; then
+        fail "weekly-update.yml still has overlap_paths job output (#231 Phase 4: dead since prove-it-test deleted)"
+    else
+        pass "weekly-update.yml has no dead overlap_paths output (Phase 4)"
+    fi
+}
+
+test_weekly_update_no_dead_version_scenario_env
+test_weekly_update_no_has_overlap_output
+test_weekly_update_no_overlap_paths_output
 test_tier2_comment_matches_trial_count
 test_tier2_cleans_stale_output
 


### PR DESCRIPTION
## Summary

ROADMAP #231 **Phase 4** — closes the cron-burn migration. After Phase 3d deleted the in-CI Claude-ranker, the workflow carried ~130 lines of code wired to nothing:

- `env.VERSION_SCENARIO` (no-op since version-test deleted in Phase 3a)
- `has_overlap` / `overlap_paths` job outputs (consumed by zero downstream jobs since prove-it-test was deleted in Phase 2)
- `Generate placeholder analysis` + `Parse analysis result` steps (wrote `/tmp/analysis.json` with `relevance=UNKNOWN` purely to read it back into outputs that became hardcoded)
- `Build PR body` step + the `case "$RELEVANCE"` switch (relevance is always `UNKNOWN` now, so title/label/case-block collapse to literal `[UNKNOWN]` / `relevance-UNKNOWN`)

**Workflow shrinks 289 → 161 lines (-44%)**, steps consolidated `10 → 5` operational (6 YAML steps including checkout). Detection + version compare + existing-PR check fold into one `detect` step. PR body inlined directly in `create-pull-request` `body:` field.

**Bonus fix (Codex round 1 P1):** `test_workflow_cron_staggered` no longer false-greens. The original grep version matched **commented** cron lines, so a real active-vs-active collision could pass silently. Rewritten to use Python YAML parsing so only ACTIVE schedules are compared. New `test_workflow_cron_collision_detected` synthesizes a colliding cron in a tmpdir `release.yml` + asserts the detection logic flags it — proving the stagger test isn't a silent no-op.

**Phase 3+4 cumulative:** weekly-update.yml from ~1670 lines (pre-Phase 3) to 161 lines (**-90%**). Five jobs/workflows + one in-job ranker chain + Phase 4 dead code removed. ROADMAP #231 closes here.

**Codex round 2 CERTIFIED 10/10** — round 1 was 7/10 with 3 findings (1 P1, 2 P2) all fixed and mutation-verified.

## Test plan

- [x] `bash tests/test-workflow-triggers.sh` — 169/169 (3 new Phase 4 regression tests + 2 updated)
- [x] `bash tests/test-api-feature-detection.sh` — 34/34 (new `test_workflow_cron_collision_detected` regression)
- [x] Full sweep: 45/45 test files green
- [x] YAML validity: `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes
- [x] Mutation verified: `VERSION_SCENARIO` re-injection → fail; `has_overlap` re-injection → fail; `claude-code-action@v1` re-injection → fail with `RESURRECTED`; active cron collision injection → fail with `collision`
- [x] Versions consistent at 1.55.0: `package.json`, `SDLC.md`, `CLAUDE_CODE_SDLC_WIZARD.md` (both example occurrences), `.claude-plugin/plugin.json` + `marketplace.json`, `skills/update/SKILL.md` teaching example
- [ ] CI green
- [ ] PR review pass