### PR TITLE
fix(benchmark): de-coach E2E simulation prompt — #96 Phase 1

### DIFF
--- a/.github/workflows/benchmark-model-comparison.yml
+++ b/.github/workflows/benchmark-model-comparison.yml
@@ -166,30 +166,24 @@ jobs:
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "Read,Edit,Write,Bash(npm *),Bash(node *),Bash(git *),Glob,Grep,TodoWrite,TaskCreate,Task"
             --add-dir tests/e2e
+          # Neutral task prompt (#96 Phase 1). Previous version coached
+          # the agent on every scored behavior — benchmark saturated 10/10.
+          # See tests/e2e/local-shepherd.sh for the same fix and rationale.
           prompt: |
-            You are running an E2E SDLC simulation. Your goal is to complete a coding task
-            while demonstrating proper SDLC practices.
+            You are completing a coding task in a real working directory.
 
             Working directory: tests/e2e/fixtures/test-repo
             Scenario file: tests/e2e/scenarios/${{ matrix.scenario }}.md
 
-            STEPS:
-            1. Read the scenario file to understand the task and complexity
-            2. Use TodoWrite or TaskCreate to track your work
-            3. State your confidence level explicitly: "Confidence: HIGH", "Confidence: MEDIUM", or "Confidence: LOW"
-            4. For medium/hard tasks, plan your approach before coding (outline steps in a message)
-            5. Follow TDD: write/update tests FIRST, verify they fail, then implement
-            6. Run `npm test` to verify all tests pass
-            7. Self-review: use Read to read back the files you modified, check for issues
+            Read the scenario file for the task spec. Complete it however you'd
+            normally complete a coding task — using whatever practices your tooling,
+            skills, or instructions teach you. The result will be evaluated
+            independently.
 
-            IMPORTANT:
-            - You MUST use TodoWrite or TaskCreate (scored by automated checks)
-            - You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)
-            - Write or edit test files BEFORE implementation files (TDD RED phase is scored)
-            - You MUST self-review by using Read on files you modified before finishing (scored by automated checks)
-            - All files you need are in the working directory — do not search elsewhere
-            - Be efficient with your turns — execute, don't just plan
-            - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead
+            Constraints:
+            - All files you need are in the working directory; do not search elsewhere.
+            - Do NOT use EnterPlanMode or ExitPlanMode — plan inline in messages.
+            - Be efficient — execute, don't just plan.
 
       - name: Integrity check simulation
         run: |

--- a/tests/e2e/local-shepherd.sh
+++ b/tests/e2e/local-shepherd.sh
@@ -196,36 +196,36 @@ OUTPUT_FILE="$TMPRUN/claude-execution-output.json"
 REL_SCENARIO="tests/e2e/scenarios/$SCENARIO_NAME.md"
 FIXTURES_REL="tests/e2e/fixtures/test-repo"
 
