### PR TITLE
feat(benchmark): ground-truth gate post-sim (v1.58.0, ROADMAP #96 Phase 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.57.0",
+      "version": "1.58.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
       - name: Run community fetcher tests (#207)
         run: ./tests/test-community-fetch.sh
 
+      - name: Run ground-truth verification tests (#96 Phase 2)
+        run: ./tests/test-ground-truth.sh
+
       - name: Run update-skill Step 7.7 hoist tests (v1.39.1)
         run: ./tests/test-update-skill-step-7-7.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.58.0] - 2026-04-30
+
+### Added
+
+- **Ground-truth gate for the E2E benchmark — closes ROADMAP #96 Phase 2.** New `tests/e2e/ground-truth.sh` runs the fixture's own test suite (`npm test`) post-simulation and emits structured JSON: `{tests_run, tests_pass, tests_rc, tests_tail}`. `local-shepherd.sh` calls it after the evaluator, before the score-history append. If tests fail, the final score is **capped at 5/10** (configurable via `GROUND_TRUTH_FAIL_CAP`) — the judge can't tell if `npm test` actually passes; only running it can.
+
+  Combined with Phase 1's de-coaching (v1.57.0), the benchmark now requires **both** judge approval **and** real test passage. Catches "agent followed protocol but produced broken code" false-positives — exactly the failure mode the v1.32.0 cross-model audit warned about.
+
+  Score-history rows now record `original_judge_score`, `tests_run`, `tests_pass`, `ground_truth_gated` so trend analytics can distinguish judge noise from real regressions.
+
+  Cross-platform timeout: uses `timeout` if available, falls back to `gtimeout` (coreutils on macOS), and finally a portable `perl` fallback for stock systems. Default `GROUND_TRUTH_TIMEOUT=120s`.
+
+  Escape hatches:
+  - `SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1` — disables the gate entirely (raw judge scores)
+  - `SDLC_SHEPHERD_FIXTURE_DIR=...` — override fixture location (default `tests/e2e/fixtures/test-repo`)
+  - `SDLC_SHEPHERD_GROUND_TRUTH=...` — override script path (used by tests)
+
+### Tests
+
+- New `tests/test-ground-truth.sh` (11 tests): passing/failing/no-test/no-package/missing-dir/no-args/help/JSON-validity/timeout-enforcement.
+- 4 new integration tests in `tests/test-local-shepherd.sh` (38 total): gate caps judge=9 to score=5, gate leaves passing judge alone, no-tests fixture skips gate, `SKIP_GROUND_TRUTH` env var fully disables gate.
+- Wired into `ci.yml` and `CONTRIBUTING.md` test list.
+
+### Files
+
+- `tests/e2e/ground-truth.sh` (new, 105 lines)
+- `tests/test-ground-truth.sh` (new, 11 tests)
+- `tests/e2e/local-shepherd.sh` (gate logic + new score-history fields)
+- `tests/test-local-shepherd.sh` (4 new integration tests)
+- `.github/workflows/ci.yml` + `CONTRIBUTING.md` (test list)
+- Version bump 1.57.0 → 1.58.0
+
+### Phase 3 (future)
+
+- Install wizard files into the local-shepherd test fixture so the simulation tests "wizard-installed agent" vs "wizard-less agent." That's the actual *"does the wizard work?"* test — pairs with calibration scenarios that include subtle bugs to test self-review effectiveness.
+
 ## [1.57.0] - 2026-04-30
 
 ### Fixed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2974,7 +2974,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.57.0 -->
+<!-- SDLC Wizard Version: 1.58.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4039,7 +4039,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.57.0 -->
+<!-- SDLC Wizard Version: 1.58.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-prompt-hook-fires-once.sh && \
    ./tests/test-community-scanner.sh && \
    ./tests/test-community-fetch.sh && \
+   ./tests/test-ground-truth.sh && \
    ./tests/test-update-skill-step-7-7.sh && \
    ./tests/test-update-skill-cli-version.sh && \
    ./tests/test-cleanup-period-guidance.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.57.0 -->
+<!-- SDLC Wizard Version: 1.58.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.57.0 |
+| Wizard Version | 1.58.0 |
 | Last Updated | 2026-04-29 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.57.0
+Latest:    1.58.0
 
 What changed:
+- [1.58.0] ground-truth gate for E2E benchmark (#96 Phase 2) — `tests/e2e/ground-truth.sh` runs `npm test` post-sim; final score capped at 5 if tests fail. Catches "agent followed protocol but produced broken code"
 - [1.57.0] de-coach E2E benchmark prompt (#96 Phase 1) — remove answer-key leakage that saturated benchmark scores at 10/10; new neutral task framing measures organic SDLC behavior
 - [1.56.0] community feature-discovery fetcher (#207) — `tests/e2e/fetch-community.sh` pulls Reddit + HN; pipe to `scan-community.sh` to surface candidate /slash-commands
 - [1.55.0] shrink weekly-update.yml dead code (#231 Phase 4) — delete env.VERSION_SCENARIO + has_overlap/overlap_paths outputs + placeholder/parse steps; 289 → 161 lines (-44%)

--- a/tests/e2e/ground-truth.sh
+++ b/tests/e2e/ground-truth.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# ROADMAP #96 Phase 2 — independent ground-truth verification.
+#
+# Runs the fixture's own test suite (`npm test`) post-simulation and emits
+# JSON: { "tests_run": bool, "tests_pass": bool, "tests_tail": string,
+#         "tests_rc": int, "reason": string }
+#
+# Combined with the judge score in local-shepherd.sh, this catches "agent
+# followed protocol but produced broken code" false-positives — the judge
+# can't tell whether `npm test` actually passes; only running it can.
+#
+# Usage:
+#   ./ground-truth.sh /path/to/fixture/dir
+#   ./ground-truth.sh --help
+#
+# Behavior:
+#   - No package.json in fixture → tests_run=false (skip, no gate)
+#   - No "test" script in package.json → tests_run=false (skip)
+#   - Test script exists, exits 0 → tests_run=true, tests_pass=true
+#   - Test script exists, exits non-zero → tests_run=true, tests_pass=false
+#   - Test script hangs → killed at GROUND_TRUTH_TIMEOUT (default 120s)
+#
+# Exit codes:
+#   0 — emitted valid JSON (tests_pass may be true OR false; caller decides)
+#   1 — bad args / fixture dir not found
+
+set -e
+
+USAGE="Usage: $0 <fixture-dir>
+  Runs 'npm test' in the fixture directory and emits JSON ground truth.
+  GROUND_TRUTH_TIMEOUT=<seconds> caps test runtime (default 120)."
+
+if [ "$#" -eq 0 ]; then
+    echo "error: missing argument" >&2
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "$USAGE"
+    exit 0
+fi
+
+FIXTURE_DIR="$1"
+TIMEOUT="${GROUND_TRUTH_TIMEOUT:-120}"
+
+if [ ! -d "$FIXTURE_DIR" ]; then
+    echo "error: fixture dir not found: $FIXTURE_DIR" >&2
+    exit 1
+fi
+
+# No package.json → skip
+if [ ! -f "$FIXTURE_DIR/package.json" ]; then
+    jq -nc '{tests_run:false, reason:"no_package_json"}'
+    exit 0
+fi
+
+# No "test" script → skip
+TEST_SCRIPT=$(jq -r '.scripts.test // empty' "$FIXTURE_DIR/package.json" 2>/dev/null)
+if [ -z "$TEST_SCRIPT" ]; then
+    jq -nc '{tests_run:false, reason:"no_test_script"}'
+    exit 0
+fi
+
+# Run tests with timeout. macOS doesn't ship `timeout` by default — use
+# perl as a fallback so this works on stock systems. (gtimeout from
+# coreutils works too if installed, but assume nothing.)
+LOG=$(mktemp -t gt-test-out.XXXXXX)
+trap 'rm -f "$LOG"' EXIT
+
+# Cross-platform timeout via perl. The inner subshell cd's into the
+# fixture; the outer perl wrapper enforces the deadline.
+set +e
+if command -v timeout >/dev/null 2>&1; then
+    ( cd "$FIXTURE_DIR" && timeout "$TIMEOUT" npm test --silent ) > "$LOG" 2>&1
+elif command -v gtimeout >/dev/null 2>&1; then
+    ( cd "$FIXTURE_DIR" && gtimeout "$TIMEOUT" npm test --silent ) > "$LOG" 2>&1
+else
+    perl -e '
+        use strict; use warnings;
+        my ($timeout, $dir, @cmd) = @ARGV;
+        my $pid = fork();
+        if ($pid == 0) {
+            chdir $dir or die "chdir: $!";
+            exec @cmd;
+            exit 127;
+        }
+        local $SIG{ALRM} = sub { kill "TERM", $pid; sleep 1; kill "KILL", $pid; exit 124; };
+        alarm $timeout;
+        waitpid $pid, 0;
+        my $rc = $? >> 8;
+        exit $rc;
+    ' "$TIMEOUT" "$FIXTURE_DIR" npm test --silent > "$LOG" 2>&1
+fi
+RC=$?
+set -e
+
+# Tail the last 1KB of output (jq-safe — strip control chars).
+TAIL=$(tail -c 1000 "$LOG" 2>/dev/null | tr -d '\000-\010\013-\037' | head -c 1000)
+
+if [ "$RC" -eq 0 ]; then
+    jq -nc --arg tail "$TAIL" \
+        '{tests_run:true, tests_pass:true, tests_rc:0, tests_tail:$tail}'
+else
+    jq -nc --arg tail "$TAIL" --argjson rc "$RC" \
+        '{tests_run:true, tests_pass:false, tests_rc:$rc, tests_tail:$tail}'
+fi

--- a/tests/e2e/local-shepherd.sh
+++ b/tests/e2e/local-shepherd.sh
@@ -51,6 +51,43 @@ SCENARIOS_DIR="$SCRIPT_DIR/scenarios"
 DEFAULT_HISTORY="$SCRIPT_DIR/score-history.jsonl"
 HISTORY_FILE="${SDLC_SHEPHERD_HISTORY_FILE:-$DEFAULT_HISTORY}"
 EVALUATOR="${SDLC_SHEPHERD_EVALUATOR:-$SCRIPT_DIR/evaluate.sh}"
+GROUND_TRUTH="${SDLC_SHEPHERD_GROUND_TRUTH:-$SCRIPT_DIR/ground-truth.sh}"
+
+# ROADMAP #96 Phase 2: ground-truth gate helper. Runs the fixture's own
+# test suite and gates the judge score: tests-fail caps at
+# GROUND_TRUTH_FAIL_CAP (default 5). Re-used by single-mode AND compare-
+# baseline mode (Codex F-02). Path resolution:
+#   - single mode: cwd-relative tests/e2e/fixtures/test-repo
+#   - compare-baseline: $BASELINE_DIR/.../test-repo for baseline,
+#     $CANDIDATE_DIR/.../test-repo for candidate (Codex F-01).
+#
+# Usage:  run_gate <fixture_dir> <judge_score>
+# Echoes: "tests_run|tests_pass|final_score|gated"
+run_gate() {
+    local fixture_dir="$1"
+    local judge_score="$2"
+    local cap="${GROUND_TRUTH_FAIL_CAP:-5}"
+    local gt_json='{"tests_run":false,"reason":"ground_truth_disabled"}'
+    if [ "${SDLC_SHEPHERD_SKIP_GROUND_TRUTH:-0}" != "1" ] && [ -x "$GROUND_TRUTH" ]; then
+        set +e
+        gt_json=$("$GROUND_TRUTH" "$fixture_dir" 2>/dev/null)
+        local rc=$?
+        set -e
+        if [ "$rc" -ne 0 ] || ! echo "$gt_json" | jq empty 2>/dev/null; then
+            gt_json='{"tests_run":false,"reason":"ground_truth_error"}'
+        fi
+    fi
+    local tr tp final gated
+    tr=$(echo "$gt_json" | jq -r '.tests_run // false')
+    tp=$(echo "$gt_json" | jq -r '.tests_pass // false')
+    final="$judge_score"
+    gated=false
+    if [ "$tr" = "true" ] && [ "$tp" = "false" ] && [ "$judge_score" -gt "$cap" ]; then
+        final="$cap"
+        gated=true
+    fi
+    echo "$tr|$tp|$final|$gated"
+}
 
 usage() {
     cat >&2 <<EOF
@@ -393,6 +430,21 @@ if [ "$COMPARE_BASELINE" = "1" ]; then
     case "$BASELINE_MAX" in ''|*[!0-9]*) BASELINE_MAX=10 ;; esac
     [ -z "$BASELINE_CRIT" ] && BASELINE_CRIT='{}'
 
+    # ROADMAP #96 Phase 2 (Codex F-01/F-02): ground-truth gate on baseline.
+    # Path resolves relative to $BASELINE_DIR (which contains a fresh
+    # checkout — for non-strip mode) or the intact-fixture sibling (strip
+    # mode). Fixture lives at tests/e2e/fixtures/test-repo within either.
+    BASELINE_ORIGINAL_SCORE="$BASELINE_SCORE"
+    BASELINE_GT_FIXTURE="${SDLC_SHEPHERD_BASELINE_FIXTURE_DIR:-$BASELINE_DIR/tests/e2e/fixtures/test-repo}"
+    BASELINE_GATE_RESULT=$(run_gate "$BASELINE_GT_FIXTURE" "$BASELINE_SCORE")
+    BASELINE_TESTS_RUN=$(echo "$BASELINE_GATE_RESULT" | cut -d'|' -f1)
+    BASELINE_TESTS_PASS=$(echo "$BASELINE_GATE_RESULT" | cut -d'|' -f2)
+    BASELINE_SCORE=$(echo "$BASELINE_GATE_RESULT" | cut -d'|' -f3)
+    BASELINE_GATED=$(echo "$BASELINE_GATE_RESULT" | cut -d'|' -f4)
+    if [ "$BASELINE_GATED" = "true" ]; then
+        echo "Baseline ground-truth gate: tests failed → score capped (judge gave $BASELINE_ORIGINAL_SCORE/$BASELINE_MAX)" >&2
+    fi
+
     # Codex P1 #1: do NOT append the baseline row here. Defer to after the
     # candidate sim+eval succeeds — otherwise a candidate failure leaves an
     # orphan baseline row in history with no comparison partner. Both rows
@@ -481,6 +533,29 @@ case "$SCORE" in ''|*[!0-9]*) SCORE=0 ;; esac
 case "$MAX_SCORE" in ''|*[!0-9]*) MAX_SCORE=10 ;; esac
 [ -z "$CRIT" ] && CRIT='{}'
 
+# ---- ROADMAP #96 Phase 2: ground-truth gate (candidate / single-mode) ----
+# Path resolves to $CANDIDATE_DIR/.../test-repo in compare-baseline mode
+# (Codex F-01) or cwd-relative in single-mode. Override with
+# SDLC_SHEPHERD_FIXTURE_DIR for tests.
+ORIGINAL_SCORE="$SCORE"
+if [ "$COMPARE_BASELINE" = "1" ] && [ -n "$CANDIDATE_DIR" ]; then
+    # --strip-paths mode: candidate sim ran in $CANDIDATE_DIR (Codex F-01).
+    # The fixture's there too; the agent's edits don't touch the working repo.
+    GT_FIXTURE_DIR="${SDLC_SHEPHERD_FIXTURE_DIR:-$CANDIDATE_DIR/tests/e2e/fixtures/test-repo}"
+else
+    # Single mode OR default --compare-baseline: candidate sim runs in REPO_ROOT
+    # (current branch's working tree) → cwd-relative fixture path.
+    GT_FIXTURE_DIR="${SDLC_SHEPHERD_FIXTURE_DIR:-tests/e2e/fixtures/test-repo}"
+fi
+GATE_RESULT=$(run_gate "$GT_FIXTURE_DIR" "$SCORE")
+TESTS_RUN=$(echo "$GATE_RESULT" | cut -d'|' -f1)
+TESTS_PASS=$(echo "$GATE_RESULT" | cut -d'|' -f2)
+SCORE=$(echo "$GATE_RESULT" | cut -d'|' -f3)
+GROUND_TRUTH_GATED=$(echo "$GATE_RESULT" | cut -d'|' -f4)
+if [ "$GROUND_TRUTH_GATED" = "true" ]; then
+    echo "Ground-truth gate: tests failed → score capped (judge gave $ORIGINAL_SCORE/$MAX_SCORE)" >&2
+fi
+
 # Provenance fields were computed once before the baseline run (see above).
 # Append history rows. When --compare-baseline is set, both baseline AND
 # candidate rows are written here (deferred from the baseline block per
@@ -488,7 +563,8 @@ case "$MAX_SCORE" in ''|*[!0-9]*) MAX_SCORE=10 ;; esac
 # Single-run mode omits comparison_role for backward compat.
 mkdir -p "$(dirname "$HISTORY_FILE")"
 if [ "$COMPARE_BASELINE" = "1" ]; then
-    # Baseline row first (deferred from baseline block).
+    # Baseline row first (deferred from baseline block). Includes ground-
+    # truth telemetry from the per-row gate (Codex F-02).
     jq -nc \
         --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --arg scenario "$SCENARIO_NAME" \
@@ -502,7 +578,11 @@ if [ "$COMPARE_BASELINE" = "1" ]; then
         --arg auth_mode "$AUTH_MODE" \
         --arg comparison_role "baseline" \
         --argjson pr_number "$PR_NUMBER" \
-        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, comparison_role:$comparison_role, pr_number:$pr_number}' \
+        --argjson original_judge_score "$BASELINE_ORIGINAL_SCORE" \
+        --argjson tests_run "$BASELINE_TESTS_RUN" \
+        --argjson tests_pass "$BASELINE_TESTS_PASS" \
+        --argjson ground_truth_gated "$BASELINE_GATED" \
+        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, comparison_role:$comparison_role, pr_number:$pr_number, original_judge_score:$original_judge_score, tests_run:$tests_run, tests_pass:$tests_pass, ground_truth_gated:$ground_truth_gated}' \
         >> "$HISTORY_FILE"
     # Candidate row second.
     jq -nc \
@@ -518,7 +598,11 @@ if [ "$COMPARE_BASELINE" = "1" ]; then
         --arg auth_mode "$AUTH_MODE" \
         --arg comparison_role "candidate" \
         --argjson pr_number "$PR_NUMBER" \
-        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, comparison_role:$comparison_role, pr_number:$pr_number}' \
+        --argjson original_judge_score "$ORIGINAL_SCORE" \
+        --argjson tests_run "$TESTS_RUN" \
+        --argjson tests_pass "$TESTS_PASS" \
+        --argjson ground_truth_gated "$GROUND_TRUTH_GATED" \
+        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, comparison_role:$comparison_role, pr_number:$pr_number, original_judge_score:$original_judge_score, tests_run:$tests_run, tests_pass:$tests_pass, ground_truth_gated:$ground_truth_gated}' \
         >> "$HISTORY_FILE"
 else
     jq -nc \
@@ -533,7 +617,11 @@ else
         --arg claude_code_version "$CLAUDE_CODE_VERSION" \
         --arg auth_mode "$AUTH_MODE" \
         --argjson pr_number "$PR_NUMBER" \
-        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, pr_number:$pr_number}' \
+        --argjson original_score "$ORIGINAL_SCORE" \
+        --argjson tests_run "$TESTS_RUN" \
+        --argjson tests_pass "$TESTS_PASS" \
+        --argjson ground_truth_gated "$GROUND_TRUTH_GATED" \
+        '{timestamp:$ts, scenario:$scenario, score:$score, max_score:$max_score, criteria:$criteria, execution_path:$execution_path, host_os:$host_os, cli_version:$cli_version, claude_code_version:$claude_code_version, auth_mode:$auth_mode, pr_number:$pr_number, original_judge_score:$original_score, tests_run:$tests_run, tests_pass:$tests_pass, ground_truth_gated:$ground_truth_gated}' \
         >> "$HISTORY_FILE"
 fi
 

