### PR TITLE
feat: cross-reference XDLC siblings (codex + GDLC) — v1.64.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.64.0] - 2026-04-30
+
+### Added (XDLC ecosystem cross-references)
+
+- **README gets an "XDLC Ecosystem (Sibling Projects)" section.** The wizard ships as one of three published siblings — `agentic-sdlc-wizard` (this repo, Claude Code / SDLC), `codex-sdlc-wizard` (Codex CLI / SDLC), and `claude-gdlc-wizard` (Claude Code / Game Development Life Cycle). Until now, none of the three READMEs cross-referenced the others, so a user landing on one package on npm or GitHub couldn't discover the family. The new section is a 3-row table with package name + GitHub repo + one-line description, plus a pointer to the broader [XDLC ecosystem](https://github.com/BaseInfinity/xdlc) umbrella.
+
+- **Wizard doc references the GDLC sibling.** `CLAUDE_CODE_SDLC_WIZARD.md` already mentioned the Codex sibling in the MCP-tool-hooks audit (portability criterion); now expanded to mention `claude-gdlc-wizard` alongside it. Cross-host portability is reframed as "cross-host / cross-domain portability" since GDLC is a different domain (games), not just a different agent.
+
+- **ROADMAP "Built With SDLC Wizard" table adds the GDLC row.** Previously listed only this repo and `codex-sdlc-wizard`. Now lists all three siblings; status column shows current sibling versions (Codex v0.7.x, GDLC v0.2.x).
+
+### Tests
+
+- **3 new tests in `tests/test-doc-consistency.sh`** prevent drift:
+  - `test_readme_references_all_siblings` — README must mention both sibling package names by literal string match (`codex-sdlc-wizard`, `claude-gdlc-wizard`)
+  - `test_readme_has_ecosystem_section` — README must have a discoverable `## XDLC Ecosystem` / `## Family` / `## Siblings` heading (not just an inline mention)
+  - `test_wizard_doc_mentions_gdlc_sibling` — Wizard doc must reference `claude-gdlc-wizard` wherever Codex sibling is mentioned (regression guard for sibling parity)
+
+  TDD-verified: all three failed before the doc edits, all three pass after. 33/33 doc-consistency tests green.
+
+### Files
+
+- `README.md` (new "XDLC Ecosystem (Sibling Projects)" section)
+- `CLAUDE_CODE_SDLC_WIZARD.md` (line 501 expanded — Codex + GDLC siblings, cross-host/cross-domain portability framing)
+- `ROADMAP.md` ("Built With SDLC Wizard" table — added GDLC row, bumped this repo's status to v1.64.0)
+- `tests/test-doc-consistency.sh` (+3 tests, 33 total)
+- `CHANGELOG.md`, `SDLC.md`, `skills/update/SKILL.md`, `package.json`, `.claude-plugin/plugin.json` + `marketplace.json` (1.63.0 → 1.64.0)
+
+### Follow-up
+
+- Mirror issues filed in `BaseInfinity/codex-sdlc-wizard` and `BaseInfinity/claude-gdlc-wizard` so each sibling adds the same Ecosystem section pointing back here. Bidirectional cross-references means any of the 3 npm package pages surfaces the family.
+
 ## [1.63.0] - 2026-04-30
 
 ### Added (cache-cost observability closeout — closes ROADMAP #204)

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -498,7 +498,7 @@ CC 2.1.118 introduced `type: "mcp_tool"` for hooks — a hook can now directly i
 
 **Decision criteria applied** (any one rules out MCP):
 
-1. **Portability** — bash hooks port to the **shipped** Codex sibling (`~/codex-sdlc-wizard`) and to a **planned** OpenCode sibling (ROADMAP #91, not yet shipped) without rewrite. MCP hooks are CC-specific. Cross-host portability is an XDLC requirement.
+1. **Portability** — bash hooks port to the **shipped** sibling wizards (`codex-sdlc-wizard` for Codex CLI, `claude-gdlc-wizard` for the Game Development Life Cycle variant) and to a **planned** OpenCode sibling (ROADMAP #91, not yet shipped) without rewrite. MCP hooks are CC-specific. Cross-host / cross-domain portability is an XDLC requirement.
 2. **Fail-closed gating** — hooks that block an action (exit 2 from PreCompact) need a fail-closed contract: any error in the hook MUST keep the block in place. CC docs ([code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks)) confirm `mcp_tool` hooks CAN gate via `decision: "block"` JSON output, but **MCP server errors are non-blocking by design** — if the MCP server is down/slow/buggy, the action proceeds. That breaks the fail-closed contract. Bash exit 2 fails closed.
 3. **Local-only state** — hooks that read/write `~/.cache/sdlc-wizard/` or `.reviews/handoff.json` don't surface state across tool boundaries. MCP adds a wire format without consumers.
 
@@ -2974,7 +2974,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.63.0 -->
+<!-- SDLC Wizard Version: 1.64.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4053,7 +4053,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.63.0 -->
+<!-- SDLC Wizard Version: 1.64.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/README.md
+++ b/README.md
@@ -257,6 +257,18 @@ This isn't the only Claude Code SDLC tool. Here's an honest comparison:
 | [CHANGELOG.md](CHANGELOG.md) | Version history, what changed and when |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute, evaluation methodology |
 
+## XDLC Ecosystem (Sibling Projects)
+
+This wizard is one of three published siblings. Same enforcement philosophy, different agent / domain:
+
+| Package | Agent / Domain | What It Does |
+|---------|----------------|--------------|
+| [`agentic-sdlc-wizard`](https://www.npmjs.com/package/agentic-sdlc-wizard) ([repo](https://github.com/BaseInfinity/claude-sdlc-wizard)) | Claude Code / SDLC | This repo. Plan → TDD → self-review for code, with hooks + skills + CI scoring |
+| [`codex-sdlc-wizard`](https://www.npmjs.com/package/codex-sdlc-wizard) ([repo](https://github.com/BaseInfinity/codex-sdlc-wizard)) | OpenAI Codex / SDLC | Same SDLC enforcement, ported to Codex CLI (writes `.codex/` + `AGENTS.md`) |
+| [`claude-gdlc-wizard`](https://www.npmjs.com/package/claude-gdlc-wizard) ([repo](https://github.com/BaseInfinity/claude-gdlc-wizard)) | Claude Code / GDLC | Game Development Life Cycle — persona-driven playtest cycles, triangulated findings, ratchet-only-tightens |
+
+All three are part of the broader [XDLC ecosystem](https://github.com/BaseInfinity/xdlc) — generalized lifecycle enforcement across agents and domains.
+
 ## Community
 
 <div align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,8 +175,9 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 
 | Project | Repo | Status |
 |---------|------|--------|
-| SDLC Wizard itself | BaseInfinity/claude-sdlc-wizard | Dogfooded, v1.34.0 |
-| Codex SDLC Adapter | BaseInfinity/codex-sdlc-wizard | v1, shipped with SDLC workflow |
+| SDLC Wizard itself | BaseInfinity/claude-sdlc-wizard | Dogfooded, v1.64.0 |
+| Codex SDLC Adapter | BaseInfinity/codex-sdlc-wizard | v0.7.x, shipped with SDLC workflow |
+| GDLC Wizard (games sibling) | BaseInfinity/claude-gdlc-wizard | v0.2.x, persona-driven playtest cycles |
 | _(add as projects are marked)_ | | |
 
 **TODO:** audit Stefan's GitHub projects + production apps, mark the ones that used the wizard, then list them here. Do not populate from memory — only list what's been marked.

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.63.0 -->
+<!-- SDLC Wizard Version: 1.64.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.63.0 |
+| Wizard Version | 1.64.0 |
 | Last Updated | 2026-04-30 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.63.0
+Latest:    1.64.0
 
 What changed:
+- [1.64.0] XDLC ecosystem cross-references — README, wizard doc, and ROADMAP now cross-reference all three sibling packages (`agentic-sdlc-wizard`, `codex-sdlc-wizard`, `claude-gdlc-wizard`). New "Ecosystem (Sibling Projects)" section in README. 3 new doc-consistency tests prevent drift.
 - [1.63.0] cache-cost observability closeout (#204 absorbed by #220) — `tests/test-token-spike.sh` gains explicit cache-miss regression test + negative-control test. SDLC skill + wizard doc gain "Cache-Cost Surprises" sections covering 10-20× silent cost blowups (mid-session CLAUDE.md edits, idle pruning, upstream cache bugs) and detection via `hooks/token-spike-check.sh`'s `costly_tokens` metric.
 - [1.62.0] roadmap hygiene + #211 backfill — closes paperwork-stale rows (#207, #211 historical, #215, #217, #78, #79, #80, #219). Backfilled 5 corrupted `score-history.jsonl` rows from `max_score:10` → `max_score:11` (UI scenarios with design_system criterion). Codex strategic review confirmed scope.
 - [1.61.0] calibration scenarios for #96 Phase 3 PR 2 — `tests/e2e/scenarios/calibration-careful-read.md` (parsePrice with 5 edge-case formats) tests whether self-review catches missed requirements. Score delta between SDLC and naive agents on this scenario is a calibration signal for `lift-proof.sh`

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -628,6 +628,68 @@ test_wizard_doc_mentions_less_permission_prompts
 test_wizard_doc_mentions_permissions_command
 
 # ────────────────────────────────────────────
+# XDLC Ecosystem Cross-References
+# ────────────────────────────────────────────
+#
+# This repo is one of three published siblings:
+#   - agentic-sdlc-wizard (this repo, npm) — Claude Code SDLC
+#   - codex-sdlc-wizard (npm) — Codex SDLC adapter
+#   - claude-gdlc-wizard (npm) — Game Development Life Cycle sibling
+#
+# Each package's README and primary docs should cross-reference the others
+# so users landing on one package can discover the family. Without this,
+# discoverability across the 3 packages is weak.
+
+echo ""
+echo "--- XDLC Ecosystem Cross-Refs ---"
+
+# README must reference all 3 sibling packages by name so users on npm/GH
+# can discover the family. Codex sibling = `codex-sdlc-wizard`,
+# GDLC sibling = `claude-gdlc-wizard`. This repo's npm name is
+# `agentic-sdlc-wizard` (already implicit in install commands, but the
+# Ecosystem section should make all three explicit).
+test_readme_references_all_siblings() {
+    local README="$REPO_ROOT/README.md"
+    if [ ! -f "$README" ]; then fail "README.md not found"; return; fi
+    local missing=()
+    grep -q 'codex-sdlc-wizard' "$README" || missing+=("codex-sdlc-wizard")
+    grep -q 'claude-gdlc-wizard' "$README" || missing+=("claude-gdlc-wizard")
+    if [ ${#missing[@]} -gt 0 ]; then
+        fail "README.md missing sibling refs: ${missing[*]}"
+    else
+        pass "README.md references both sibling packages (codex-sdlc-wizard, claude-gdlc-wizard)"
+    fi
+}
+
+# README should have a discoverable Ecosystem/Family section heading so
+# users skimming the TOC find the cross-references, not just inline mentions.
+test_readme_has_ecosystem_section() {
+    local README="$REPO_ROOT/README.md"
+    if [ ! -f "$README" ]; then fail "README.md not found"; return; fi
+    if grep -qiE '^##+ (XDLC )?(Ecosystem|Family|Sibling|Related Projects)' "$README"; then
+        pass "README.md has an Ecosystem/Family section heading"
+    else
+        fail "README.md missing an Ecosystem/Family/Siblings section heading"
+    fi
+}
+
+# Wizard doc already mentions Codex sibling (line 501); GDLC was added to
+# the family 2026-04-26 and should be referenced wherever Codex is.
+test_wizard_doc_mentions_gdlc_sibling() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    if grep -q 'claude-gdlc-wizard' "$DOC"; then
+        pass "CLAUDE_CODE_SDLC_WIZARD.md references claude-gdlc-wizard sibling"
+    else
+        fail "Wizard doc missing claude-gdlc-wizard sibling reference"
+    fi
+}
+
+test_readme_references_all_siblings
+test_readme_has_ecosystem_section
+test_wizard_doc_mentions_gdlc_sibling
+
+# ────────────────────────────────────────────
 # Summary
 # ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- README gets a new **XDLC Ecosystem (Sibling Projects)** section pointing at `codex-sdlc-wizard` and `claude-gdlc-wizard` so users landing on any one of the three npm packages can discover the family
- Wizard doc + ROADMAP "Built With" table extended to reference all three siblings (was Codex-only)
- 3 new doc-consistency tests prevent drift; TDD-verified (failed before edits, pass after)
- v1.63.0 → v1.64.0; CHANGELOG documents the ecosystem cross-reference

## Why now

Audit 2026-04-30 found `claude-gdlc-wizard` (added 4 days ago) was referenced **zero times** in this repo, and `README.md` had no ecosystem section at all — so a user landing on this npm page couldn't find the other two siblings.

## Test plan
- [x] tests/test-doc-consistency.sh — 33/33 green (3 new ecosystem tests)
- [x] tests/test-cli.sh — green
- [x] tests/test-hooks.sh — 154/154 green
- [x] tests/test-plugin.sh — green
- [x] tests/test-self-update.sh — 153/153 green
- [x] tests/test-release-workflow.sh — 14/14 green
- [x] tests/test-audit-session-load.sh — 9/9 green (no token-bloat regression)
- [x] All 6 version files synced to 1.64.0
- [ ] CI green
- [ ] Mirror issues filed in BaseInfinity/codex-sdlc-wizard and BaseInfinity/claude-gdlc-wizard after merge