-# Full prompt — byte-equivalent to .github/workflows/ci.yml:338-361 modulo
-# the pr-branch/ prefix that only exists in CI's checked-out-artifact layout.
-# bash 3.2 on macOS has a heredoc-in-$() parsing bug when the body contains
-# backticks (even inside a 'PROMPT'-quoted delimiter), so we write the prompt
-# to a temp file line-by-line and read it back. Ugly but bash-3.2 safe.
+# Neutral task prompt (#96 Phase 1, ROADMAP fix). The previous version
+# coached the agent on every scored behavior — which is why the benchmark
+# saturated at 10/10 and the v1.32.0 cross-model audit rated it 2/10
+# NOT CERTIFIED. Removing the cheat sheet measures whether agents
+# practice SDLC organically. A wizard-installed fixture (Phase 3,
+# future) will then demonstrate that wizard installation lifts
+# organic-low scores back up. Test #96-Phase-1 in
+# tests/test-local-shepherd.sh asserts cheat-sheet phrases do not
+# resurrect — that's why this comment paraphrases instead of quoting.
+#
+# bash 3.2 on macOS has a heredoc-in-$() parsing bug when the body
+# contains backticks (even inside a 'PROMPT'-quoted delimiter), so we
+# write the prompt to a temp file line-by-line and read it back. Ugly
+# but bash-3.2 safe.
 PROMPT_FILE="$TMPRUN/parity-prompt.txt"
 {
-    printf '%s\n' "You are running an E2E SDLC simulation. Your goal is to complete a coding task"
-    printf '%s\n' "while demonstrating proper SDLC practices."
+    printf '%s\n' "You are completing a coding task in a real working directory."
     printf '%s\n' ""
     printf '%s\n' "Working directory: $FIXTURES_REL"
     printf '%s\n' "Scenario file: $REL_SCENARIO"
     printf '%s\n' ""
-    printf '%s\n' "STEPS:"
-    printf '%s\n' "1. Read the scenario file to understand the task and complexity"
-    printf '%s\n' "2. Use TodoWrite or TaskCreate to track your work"
-    printf '%s\n' '3. State your confidence level explicitly: "Confidence: HIGH", "Confidence: MEDIUM", or "Confidence: LOW"'
-    printf '%s\n' "4. For medium/hard tasks, plan your approach before coding (outline steps in a message)"
-    printf '%s\n' "5. Follow TDD: write/update tests FIRST, verify they fail, then implement"
-    printf '6. Run %cnpm test%c to verify all tests pass\n' 96 96
-    printf '%s\n' "7. Self-review: use Read to read back the files you modified, check for issues"
+    printf '%s\n' "Read the scenario file for the task spec. Complete it however you'\''d"
+    printf '%s\n' "normally complete a coding task — using whatever practices your tooling,"
+    printf '%s\n' "skills, or instructions teach you. The result will be evaluated"
+    printf '%s\n' "independently."
     printf '%s\n' ""
-    printf '%s\n' "IMPORTANT:"
-    printf '%s\n' "- You MUST use TodoWrite or TaskCreate (scored by automated checks)"
-    printf '%s\n' '- You MUST state confidence as exactly "Confidence: HIGH/MEDIUM/LOW" (scored by automated checks)'
-    printf '%s\n' "- Write or edit test files BEFORE implementation files (TDD RED phase is scored)"
-    printf '%s\n' "- You MUST self-review by using Read on files you modified before finishing (scored by automated checks)"
-    printf '%s\n' "- All files you need are in the working directory — do not search elsewhere"
-    printf '%s\n' "- Be efficient with your turns — execute, don't just plan"
-    printf '%s\n' "- Do NOT use EnterPlanMode or ExitPlanMode — plan inline in your messages instead"
+    printf '%s\n' "Constraints:"
+    printf '%s\n' "- All files you need are in the working directory; do not search elsewhere."
+    printf '%s\n' "- Do NOT use EnterPlanMode or ExitPlanMode — plan inline in messages."
+    printf '%s\n' "- Be efficient — execute, don'\''t just plan."
 } > "$PROMPT_FILE"
 PARITY_PROMPT=$(cat "$PROMPT_FILE")
 