--- a/tests/test-ground-truth.sh
+++ b/tests/test-ground-truth.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# Roadmap #96 Phase 2 — independent ground-truth verification.
+# After a simulation runs, ground-truth.sh executes the fixture's test
+# suite (`npm test`) to record whether the agent's edits actually work.
+# Combined with the judge score, this catches "agent followed protocol
+# but produced broken code" false-positives.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GT="$SCRIPT_DIR/e2e/ground-truth.sh"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== Ground-Truth Verification Tests (Roadmap #96 Phase 2) ==="
+echo ""
+
+# ---- Helpers ----
+
+# Make a tmp fixture with a package.json that defines the requested
+# test script behavior.
+make_fixture() {
+    local kind="$1"
+    local dir
+    dir=$(mktemp -d -t gt-fixture.XXXXXX)
+    case "$kind" in
+        pass)
+            cat > "$dir/package.json" <<'EOF'
+{ "name": "gt-pass", "version": "1.0.0",
+  "scripts": { "test": "echo PASS_OK && exit 0" } }
+EOF
+            ;;
+        fail)
+            cat > "$dir/package.json" <<'EOF'
+{ "name": "gt-fail", "version": "1.0.0",
+  "scripts": { "test": "echo FAIL_LINE_1 && echo FAIL_LINE_2 && exit 1" } }
+EOF
+            ;;
+        no-test)
+            cat > "$dir/package.json" <<'EOF'
+{ "name": "gt-no-test", "version": "1.0.0",
+  "scripts": { "build": "echo nope" } }
+EOF
+            ;;
+        no-package)
+            : # empty dir
+            ;;
+        slow)
+            cat > "$dir/package.json" <<'EOF'
+{ "name": "gt-slow", "version": "1.0.0",
+  "scripts": { "test": "sleep 30 && exit 0" } }
+EOF
+            ;;
+    esac
+    echo "$dir"
+}
+
+# ---- Tests ----
+
+test_script_exists() {
+    if [ -x "$GT" ]; then
+        pass "ground-truth.sh exists and is executable"
+    else
+        fail "ground-truth.sh not found or not executable: $GT"
+    fi
+}
+test_script_exists
+
+if [ ! -x "$GT" ]; then
+    echo ""
+    echo "=== Results ==="
+    echo "Passed: $PASSED, Failed: $FAILED"
+    exit 1
+fi
+
+test_passing_fixture_emits_pass() {
+    local dir
+    dir=$(make_fixture pass)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    if echo "$out" | jq -e '.tests_run == true and .tests_pass == true' >/dev/null 2>&1; then
+        pass "passing fixture → tests_run=true, tests_pass=true"
+    else
+        fail "passing fixture wrong output: $out"
+    fi
+}
+test_passing_fixture_emits_pass
+
+test_failing_fixture_emits_fail() {
+    local dir
+    dir=$(make_fixture fail)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    if echo "$out" | jq -e '.tests_run == true and .tests_pass == false' >/dev/null 2>&1; then
+        pass "failing fixture → tests_run=true, tests_pass=false"
+    else
+        fail "failing fixture wrong output: $out"
+    fi
+}
+test_failing_fixture_emits_fail
+
+test_failing_fixture_captures_tail() {
+    local dir
+    dir=$(make_fixture fail)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    local tail
+    tail=$(echo "$out" | jq -r '.tests_tail // ""')
+    if echo "$tail" | grep -q "FAIL_LINE_2"; then
+        pass "failing fixture captures stdout tail (FAIL_LINE_2 visible)"
+    else
+        fail "failing fixture missing tail content. Got: $tail"
+    fi
+}
+test_failing_fixture_captures_tail
+
+test_no_test_script_skips_gracefully() {
+    local dir
+    dir=$(make_fixture no-test)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    if echo "$out" | jq -e '.tests_run == false' >/dev/null 2>&1; then
+        pass "fixture without test script → tests_run=false"
+    else
+        fail "no-test fixture wrong output: $out"
+    fi
+}
+test_no_test_script_skips_gracefully
+
+test_no_package_json_skips_gracefully() {
+    local dir
+    dir=$(make_fixture no-package)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    if echo "$out" | jq -e '.tests_run == false' >/dev/null 2>&1; then
+        pass "fixture without package.json → tests_run=false"
+    else
+        fail "no-package fixture wrong output: $out"
+    fi
+}
+test_no_package_json_skips_gracefully
+
+test_missing_dir_errors() {
+    local out rc
+    set +e
+    out=$("$GT" /tmp/nonexistent-gt-dir-$$ 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ] && echo "$out" | grep -qiE "not found|does not exist"; then
+        pass "missing fixture dir → error exit + clear message"
+    else
+        fail "missing dir should error. rc=$rc out=$out"
+    fi
+}
+test_missing_dir_errors
+
+test_no_args_errors() {
+    local out rc
+    set +e
+    out=$("$GT" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ] && echo "$out" | grep -qiE "usage|argument"; then
+        pass "no args → error + usage"
+    else
+        fail "no args should show usage. rc=$rc out=$out"
+    fi
+}
+test_no_args_errors
+
+test_help_flag_works() {
+    local out
+    out=$("$GT" --help 2>&1 || true)
+    if echo "$out" | grep -qiE "usage|fixture"; then
+        pass "--help shows usage"
+    else
+        fail "--help did not show usage. Got: $out"
+    fi
+}
+test_help_flag_works
+
+test_emits_valid_json() {
+    local dir
+    dir=$(make_fixture pass)
+    local out
+    out=$("$GT" "$dir" 2>&1)
+    rm -rf "$dir"
+    if echo "$out" | jq empty >/dev/null 2>&1; then
+        pass "output is valid JSON"
+    else
+        fail "output is not valid JSON: $out"
+    fi
+}
+test_emits_valid_json
+
+test_timeout_long_running() {
+    local dir
+    dir=$(make_fixture slow)
+    local start end elapsed
+    start=$(date +%s)
+    set +e
+    GROUND_TRUTH_TIMEOUT=2 "$GT" "$dir" >/dev/null 2>&1
+    set -e
+    end=$(date +%s)
+    elapsed=$((end - start))
+    rm -rf "$dir"
+    if [ "$elapsed" -lt 10 ]; then
+        pass "GROUND_TRUTH_TIMEOUT honored (elapsed=${elapsed}s, sleep was 30s)"
+    else
+        fail "timeout not enforced — elapsed=${elapsed}s for a 2s timeout on a 30s sleep"
+    fi
+}
+test_timeout_long_running
+
+# ---- Results ----
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASSED, Failed: $FAILED"
+if [ "$FAILED" -ne 0 ]; then
+    exit 1
+fi
+echo "All ground-truth tests passed."

