### PR TITLE
docs: surface codex-sdlc-wizard sibling near top of README + wizard doc

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -22,6 +22,8 @@ You set it up, Claude follows it. The magic is that structured human engineering
 
 **The result:** Claude follows a disciplined engineering process automatically. You just review and approve.
 
+> **Built for Claude Code.** Using OpenAI's Codex CLI instead? See [`codex-sdlc-wizard`](https://github.com/BaseInfinity/codex-sdlc-wizard) — same SDLC enforcement, ported.
+
 ---
 
 ## The Vision

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A **self-evolving Software Development Life Cycle (SDLC) enforcement system for 
 
 **Built on 15+ years of software engineering and founding engineering experience** — battle-tested patterns from real production systems, baked into an AI agent that follows tried-and-true software quality practices so you don't have to enforce them manually.
 
+> **Built for Claude Code.** Using OpenAI's Codex CLI instead? Check out [`codex-sdlc-wizard`](https://github.com/BaseInfinity/codex-sdlc-wizard) — same SDLC enforcement, ported. ([Full ecosystem](#xdlc-ecosystem-sibling-projects).)
+
 ## Install
 
 **Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)** (Anthropic's CLI for Claude).

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -685,9 +685,37 @@ test_wizard_doc_mentions_gdlc_sibling() {
     fi
 }
 
+# Codex sibling must surface near the top of README + wizard doc so users
+# landing on either entry point see the alternative-agent option without
+# scrolling 250+ lines to the Ecosystem section. (User feedback
+# 2026-05-04: "mention codex-sdlc-wizard towards the top after mentioning
+# this is for claude — 'this is for Claude but check out codex for
+# alternatives'.")
+test_readme_mentions_codex_near_top() {
+    local README="$REPO_ROOT/README.md"
+    if [ ! -f "$README" ]; then fail "README.md not found"; return; fi
+    if head -30 "$README" | grep -q 'codex-sdlc-wizard'; then
+        pass "README.md mentions codex-sdlc-wizard within first 30 lines"
+    else
+        fail "README.md does not mention codex-sdlc-wizard near top (first 30 lines)"
+    fi
+}
+
+test_wizard_doc_mentions_codex_near_top() {
+    local DOC="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    if [ ! -f "$DOC" ]; then fail "CLAUDE_CODE_SDLC_WIZARD.md not found"; return; fi
+    if head -50 "$DOC" | grep -q 'codex-sdlc-wizard'; then
+        pass "CLAUDE_CODE_SDLC_WIZARD.md mentions codex-sdlc-wizard within first 50 lines"
+    else
+        fail "CLAUDE_CODE_SDLC_WIZARD.md does not mention codex-sdlc-wizard near top (first 50 lines)"
+    fi
+}
+
 test_readme_references_all_siblings
 test_readme_has_ecosystem_section
 test_wizard_doc_mentions_gdlc_sibling
+test_readme_mentions_codex_near_top
+test_wizard_doc_mentions_codex_near_top
 
 # ────────────────────────────────────────────
 # Summary


### PR DESCRIPTION
## Summary

Surface the Codex sibling at the top of both entry points (README + wizard doc) so users on OpenAI's Codex CLI find the alternative without scrolling 250+/500+ lines to the Ecosystem section.

- `README.md` (line 7): blockquote callout right after the tagline, before Install
- `CLAUDE_CODE_SDLC_WIZARD.md` (line 24): blockquote callout right after the "What This Is" intro, before the section divider
- `tests/test-doc-consistency.sh`: two head-N grep tests (30 lines for README, 50 for wizard doc) so the callout doesn't drift out of the top fold

OpenCode sibling intentionally not mentioned yet (per maintainer — bootstrap shipping in a different session).

## Test plan

- [x] `bash tests/test-doc-consistency.sh` — 35/0 (was 33/2 RED; both new tests now PASS)
- [x] 22 of 23 doc-touching tests green locally; the one remaining failure (`test-persist-score-history.sh`) reproduces on `origin/main` HEAD without my diff — pre-existing, unrelated
- [ ] CI validate green