--- a/tests/test-local-shepherd.sh
+++ b/tests/test-local-shepherd.sh
@@ -490,23 +490,36 @@ EOF
 test_shepherd_prompt_has_required_signatures() {
     # Originally LS-003 P1 (parity with ci.yml). After ROADMAP #212 Option 1
     # removed the e2e jobs from ci.yml, parity with a deleted block is moot.
-    # Keep the test — assert shepherd itself has the required signature lines,
-    # so that if someone guts the prompt, tests fail.
+    # ROADMAP #96 Phase 1 (de-coaching): the old prompt told the agent
+    # exactly what was scored ("MUST use TodoWrite (scored by automated
+    # checks)" etc.) which saturated the benchmark at 10/10. The new
+    # prompt is neutral task framing — the agent must practice SDLC
+    # organically. Test asserts the new neutral signatures so a future
+    # regression that re-introduces the cheat sheet shows up here.
     local miss=""
     for sig in \
-        "You are running an E2E SDLC simulation" \
-        "Use TodoWrite or TaskCreate to track your work" \
-        "Follow TDD: write/update tests FIRST" \
+        "You are completing a coding task" \
+        "Working directory:" \
+        "Scenario file:" \
         "Do NOT use EnterPlanMode or ExitPlanMode"; do
         if ! grep -qF "$sig" "$SHEPHERD"; then
             miss="$miss|missing-in-shepherd: $sig"
+        fi
+    done
+    # Negative assertion: cheat-sheet phrases must NOT resurrect.
+    for forbidden in \
+        "scored by automated checks" \
+        "MUST use TodoWrite" \
+        "TDD RED phase is scored"; do
+        if grep -qF "$forbidden" "$SHEPHERD"; then
+            miss="$miss|cheat-sheet phrase resurrected: $forbidden"
         fi
     done
     if ! grep -qF -- "--add-dir" "$SHEPHERD"; then miss="$miss|shepherd missing --add-dir"; fi
     if ! grep -qF -- "--max-turns" "$SHEPHERD"; then miss="$miss|shepherd missing --max-turns"; fi
     if ! grep -qF -- "--allowedTools" "$SHEPHERD"; then miss="$miss|shepherd missing --allowedTools"; fi
     if [ -z "$miss" ]; then
-        pass "shepherd embeds all required prompt signature lines + parity flags"
+        pass "shepherd has neutral task prompt + parity flags (no answer-key coaching)"
     else
         fail "shepherd prompt drift:$miss"
     fi

--- a/tests/test-model-comparison.sh
+++ b/tests/test-model-comparison.sh
@@ -335,16 +335,31 @@ test_integrity_check() {
     fi
 }
 
-# Test 22: Simulation prompt includes TDD and confidence instructions
+# Test 22: Simulation prompt is neutral (no answer-key coaching)
+# ROADMAP #96 Phase 1: the previous prompt explicitly told the agent
+# what was scored ("MUST use TodoWrite (scored by automated checks)"
+# etc.) which saturated the benchmark at 10/10 (v1.32.0 audit: 2/10
+# NOT CERTIFIED). The wizard is installed into the test fixture in
+# Test 23 — the wizard's SDLC skill is what should drive TDD /
+# confidence behavior, not a cheat sheet in the prompt. This test
+# inverts: confirm cheat-sheet phrases are NOT in the workflow.
 test_prompt_quality() {
     if [ ! -f "$WORKFLOW" ]; then fail "Workflow file missing"; return; fi
-    local has_tdd has_conf
-    has_tdd=$(grep -ci "TDD\|test.*first\|test.*BEFORE" "$WORKFLOW" || true)
-    has_conf=$(grep -ci "confidence\|Confidence:" "$WORKFLOW" || true)
-    if [ "$has_tdd" -gt 0 ] && [ "$has_conf" -gt 0 ]; then
-        pass "Simulation prompt includes TDD and confidence instructions"
+    local resurrected=""
+    for forbidden in \
+        "scored by automated checks" \
+        "MUST use TodoWrite" \
+        "MUST state confidence" \
+        "TDD RED phase is scored" \
+        "MUST self-review"; do
+        if grep -qF "$forbidden" "$WORKFLOW"; then
+            resurrected="$resurrected|$forbidden"
+        fi
+    done
+    if [ -z "$resurrected" ]; then
+        pass "Simulation prompt has no answer-key coaching (#96 Phase 1)"
     else
-        fail "Simulation prompt missing TDD ($has_tdd) or confidence ($has_conf) instructions"
+        fail "Cheat-sheet phrase resurrected in workflow prompt: ${resurrected}"
     fi
 }
 


### PR DESCRIPTION
## Summary

Closes the answer-key leakage in the local-shepherd benchmark. Codex independent priority review identified this as the **single highest-leverage next action** in the repo: the benchmark scores 10/10 on every run because the prompt tells the agent exactly what's scored.

## What changed

The previous prompt coached the agent on every scored behavior:
- *"You MUST use TodoWrite or TaskCreate (scored by automated checks)"*
- *"You MUST state confidence as exactly 'Confidence: HIGH/MEDIUM/LOW' (scored by automated checks)"*
- *"Write or edit test files BEFORE implementation files (TDD RED phase is scored)"*
- *"You MUST self-review by using Read on files you modified before finishing (scored by automated checks)"*

This was the v1.32.0 cross-model audit's core finding (Codex GPT-5.4 xhigh, **2/10 NOT CERTIFIED**). ROADMAP #96 named it "DONE (but benchmark is broken)" — meaning the infra shipped, the actual de-coaching never happened. **This commit does it.**

Replaced with neutral task framing in:
- `tests/e2e/local-shepherd.sh` (both modes)
- `.github/workflows/benchmark-model-comparison.yml` (A/B model benchmark)

The new prompt: working directory + scenario file + *"Complete however you'd normally complete a coding task using whatever practices your tooling, skills, or instructions teach you."* No mention of TodoWrite / confidence / TDD / self-review.

## Why this matters

The fixture (`tests/e2e/fixtures/test-repo`) does **NOT** have the wizard installed. So under the new prompt the benchmark measures whether agents practice SDLC **organically**.

- **Phase 2** (next, separate PR): add `npm test` post-run as independent ground truth — high score requires BOTH judge approval AND real tests passing.
- **Phase 3** (later): install wizard files into the fixture and prove that wizard installation lifts organically-low scores back up. That's the actual *"does the wizard work?"* test.

## Test changes

- `test_shepherd_prompt_has_required_signatures` rewritten:
  - Asserts new neutral signatures present (`"You are completing a coding task"`, `"Working directory:"`, `"Scenario file:"`, `"Do NOT use EnterPlanMode"`).
  - **Negative** assertion: cheat-sheet phrases (`"scored by automated checks"`, `"MUST use TodoWrite"`, `"TDD RED phase is scored"`) must NOT resurrect.

## Test plan

- [x] `bash tests/test-local-shepherd.sh` — 34/34
- [x] `bash tests/test-workflow-triggers.sh` — 169/169
- [x] Full sweep: 45/46 test files green; the one fail is `test-persist-score-history.sh`, which was already failing on main (pre-existing macOS-specific flake; CI green for it)
- [x] YAML validity: `python3 -c 'import yaml; yaml.safe_load(...)'` passes
- [ ] CI green