--- a/tests/test-local-shepherd.sh
+++ b/tests/test-local-shepherd.sh
@@ -1150,6 +1150,348 @@ test_strip_paths_no_leak_on_setup_failure
 test_strip_paths_trap_set_before_tmpdir
 test_strip_paths_pr_comment_uses_intact_stripped_labels
 
+# ---- ROADMAP #96 Phase 2: ground-truth gate integration tests ----
+# The shepherd runs ground-truth.sh post-simulation. If `npm test` fails,
+# the score gets capped at GROUND_TRUTH_FAIL_CAP (default 5). Score-
+# history rows record tests_run/tests_pass/ground_truth_gated/
+# original_judge_score so trend analytics can distinguish judge-noise
+# from real regression.
+test_ground_truth_gate_caps_score_when_tests_fail() {
+    local tmpdir bindir history_file evaluator gt
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    history_file="$tmpdir/score-history.jsonl"
+    evaluator="$tmpdir/mock-evaluator.sh"
+    gt="$tmpdir/mock-ground-truth.sh"
+    touch "$history_file"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    # Judge gives 9/10
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":9,"max_score":10,"criteria":{}}'
+EOF
+    # But ground-truth says tests fail
+    cat > "$gt" <<'EOF'
+#!/bin/bash
+echo '{"tests_run":true,"tests_pass":false,"tests_rc":1,"tests_tail":"AssertionError"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$history_file" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 >/dev/null 2>&1 || true
+    local row
+    row=$(tail -1 "$history_file" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$row" | jq -e '.score == 5 and .original_judge_score == 9 and .ground_truth_gated == true and .tests_pass == false' >/dev/null 2>&1; then
+        pass "ground-truth gate caps judge=9 to score=5 when tests fail"
+    else
+        fail "ground-truth gate did not apply. row=$row"
+    fi
+}
+test_ground_truth_gate_caps_score_when_tests_fail
+
+test_ground_truth_gate_passes_through_when_tests_pass() {
+    local tmpdir bindir history_file evaluator gt
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    history_file="$tmpdir/score-history.jsonl"
+    evaluator="$tmpdir/mock-evaluator.sh"
+    gt="$tmpdir/mock-ground-truth.sh"
+    touch "$history_file"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":8,"max_score":10,"criteria":{}}'
+EOF
+    cat > "$gt" <<'EOF'
+#!/bin/bash
+echo '{"tests_run":true,"tests_pass":true,"tests_rc":0,"tests_tail":"OK"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$history_file" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 >/dev/null 2>&1 || true
+    local row
+    row=$(tail -1 "$history_file" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$row" | jq -e '.score == 8 and .ground_truth_gated == false and .tests_pass == true' >/dev/null 2>&1; then
+        pass "ground-truth gate leaves judge score alone when tests pass"
+    else
+        fail "ground-truth gate misfired. row=$row"
+    fi
+}
+test_ground_truth_gate_passes_through_when_tests_pass
+
+test_ground_truth_skipped_when_no_tests_configured() {
+    # Fixture without test script → tests_run=false → no gate applied,
+    # judge score stands alone.
+    local tmpdir bindir history_file evaluator gt
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    history_file="$tmpdir/score-history.jsonl"
+    evaluator="$tmpdir/mock-evaluator.sh"
+    gt="$tmpdir/mock-ground-truth.sh"
+    touch "$history_file"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":7,"max_score":10,"criteria":{}}'
+EOF
+    cat > "$gt" <<'EOF'
+#!/bin/bash
+echo '{"tests_run":false,"reason":"no_test_script"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$history_file" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 >/dev/null 2>&1 || true
+    local row
+    row=$(tail -1 "$history_file" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$row" | jq -e '.score == 7 and .ground_truth_gated == false and .tests_run == false' >/dev/null 2>&1; then
+        pass "no-tests fixture → judge score stands alone (no gate)"
+    else
+        fail "no-tests path misfired. row=$row"
+    fi
+}
+test_ground_truth_skipped_when_no_tests_configured
+
+test_ground_truth_skip_env_var() {
+    # SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1 disables gate entirely (escape
+    # hatch for users who don't have a fixture or want raw judge scores).
+    local tmpdir bindir history_file evaluator
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    history_file="$tmpdir/score-history.jsonl"
+    evaluator="$tmpdir/mock-evaluator.sh"
+    touch "$history_file"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":9,"max_score":10,"criteria":{}}'
+EOF
+    chmod +x "$evaluator"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1 \
+        SDLC_SHEPHERD_HISTORY_FILE="$history_file" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 >/dev/null 2>&1 || true
+    local row
+    row=$(tail -1 "$history_file" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$row" | jq -e '.score == 9 and .tests_run == false and .ground_truth_gated == false' >/dev/null 2>&1; then
+        pass "SDLC_SHEPHERD_SKIP_GROUND_TRUTH disables gate entirely"
+    else
+        fail "skip env var did not disable gate. row=$row"
+    fi
+}
+test_ground_truth_skip_env_var
+
+# ---- ROADMAP #96 Phase 2 (Codex F-01/F-02): compare-baseline gate ----
+# The gate must apply per-row in compare-baseline mode AND test the
+# CANDIDATE_DIR fixture, not the repo-root fixture. Round 1 missed
+# both gaps; round 2 wires baseline/candidate gates separately.
+test_compare_baseline_gate_caps_candidate_when_tests_fail() {
+    local tmpdir bindir evaluator gt
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    evaluator="$tmpdir/eval.sh"
+    gt="$tmpdir/ground-truth.sh"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir" "abcd1234" "$tmpdir/git.log"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    # Both legs return judge=9 (above cap)
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":9,"max_score":10,"criteria":{}}'
+EOF
+    # Both legs: tests fail
+    cat > "$gt" <<'EOF'
+#!/bin/bash
+echo '{"tests_run":true,"tests_pass":false,"tests_rc":1,"tests_tail":"failed"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 --compare-baseline \
+        >/dev/null 2>&1 || true
+    local baseline_row candidate_row
+    baseline_row=$(grep '"comparison_role":"baseline"' "$tmpdir/score-history.jsonl" 2>/dev/null)
+    candidate_row=$(grep '"comparison_role":"candidate"' "$tmpdir/score-history.jsonl" 2>/dev/null)
+    rm -rf "$tmpdir"
+    local ok_baseline ok_candidate
+    ok_baseline=$(echo "$baseline_row" | jq -e '.score == 5 and .original_judge_score == 9 and .ground_truth_gated == true and .tests_pass == false' >/dev/null 2>&1 && echo yes || echo no)
+    ok_candidate=$(echo "$candidate_row" | jq -e '.score == 5 and .original_judge_score == 9 and .ground_truth_gated == true and .tests_pass == false' >/dev/null 2>&1 && echo yes || echo no)
+    if [ "$ok_baseline" = "yes" ] && [ "$ok_candidate" = "yes" ]; then
+        pass "compare-baseline gate caps BOTH baseline + candidate when tests fail"
+    else
+        fail "compare-baseline gate misfired. baseline=$ok_baseline ($baseline_row) candidate=$ok_candidate ($candidate_row)"
+    fi
+}
+test_compare_baseline_gate_caps_candidate_when_tests_fail
+
+test_compare_baseline_gate_no_cap_when_judge_below_cap() {
+    # Edge case: judge=4 already below cap. Tests fail. Score stays 4.
+    # ground_truth_gated must be false (cap didn't apply).
+    local tmpdir bindir evaluator gt
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    evaluator="$tmpdir/eval.sh"
+    gt="$tmpdir/ground-truth.sh"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir" "abcd1234" "$tmpdir/git.log"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":4,"max_score":10,"criteria":{}}'
+EOF
+    cat > "$gt" <<'EOF'
+#!/bin/bash
+echo '{"tests_run":true,"tests_pass":false,"tests_rc":1,"tests_tail":"failed"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 --compare-baseline \
+        >/dev/null 2>&1 || true
+    local candidate_row
+    candidate_row=$(grep '"comparison_role":"candidate"' "$tmpdir/score-history.jsonl" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$candidate_row" | jq -e '.score == 4 and .original_judge_score == 4 and .ground_truth_gated == false and .tests_pass == false' >/dev/null 2>&1; then
+        pass "compare-baseline: judge=4 + tests-fail leaves score=4, gated=false"
+    else
+        fail "compare-baseline cap-boundary semantics wrong. row=$candidate_row"
+    fi
+}
+test_compare_baseline_gate_no_cap_when_judge_below_cap
+
+test_compare_baseline_gate_baseline_uses_baseline_dir() {
+    # F-01 regression (default compare-baseline mode): the BASELINE leg
+    # of the gate must invoke ground-truth with $BASELINE_DIR fixture,
+    # not the repo-root path. Candidate runs in REPO_ROOT in default
+    # mode, so candidate-side path being repo-root is CORRECT —
+    # only the baseline-side has to point at the worktree.
+    local tmpdir bindir evaluator gt gt_log
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    evaluator="$tmpdir/eval.sh"
+    gt="$tmpdir/ground-truth.sh"
+    gt_log="$tmpdir/gt.log"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir" "abcd1234" "$tmpdir/git.log"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":7,"max_score":10,"criteria":{}}'
+EOF
+    cat > "$gt" <<EOF
+#!/bin/bash
+echo "\$@" >> "$gt_log"
+echo '{"tests_run":true,"tests_pass":true,"tests_rc":0,"tests_tail":"ok"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 --compare-baseline \
+        >/dev/null 2>&1 || true
+    local logged baseline_path candidate_path
+    logged=$(cat "$gt_log" 2>/dev/null)
+    baseline_path=$(echo "$logged" | sed -n '1p')
+    candidate_path=$(echo "$logged" | sed -n '2p')
+    rm -rf "$tmpdir"
+    # Baseline path must be an absolute path containing 'sdlc-baseline'
+    # (the mktemp prefix) — proving it points to BASELINE_DIR, not repo-root.
+    if echo "$baseline_path" | grep -qE 'sdlc-baseline.*tests/e2e/fixtures/test-repo$' \
+       && [ "$candidate_path" = "tests/e2e/fixtures/test-repo" ]; then
+        pass "compare-baseline gate paths: baseline=BASELINE_DIR (Codex F-01), candidate=repo-root (CWD)"
+    else
+        fail "gate path resolution wrong. baseline='$baseline_path' candidate='$candidate_path'"
+    fi
+}
+test_compare_baseline_gate_baseline_uses_baseline_dir
+
+test_strip_paths_gate_uses_candidate_strip_dir() {
+    # Codex F-01 round 2 nit: in --strip-paths mode, the candidate gate
+    # must invoke ground-truth with $CANDIDATE_DIR/.../test-repo (the
+    # stripped-fixture worktree). Without this, the gate would test the
+    # repo's working-tree fixture even though the agent ran against a
+    # stripped copy. Mock ground-truth records argv to verify the path.
+    local tmpdir bindir evaluator gt gt_log
+    tmpdir=$(mktemp -d)
+    bindir="$tmpdir/bin"
+    evaluator="$tmpdir/eval.sh"
+    gt="$tmpdir/ground-truth.sh"
+    gt_log="$tmpdir/gt.log"
+    _mock_gh "$bindir" "false" "$tmpdir/gh.log"
+    _mock_git "$bindir" "abcd1234" "$tmpdir/git.log"
+    _mock_claude "$bindir" "$tmpdir/claude.log"
+    _mock_curl "$bindir"
+    cat > "$evaluator" <<'EOF'
+#!/bin/bash
+echo '{"score":7,"max_score":10,"criteria":{}}'
+EOF
+    cat > "$gt" <<EOF
+#!/bin/bash
+echo "\$@" >> "$gt_log"
+echo '{"tests_run":true,"tests_pass":true,"tests_rc":0,"tests_tail":"ok"}'
+EOF
+    chmod +x "$evaluator" "$gt"
+    PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
+        SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
+        SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_GROUND_TRUTH="$gt" \
+        SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
+        CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 231 \
+        --compare-baseline \
+        --strip-paths '[".claude/hooks/sdlc-prompt-check.sh"]' \
+        >/dev/null 2>&1 || true
+    local logged baseline_path candidate_path
+    logged=$(cat "$gt_log" 2>/dev/null)
+    baseline_path=$(echo "$logged" | sed -n '1p')
+    candidate_path=$(echo "$logged" | sed -n '2p')
+    rm -rf "$tmpdir"
+    # Both paths must point to mktemp-style strip worktree dirs (not
+    # repo-root). Baseline mktemp prefix: "sdlc-baseline-strip", candidate:
+    # "sdlc-candidate-strip". Both end in tests/e2e/fixtures/test-repo.
+    if echo "$baseline_path" | grep -qE 'sdlc-baseline-strip.*tests/e2e/fixtures/test-repo$' \
+       && echo "$candidate_path" | grep -qE 'sdlc-candidate-strip.*tests/e2e/fixtures/test-repo$'; then
+        pass "strip-paths gate: baseline=BASELINE_DIR (intact), candidate=CANDIDATE_DIR (stripped) [Codex F-01]"
+    else
+        fail "strip-paths gate path resolution wrong. baseline='$baseline_path' candidate='$candidate_path'"
+    fi
+}
+test_strip_paths_gate_uses_candidate_strip_dir
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASSED"

--- a/tests/test-local-shepherd.sh
+++ b/tests/test-local-shepherd.sh
@@ -563,9 +563,14 @@ fi
 EOF
     chmod +x "$evaluator"
     rm -f "$state_file"
+    # SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1: pre-existing compare-baseline tests
+    # were written before the ground-truth gate (#96 Phase 2). They assert
+    # raw judge scores, not gated ones. Skip gate here; gate-specific tests
+    # set their own SDLC_SHEPHERD_GROUND_TRUTH mock.
     PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
         SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
         SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1 \
         SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
         CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 227 --compare-baseline \
         > "$tmpdir/stdout.log" 2> "$tmpdir/stderr.log" || true
@@ -833,9 +838,11 @@ fi
 EOF
     chmod +x "$evaluator"
     rm -f "$state_file"
+    # SKIP_GROUND_TRUTH for the same reason as _compare_baseline_run.
     PATH="$bindir:$PATH" ANTHROPIC_API_KEY=test-key \
         SDLC_LOCAL_SHEPHERD_DRY_RUN=1 \
         SDLC_SHEPHERD_EVALUATOR="$evaluator" \
+        SDLC_SHEPHERD_SKIP_GROUND_TRUTH=1 \
         SDLC_SHEPHERD_HISTORY_FILE="$tmpdir/score-history.jsonl" \
         CLAUDE_PROJECT_DIR="$REPO_ROOT" "$SHEPHERD" 231 \
         --compare-baseline --strip-paths "$strip_arg" \


### PR DESCRIPTION
## Summary

Closes ROADMAP **#96 Phase 2**. Adds independent ground-truth verification to the E2E benchmark.

After the simulation runs, `tests/e2e/ground-truth.sh` runs the fixture's `npm test`. If tests fail, the final score is **capped at 5/10** (configurable via `GROUND_TRUTH_FAIL_CAP`). Combined with Phase 1's de-coaching (v1.57.0), the benchmark now requires **both** judge approval **and** real test passage — closes the "agent followed protocol but produced broken code" false-positive.

## Codex review

**Round 3 CERTIFIED 10/10** — round 1 7/10 + round 2 8/10 with 3 P1/P2 findings, all fixed and regression-tested:
- **F-01 P1**: strip-paths mode tested wrong fixture path → resolved via `$CANDIDATE_DIR/.../test-repo` + new `test_strip_paths_gate_uses_candidate_strip_dir`
- **F-02 P1**: compare-baseline rows missing gate telemetry → `run_gate()` helper applied per-leg + 3 new tests
- **F-03 P2**: CHANGELOG order wrong → reworded "after evaluator, before score-history append"

## Test plan

- [x] `tests/test-ground-truth.sh` — 11/11 (passing/failing/no-test/no-package/missing-dir/no-args/help/JSON/timeout)
- [x] `tests/test-local-shepherd.sh` — 42/42 (was 34, +8 gate tests)
- [x] Full sweep: 47/47 test files green
- [x] Mutation verified: removing `tests_pass` from ground-truth.sh fails the gate test
- [x] Cross-platform timeout fallback chain: `timeout` / `gtimeout` / `perl` (stock macOS works)
- [x] Versions consistent at 1.58.0 across all 7 pin sites
- [ ] CI green

## Files

- `tests/e2e/ground-truth.sh` (new, 105 lines)
- `tests/test-ground-truth.sh` (new, 11 tests)
- `tests/e2e/local-shepherd.sh` (run_gate helper + per-leg gate + new score-history fields)
- `tests/test-local-shepherd.sh` (4 single-mode + 3 compare-baseline + 1 strip-paths gate tests)
- `.github/workflows/ci.yml` + `CONTRIBUTING.md` (test list)
- CHANGELOG.md + version pins

## Phase 3 (next, deferred)

- Install wizard files into the local-shepherd test fixture
- Demonstrate wizard installation lifts organically-low scores back up — the actual *"does the wizard work?"* test
- Calibration scenarios with subtle bugs to test self-review effectiveness