### PR TITLE
bloat: BASELINE block fires once per CC session (v1.69.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.68.0",
+      "version": "1.69.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Run prompt-hook-fires-once tests (#224)
         run: ./tests/test-prompt-hook-fires-once.sh
 
+      - name: Run baseline-fires-once-per-session tests (token bloat audit)
+        run: ./tests/test-baseline-fires-once.sh
+
       - name: Run community scanner tests (#207)
         run: ./tests/test-community-scanner.sh
 

--- a/.reviews/baseline-fires-once-001/round-1-review.md
+++ b/.reviews/baseline-fires-once-001/round-1-review.md
@@ -1,0 +1,34 @@
+**Findings**
+
+1. **P1**: Same-session BASELINE suppression is not concurrency-safe.
+   Evidence: [sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:131) checks for the sentinel before emit, but [sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:164) writes it only after the `cat` block. A 50-process same-session race produced `baseline_outputs=13`, `sentinels=1`.
+   Certify condition: make the first-writer decision atomic, with best-effort fallback preserved, and add a parallel same-`session_id` regression test expecting exactly one BASELINE.
+
+2. **P1**: Valid `session_id` input is ignored when `jq` is unavailable or broken.
+   Evidence: [sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:47) only reads stdin when `jq` exists, and [sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:51) extracts `session_id` through `jq`. With a fake failing `jq` and valid JSON stdin: `first_baseline=1`, `second_baseline=1`, `sentinels=0`.
+   Certify condition: either make `session_id` extraction work without optional `jq`, or explicitly enforce/document `jq` as a runtime dependency and test the dependency behavior.
+
+**Checklist Evidence**
+
+(a) Sequential gate shape is correct: sentinel check at lines 122-132, BASELINE at 137-158, write after emit at 159-168. EFFORT is outside at 90-100; SETUP is outside at 103-112.
+
+(b) SETUP missing test uses sibling tmpdir: [test-baseline-fires-once.sh](/Users/stefanayala/sdlc-wizard/tests/test-baseline-fires-once.sh:110).
+
+(c) Sanitization uses `tr -cd 'A-Za-z0-9._-'` at line 128. Manual malicious id created only `baseline-shown-....badtouchtmpownedstefanayala` inside cache.
+
+(d) Prune is scoped to cache dir and filename pattern: line 167.
+
+(e) Best-effort cache failure verified: cache-dir-is-file manual run returned `rc=0`, `stderr_bytes=0`, `baseline_count=1`.
+
+(f) Version bump grep verified all 7 sites: `package.json:3`, `plugin.json:3`, `marketplace.json:16`, `SDLC.md:1`, `SDLC.md:10`, `CLAUDE_CODE_SDLC_WIZARD.md:2979`, `CLAUDE_CODE_SDLC_WIZARD.md:4058`.
+
+(g) CI path is correct: [.github/workflows/ci.yml](/Users/stefanayala/sdlc-wizard/.github/workflows/ci.yml:218) runs `./tests/test-baseline-fires-once.sh`.
+
+(h) Tests run:
+`./tests/test-baseline-fires-once.sh`: 8 passed, 0 failed.
+`./tests/test-audit-session-load.sh`: 9 passed, 0 failed.
+`./tests/test-hooks.sh`: 154 passed, 0 failed.
+
+Score: **6/10**
+
+**NOT CERTIFIED**

--- a/.reviews/baseline-fires-once-001/round-2-review.md
+++ b/.reviews/baseline-fires-once-001/round-2-review.md
@@ -1,0 +1,16 @@
+No blocking findings.
+
+Finding 1: FIXED. The BASELINE claim is now atomic via noclobber at [hooks/sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:158), with the correct fallback tree: winner emits, existing sentinel suppresses, cache failure emits. The 50-parallel regression at [tests/test-baseline-fires-once.sh](/Users/stefanayala/sdlc-wizard/tests/test-baseline-fires-once.sh:190) passed and counted exactly one `SDLC BASELINE:`.
+
+Finding 2: FIXED. Stdin is read independently of `jq`, `session_id` is extracted with grep/sed at [hooks/sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:51), and `jq` is only used for prompt parsing. The no-`jq` regression at [tests/test-baseline-fires-once.sh](/Users/stefanayala/sdlc-wizard/tests/test-baseline-fires-once.sh:218) passed. I also manually checked an escaped `session_id` mention inside `prompt`; it used the real top-level session id and suppressed the second fire.
+
+Prior passes still hold: EFFORT and SETUP remain outside the BASELINE gate, setup-missing uses a sibling tmpdir, `tr -cd 'A-Za-z0-9._-'` sanitization remains in place, prune is scoped to `baseline-shown-*`, cache-file fallback returned `rc=0`, `baseline=1`, `stderr_bytes=0`, version bumps are consistent at `1.69.0`, and CI runs `./tests/test-baseline-fires-once.sh`.
+
+Verification run:
+`./tests/test-baseline-fires-once.sh`: 10 passed  
+`./tests/test-audit-session-load.sh`: 9 passed  
+`./tests/test-hooks.sh`: 154 passed
+
+Notes for next review: `.reviews/response.json` does not match this handoff; it references `roadmap-96-phase2-001` and a different F-01. I used the handoff’s `fixes_applied` plus the actual previous review findings for this recheck.
+
+Score: 9/10, CERTIFIED

--- a/.reviews/preflight-baseline-fires-once-001.md
+++ b/.reviews/preflight-baseline-fires-once-001.md
@@ -1,0 +1,53 @@
+# Preflight Self-Review: BASELINE block fires once per CC session
+
+## What changed
+
+`hooks/sdlc-prompt-check.sh`:
+- Extract `session_id` from stdin JSON alongside existing `prompt` extraction.
+- Gate the static SDLC BASELINE `cat << 'EOF'` block on a per-session sentinel `$SDLC_WIZARD_CACHE_DIR/baseline-shown-<safe_sid>`.
+- After first emit, `mkdir -p` cache dir + `touch` sentinel; prune sentinels older than 7d via `find -mtime +7 -delete`.
+- Sanitize session_id with `tr -cd 'A-Za-z0-9._-'` (defense-in-depth — CC session_ids are UUIDs, but never trust stdin).
+- Fallback when no session_id (legacy CC stdin or direct shell test): emit BASELINE every fire (current behavior).
+
+## What did NOT change
+
+- `_find-sdlc-root.sh` walk-up logic
+- Effort-bump signal detector + nudge (lines 38-99)
+- SETUP-NOT-COMPLETE warning (lines 103-112)
+- ROADMAP #224 SDLC_HOOK_FIRE_LOG instrumentation
+- Plugin-vs-project dedupe heuristic
+- Any other hook in `hooks/`
+
+## Self-review checklist
+
+- [x] `tests/test-baseline-fires-once.sh` — 8/8 PASS (8 cases: first-fire, suppression, different-session re-emit, no-session-id back-compat, SETUP persistence, EFFORT-bump persistence, cache-isolation, byte-shrink)
+- [x] `tests/test-hooks.sh` — 154/154 PASS (no regression in existing hook test suite)
+- [x] `tests/test-prompt-hook-fires-once.sh` — 6/6 PASS (ROADMAP #224 instrumentation regression, includes byte-identical assertion)
+- [x] `tests/test-audit-session-load.sh` — 9/9 PASS (`skills/update/SKILL.md` still under 5K-token threshold)
+- [x] `tests/test-cli.sh` — 78/78 PASS
+- [x] `tests/test-plugin.sh` — 25/25 PASS
+- [x] `tests/test-doc-consistency.sh` — 35/35 PASS
+- [x] Cache writes are best-effort: unwritable cache → falls back to current behavior (BASELINE keeps emitting), never errors to user
+- [x] session_id sanitized before use in filename
+- [x] Comment block on the gating logic explains the *why* (12K token saving, skill duplication once auto-invoked) and the constraints (SETUP/EFFORT-bump must keep firing)
+- [x] Version bumped 1.68.0 → 1.69.0 across 7 metadata sites
+- [x] `CHANGELOG.md` v1.69.0 entry written with behavior matrix
+- [x] `skills/update/SKILL.md` changelog list updated with 1.69.0 entry, older entries collapsed to keep under 5K threshold
+- [x] `.github/workflows/ci.yml` wires new test into validate job
+
+## Specific things to verify in review
+
+1. **Race conditions:** if CC parallelism could fire two `UserPromptSubmit` hooks concurrently for the same session_id, both could check `[ -f $sentinel ]` as false, both emit, both touch. Worst case is BASELINE emits twice on a single rare race. Acceptable, but flag if there's a cleaner pattern.
+
+2. **Stale-cache leakage across CC restarts:** sentinel persists on disk. If a user runs the same CC `session_id` again after a restart (does CC ever reuse session_ids? — CC sessions are UUIDs, almost certainly unique), they'd see no BASELINE on their first prompt. Mitigation: 7-day prune. Verify the worst case is acceptable.
+
+3. **Filename injection / path traversal:** session_id from stdin sanitized via `tr -cd 'A-Za-z0-9._-'`. Confirm this is sufficient. CC session_ids are UUIDs (lowercase hex + dashes), so the strip is purely defense-in-depth.
+
+4. **Byte-shrink test (test 8):** asserts second fire output is `<` (first / 5). Currently 823 → 0 chars. If anyone adds new conditional output that fires post-suppression, the test will catch it. Verify the assertion is the right shape.
+
+5. **Back-compat:** `tests/test-hooks.sh` Test 5 (line ~91 `test_sdlc_hook_size`) calls `"$HOOKS_DIR/sdlc-prompt-check.sh"` with NO stdin. The hook reaches `[ ! -t 0 ]` check, finds tty (when run from terminal/test), skips stdin parse, `SESSION_ID` stays empty, BASELINE emits every fire. Test still passes. Confirm I haven't created a hidden coupling.
+
+## Known limitations
+
+- Sentinel doesn't survive `rm -rf $SDLC_WIZARD_CACHE_DIR`. User who clears cache mid-session sees BASELINE re-emit on next prompt — acceptable.
+- 7-day prune is on-emit, not periodic. A long-idle session whose sentinel ages out then resumes would see one re-emit. Acceptable.

--- a/.reviews/response.json
+++ b/.reviews/response.json
@@ -1,14 +1,19 @@
 {
-  "review_id": "roadmap-96-phase2-001",
-  "round": 3,
-  "responding_to": ".reviews/latest-review.md",
+  "review_id": "baseline-fires-once-001",
+  "round": 2,
+  "responding_to": ".reviews/baseline-fires-once-001/round-1-review.md",
   "responses": [
     {
-      "finding": "F-01",
-      "severity": "P1",
+      "finding": "1",
       "action": "FIXED",
-      "summary": "Round 2 nit closed. Added test_strip_paths_gate_uses_candidate_strip_dir which runs shepherd with --compare-baseline AND --strip-paths, mocks ground-truth.sh to log argv, and asserts both paths are tmpdir-rooted: baseline matches `sdlc-baseline-strip.*tests/e2e/fixtures/test-repo$`, candidate matches `sdlc-candidate-strip.*tests/e2e/fixtures/test-repo$`. Without my fix, the candidate path would be cwd-relative `tests/e2e/fixtures/test-repo` — that mutation would fail this test.",
-      "files": ["tests/test-local-shepherd.sh:test_strip_paths_gate_uses_candidate_strip_dir"]
+      "summary": "Atomic claim via subshell `set -C` (noclobber) + `: > sentinel` redirect. Across N parallel fires with the same session_id, exactly one wins the claim and emits; the rest see file-exists and suppress. New regression test (test_concurrency_same_session_emits_once) fires 50 parallel invocations and asserts exactly 1 BASELINE in aggregated stdout.",
+      "evidence": "hooks/sdlc-prompt-check.sh:131 (claim block), tests/test-baseline-fires-once.sh:166-189 (50-parallel test)"
+    },
+    {
+      "finding": "2",
+      "action": "FIXED",
+      "summary": "Decoupled session_id extraction from jq. Stdin is now read whenever stdin is non-tty (regardless of jq); session_id extracted via grep/sed. Prompt extraction still requires jq (multi-line + arbitrary escape content). New regression test (test_session_id_works_without_jq) builds a restricted PATH excluding jq, fires hook twice with valid session_id JSON stdin, asserts first emits / second suppresses.",
+      "evidence": "hooks/sdlc-prompt-check.sh:46-66 (decoupled extraction), tests/test-baseline-fires-once.sh:191-228 (no-jq regression test using type -P for binary-only resolution)"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.69.0] - 2026-05-04
+
+### Token-bloat fix: BASELINE block fires once per CC session
+
+Cuts ~12K tokens/session of duplicate context for users with >3 prompts. The `SDLC BASELINE` block in `hooks/sdlc-prompt-check.sh` (~250 tokens) was firing on every `UserPromptSubmit` — once Claude has the SDLC skill auto-invoked (covers TodoWrite/confidence/workflow phases), every subsequent re-emission is pure duplication. Now gated by a per-`session_id` sentinel under `$SDLC_WIZARD_CACHE_DIR/baseline-shown-<id>`, pruned at 7d.
+
+### Behavior
+
+- **First prompt of a CC session** → BASELINE emits as before (cold-start nudge survives).
+- **Subsequent prompts (same session_id)** → BASELINE suppressed.
+- **New CC session (different session_id)** → BASELINE re-emits.
+- **No session_id in stdin** (legacy CC, direct shell tests) → BASELINE emits every fire (back-compat preserved).
+- `SETUP NOT COMPLETE` warning + `EFFORT BUMP REQUIRED` nudge **continue to fire every prompt** — they're dynamic state warnings, not static reminders.
+
+### Files
+
+- `hooks/sdlc-prompt-check.sh` — extracts `session_id` from stdin JSON; gates the static BASELINE block via per-session sentinel; prunes >7d sentinels on emit.
+- `tests/test-baseline-fires-once.sh` (new — 8 cases covering first-fire, suppression, different-session re-emit, no-session-id back-compat, SETUP-warning persistence, EFFORT-bump persistence, cross-cache-dir isolation, byte-shrink verification).
+- `.github/workflows/ci.yml` — wires new test into `validate` job.
+- `CHANGELOG.md`, `SDLC.md`, `skills/update/SKILL.md`, `package.json`, `.claude-plugin/plugin.json` + `marketplace.json`, `CLAUDE_CODE_SDLC_WIZARD.md` (1.68.0 → 1.69.0).
+
+### Notes
+
+Discovered during ROADMAP #236 functional-bloat audit. Identified `sdlc-prompt-check.sh` as the #1 amplifier (every-prompt × 22 lines × N prompts). Audit method: measure cost × frequency, judge value — not blind delete-and-see. Per-prompt BASELINE failed cost/value once skill is loaded; conditional warnings + effort-bump detector earned their keep and stayed untouched. Other hooks (`model-effort-check`, `precompact-seam-check`, `token-spike-check`) are silent at healthy state — not bloat.
+
 ## [1.68.0] - 2026-05-04
 
 ### Closed (paperwork-stale roadmap rows)

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2976,7 +2976,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.68.0 -->
+<!-- SDLC Wizard Version: 1.69.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4055,7 +4055,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.68.0 -->
+<!-- SDLC Wizard Version: 1.69.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-local-shepherd.sh && \
    ./tests/test-repo-complexity.sh && \
    ./tests/test-prompt-hook-fires-once.sh && \
+   ./tests/test-baseline-fires-once.sh && \
    ./tests/test-community-scanner.sh && \
    ./tests/test-community-fetch.sh && \
    ./tests/test-ground-truth.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.68.0 -->
+<!-- SDLC Wizard Version: 1.69.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.68.0 |
+| Wizard Version | 1.69.0 |
 | Last Updated | 2026-05-04 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/hooks/sdlc-prompt-check.sh
+++ b/hooks/sdlc-prompt-check.sh
@@ -43,10 +43,25 @@ fi
 EFFORT_CACHE_DIR="${SDLC_WIZARD_CACHE_DIR:-$HOME/.cache/sdlc-wizard}"
 EFFORT_SIGNALS="$EFFORT_CACHE_DIR/effort-signals.log"
 PROMPT_TEXT=""
-if [ ! -t 0 ] && command -v jq > /dev/null 2>&1; then
+SESSION_ID=""
+# Read stdin once regardless of jq availability — session_id extraction
+# is jq-independent (Codex round 1 P1: BASELINE gate failed when jq was
+# missing or broken). Prompt extraction still needs jq because prompt
+# content can contain arbitrary multi-line text + escapes.
+if [ ! -t 0 ]; then
     STDIN_JSON=$(cat)
     if [ -n "$STDIN_JSON" ]; then
-        PROMPT_TEXT=$(printf '%s' "$STDIN_JSON" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT_TEXT=""
+        # session_id is a UUID-shaped string with no escapable content
+        # in CC's stdin contract — regex extraction is sufficient.
+        # `tr -cd` later strips anything filename-unsafe, so a malformed
+        # input cannot escape the cache dir.
+        SESSION_ID=$(printf '%s' "$STDIN_JSON" \
+            | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -1 \
+            | sed 's/.*"\([^"]*\)"$/\1/')
+        if command -v jq > /dev/null 2>&1; then
+            PROMPT_TEXT=$(printf '%s' "$STDIN_JSON" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT_TEXT=""
+        fi
     fi
 fi
 if [ -n "$PROMPT_TEXT" ]; then
@@ -109,7 +124,49 @@ SETUP
     exit 0
 fi
 
-cat << 'EOF'
+# Token-bloat fix: BASELINE block fires once per CC session (~250 tok × 50
+# prompts = ~12K wasted tokens before this gate). Once Claude has the SDLC
+# skill auto-invoked (covers TodoWrite/confidence/workflow), this static
+# block is duplicate context. Sentinel is per-session_id so a fresh CC
+# session re-emits the cold-start nudge. Without session_id (legacy CC, or
+# direct shell tests with no JSON stdin), behavior is unchanged — emits
+# every fire. SETUP-not-complete + EFFORT-bump branches above are NOT
+# gated; they're dynamic state warnings that must fire every prompt.
+#
+# Concurrency: claim is atomic via `set -C` (noclobber) — the redirect
+# `: > "$path"` create-or-fails. Across N parallel fires with the same
+# session_id, exactly one wins the claim and emits BASELINE; the rest
+# see file-exists and suppress. (Codex round 1 P1: previous "check then
+# write after emit" pattern allowed N parallel fires to all emit.)
+SHOULD_EMIT_BASELINE=1
+BASELINE_SENTINEL=""
+if [ -n "$SESSION_ID" ]; then
+    BASELINE_CACHE_DIR="${SDLC_WIZARD_CACHE_DIR:-$HOME/.cache/sdlc-wizard}"
+    # Strip path-traversal chars from session_id before using in filename
+    # (defense-in-depth — CC session_ids are UUIDs, but never trust stdin).
+    SAFE_SID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9._-')
+    if [ -n "$SAFE_SID" ]; then
+        BASELINE_SENTINEL="$BASELINE_CACHE_DIR/baseline-shown-${SAFE_SID}"
+        mkdir -p "$BASELINE_CACHE_DIR" 2>/dev/null || true
+        # Atomic create-or-fail: subshell sets noclobber so `: > "$path"`
+        # fails (rc≠0) if the file already exists. The full conditional
+        # tree:
+        #   - claim succeeds → emit (we won the race)
+        #   - claim fails AND file exists → suppress (someone else won)
+        #   - claim fails AND file doesn't exist → cache unwritable;
+        #     fall back to emit so user never loses cold-start nudge.
+        if (set -C; : > "$BASELINE_SENTINEL") 2>/dev/null; then
+            SHOULD_EMIT_BASELINE=1
+        elif [ -f "$BASELINE_SENTINEL" ]; then
+            SHOULD_EMIT_BASELINE=0
+        else
+            SHOULD_EMIT_BASELINE=1
+        fi
+    fi
+fi
+
+if [ "$SHOULD_EMIT_BASELINE" -eq 1 ]; then
+    cat << 'EOF'
 SDLC BASELINE:
 1. TodoWrite FIRST (plan tasks before coding)
 2. STATE CONFIDENCE: HIGH/MEDIUM/LOW
@@ -130,3 +187,9 @@ Workflow phases:
 
 Quick refs: SDLC.md | TESTING.md | *_PLAN.md for feature
 EOF
+    # Prune sentinels older than 7d so cache doesn't grow forever.
+    # Best-effort: errors silently swallowed.
+    if [ -n "$BASELINE_SENTINEL" ]; then
+        find "$BASELINE_CACHE_DIR" -name 'baseline-shown-*' -type f -mtime +7 -delete 2>/dev/null || true
+    fi
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,13 +93,11 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.68.0
+Latest:    1.69.0
 
 What changed:
-- [1.68.0] roadmap hygiene — closed #97 (Anthropic Policy & Research alignment audit — NO-GO with one validating parallel: April 2026 "Automated Alignment Researchers" paper conceptually parallel to our cross-model review, our implementation predates it and mitigates noted weaknesses). Research write-up at `.reviews/research-97-anthropic-policy.md`. Also closes #243 follow-up — `.metrics/token-history.jsonl` accumulating (8 rows on maintainer machine, well over 5-record threshold). 6/6 external audits NO-GO.
-- [1.67.0] roadmap hygiene — closed #99 (AutoGPT integration audit — NO-GO; AutoGPT is an agent host like Claude Code / Codex / OpenCode, no hook primitive maps, audience is agent-builders not SWE workflow). Research write-up at `.reviews/research-99-autogpt.md`. 5/5 external-product audits NO-GO (continues #76 + #77 + #235 + #95).
-- [1.66.0] roadmap hygiene — closed #95 (Nous Research NO-GO — different layer; Nous builds models + agent frameworks, we enforce SDLC process). Rolls in PR #309 codex callout near top + issue #308 close (4/4 API entries audited).
-- [1.65.0] roadmap hygiene — closed #210 (Node 24 false-green, already shipped PR #217) + #235 (Thoughtworks AI Evals NO-GO).
+- [1.69.0] token-bloat fix — `hooks/sdlc-prompt-check.sh` BASELINE block (the ~250-token "TodoWrite FIRST / STATE CONFIDENCE / AUTO-INVOKE" reminder) now fires once per CC `session_id` instead of every prompt. Saves ~12K tokens/session for any user with >3 prompts. SETUP-not-complete + EFFORT-bump warnings still fire every prompt (dynamic state). Sentinel pruned at 7d. No-session-id stdin keeps current behavior (legacy CC + tests).
+- [1.68.0–1.65.0] roadmap hygiene — five paperwork closes: #97 Anthropic Policy NO-GO + AAR-paper validating parallel; #99 AutoGPT NO-GO; #95 Nous NO-GO; #243 token-history liveness verified; #210 Node-24 false-green; #235 Thoughtworks AI Evals NO-GO. **6/6 external-product audits NO-GO** (continues #76, #77). Research write-ups in `.reviews/research-*.md`.
 - [1.64.0] XDLC ecosystem cross-references — README, wizard doc, and ROADMAP now cross-reference all three sibling packages (`agentic-sdlc-wizard`, `codex-sdlc-wizard`, `claude-gdlc-wizard`). New "Ecosystem (Sibling Projects)" section in README. 3 new doc-consistency tests prevent drift.
 - [1.63.0] cache-cost observability closeout (#204 absorbed by #220) — `tests/test-token-spike.sh` gains explicit cache-miss regression test + negative-control test. SDLC skill + wizard doc gain "Cache-Cost Surprises" sections covering 10-20× silent cost blowups (mid-session CLAUDE.md edits, idle pruning, upstream cache bugs) and detection via `hooks/token-spike-check.sh`'s `costly_tokens` metric.
 - [1.62.0] roadmap hygiene + #211 backfill — closes paperwork-stale rows (#207, #211 historical, #215, #217, #78, #79, #80, #219). Backfilled 5 corrupted `score-history.jsonl` rows from `max_score:10` → `max_score:11` (UI scenarios with design_system criterion). Codex strategic review confirmed scope.

--- a/tests/test-baseline-fires-once.sh
+++ b/tests/test-baseline-fires-once.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Roadmap (TBD): regression test for sdlc-prompt-check.sh "BASELINE block
+# emits once per session" optimization. The static SDLC BASELINE block
+# (~250 tokens) was firing on every UserPromptSubmit, duplicating itself
+# in context after Claude already had the SDLC skill loaded — an estimated
+# ~12K wasted tokens per 50-prompt session.
+#
+# Fix: when stdin JSON includes a session_id, write a sentinel to
+# $SDLC_WIZARD_CACHE_DIR/baseline-shown-<session_id> after first emit, and
+# skip the BASELINE block on subsequent fires within the same session.
+#
+# Compatibility: when stdin has no session_id (e.g. legacy CC versions,
+# direct shell tests), behavior is unchanged — BASELINE emits every fire.
+#
+# Things that MUST keep firing every prompt regardless of sentinel:
+#   - SETUP NOT COMPLETE warning (when SDLC.md / TESTING.md missing)
+#   - EFFORT BUMP REQUIRED nudge (when ≥2 LOW signals in 30 min)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/sdlc-prompt-check.sh"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== sdlc-prompt-check.sh BASELINE-fires-once-per-session Tests ==="
+echo ""
+
+WORKSPACE="${TMPDIR:-/tmp}/sdlc-baseline-once-$$"
+mkdir -p "$WORKSPACE"
+trap 'rm -rf "$WORKSPACE"' EXIT
+echo "<!-- SDLC Wizard Version: 1.69.0 -->" > "$WORKSPACE/SDLC.md"
+echo "# Testing" > "$WORKSPACE/TESTING.md"
+
+# Each test gets a fresh cache dir so sentinels from one test don't leak
+# into another. Tests that need persistence across hook fires share a cache.
+
+invoke() {
+    local cache="$1"
+    local payload="$2"
+    (cd "$WORKSPACE" && CLAUDE_PROJECT_DIR="$WORKSPACE" \
+        SDLC_WIZARD_CACHE_DIR="$cache" \
+        bash "$HOOK" <<<"$payload" 2>/dev/null)
+}
+
+# ---- Test 1: First fire with session_id emits BASELINE ----
+test_first_fire_emits_baseline() {
+    local cache="$WORKSPACE/cache-1"
+    rm -rf "$cache"
+    local out
+    out=$(invoke "$cache" '{"prompt":"hello","session_id":"sess-A"}')
+    if echo "$out" | grep -q "SDLC BASELINE:"; then
+        pass "first fire (session=A) emits SDLC BASELINE"
+    else
+        fail "first fire should emit BASELINE. Output: $out"
+    fi
+}
+
+# ---- Test 2: Second fire same session_id suppresses BASELINE ----
+test_second_fire_suppresses_baseline() {
+    local cache="$WORKSPACE/cache-2"
+    rm -rf "$cache"
+    invoke "$cache" '{"prompt":"first","session_id":"sess-B"}' > /dev/null
+    local out
+    out=$(invoke "$cache" '{"prompt":"second","session_id":"sess-B"}')
+    if echo "$out" | grep -q "SDLC BASELINE:"; then
+        fail "second fire (same session) should NOT emit BASELINE. Output: $out"
+    else
+        pass "second fire (session=B, same sentinel) suppresses BASELINE"
+    fi
+}
+
+# ---- Test 3: Different session_id re-emits BASELINE ----
+test_different_session_re_emits() {
+    local cache="$WORKSPACE/cache-3"
+    rm -rf "$cache"
+    invoke "$cache" '{"prompt":"first","session_id":"sess-C"}' > /dev/null
+    local out
+    out=$(invoke "$cache" '{"prompt":"hello","session_id":"sess-D"}')
+    if echo "$out" | grep -q "SDLC BASELINE:"; then
+        pass "different session_id (C → D, same cache) re-emits BASELINE"
+    else
+        fail "different session_id should emit BASELINE. Output: $out"
+    fi
+}
+
+# ---- Test 4: No session_id → BASELINE every fire (back-compat) ----
+test_no_session_id_back_compat() {
+    local cache="$WORKSPACE/cache-4"
+    rm -rf "$cache"
+    local out1 out2
+    out1=$(invoke "$cache" '{"prompt":"first"}')
+    out2=$(invoke "$cache" '{"prompt":"second"}')
+    if echo "$out1" | grep -q "SDLC BASELINE:" && echo "$out2" | grep -q "SDLC BASELINE:"; then
+        pass "no session_id → BASELINE emits every fire (legacy/test compat preserved)"
+    else
+        fail "without session_id, BASELINE must emit every fire. Out1=$out1 / Out2=$out2"
+    fi
+}
+
+# ---- Test 5: Setup-missing warning fires every time, ignores sentinel ----
+test_setup_missing_always_fires() {
+    # Use a sibling tmpdir (NOT a child of $WORKSPACE) — _find-sdlc-root.sh
+    # walks up from CWD to find SDLC.md, so a child dir would inherit the
+    # parent's full SDLC fixture and skip the SETUP-NOT-COMPLETE branch.
+    local broken_workspace
+    broken_workspace=$(mktemp -d "${TMPDIR:-/tmp}/sdlc-broken-XXXXXX")
+    # Empty SDLC.md (zero bytes) triggers `[ ! -s "$PROJECT_DIR/SDLC.md" ]`
+    # → SETUP NOT COMPLETE fires. find_partial_sdlc_root sees the file and
+    # sets PROJECT_DIR; the empty-file check then fires the warning.
+    : > "$broken_workspace/SDLC.md"
+    local cache="$WORKSPACE/cache-5"
+    rm -rf "$cache"
+    local out1 out2
+    out1=$( (cd "$broken_workspace" && CLAUDE_PROJECT_DIR="$broken_workspace" \
+        SDLC_WIZARD_CACHE_DIR="$cache" bash "$HOOK" <<<'{"prompt":"x","session_id":"sess-E"}' 2>/dev/null) )
+    out2=$( (cd "$broken_workspace" && CLAUDE_PROJECT_DIR="$broken_workspace" \
+        SDLC_WIZARD_CACHE_DIR="$cache" bash "$HOOK" <<<'{"prompt":"y","session_id":"sess-E"}' 2>/dev/null) )
+    rm -rf "$broken_workspace"
+    if echo "$out1" | grep -q "SETUP NOT COMPLETE" && echo "$out2" | grep -q "SETUP NOT COMPLETE"; then
+        pass "SETUP NOT COMPLETE warning fires every prompt regardless of sentinel"
+    else
+        fail "SETUP NOT COMPLETE must always fire. Out1=$out1 / Out2=$out2"
+    fi
+}
+
+# ---- Test 6: Effort-bump nudge fires every time, ignores sentinel ----
+test_effort_bump_always_fires() {
+    local cache="$WORKSPACE/cache-6"
+    rm -rf "$cache"
+    mkdir -p "$cache"
+    # Seed 2 LOW signals in last 30min so bump fires on every invocation
+    local now
+    now=$(date +%s)
+    printf '%s\tlow\n%s\tlow\n' "$((now - 60))" "$((now - 30))" > "$cache/effort-signals.log"
+
+    invoke "$cache" '{"prompt":"first","session_id":"sess-F"}' > /dev/null
+    # On second fire, BASELINE should be suppressed but EFFORT BUMP should still emit
+    local out
+    out=$(invoke "$cache" '{"prompt":"second","session_id":"sess-F"}')
+    if echo "$out" | grep -q "EFFORT BUMP REQUIRED"; then
+        pass "EFFORT BUMP REQUIRED nudge fires regardless of BASELINE sentinel"
+    else
+        fail "EFFORT BUMP must fire when signals trigger it. Output: $out"
+    fi
+}
+
+# ---- Test 7: Sentinel does not leak across cache dirs ----
+test_sentinel_isolated_per_cache() {
+    local cache_a="$WORKSPACE/cache-7a"
+    local cache_b="$WORKSPACE/cache-7b"
+    rm -rf "$cache_a" "$cache_b"
+    invoke "$cache_a" '{"prompt":"x","session_id":"shared"}' > /dev/null
+    local out
+    out=$(invoke "$cache_b" '{"prompt":"y","session_id":"shared"}')
+    if echo "$out" | grep -q "SDLC BASELINE:"; then
+        pass "sentinel isolated per SDLC_WIZARD_CACHE_DIR (no global state)"
+    else
+        fail "different cache dir must re-emit BASELINE. Output: $out"
+    fi
+}
+
+# ---- Test 8: Suppressed-fire output is markedly smaller ----
+test_suppressed_fire_is_smaller() {
+    local cache="$WORKSPACE/cache-8"
+    rm -rf "$cache"
+    local first_size second_size
+    first_size=$(invoke "$cache" '{"prompt":"first","session_id":"sess-G"}' | wc -c | tr -d ' ')
+    second_size=$(invoke "$cache" '{"prompt":"second","session_id":"sess-G"}' | wc -c | tr -d ' ')
+    # First fire emits BASELINE (~600 chars including the cat block).
+    # Second fire emits at most a trailing newline (or empty). Demand 5x reduction
+    # to confirm the bulk of the BASELINE block is actually gone, not just trimmed.
+    if [ "$first_size" -gt 400 ] && [ "$second_size" -lt $((first_size / 5)) ]; then
+        pass "suppressed fire is >5x smaller (${first_size} → ${second_size} chars)"
+    else
+        fail "suppression didn't shrink output enough. first=${first_size} second=${second_size}"
+    fi
+}
+
+# ---- Test 9: Concurrency race — 50 parallel same-session fires emit BASELINE
+#       exactly once. Codex round 1 P1: prior "check then write-after-emit"
+#       allowed N parallel fires to all emit; atomic noclobber claim fixes it.
+test_concurrency_same_session_emits_once() {
+    local cache="$WORKSPACE/cache-9"
+    rm -rf "$cache"
+    local agg="$WORKSPACE/cache-9-outputs"
+    rm -f "$agg"
+    local i pids=()
+    # Fire 50 invocations concurrently with the same session_id. Each
+    # invocation appends its stdout to the aggregate file; greping for
+    # "SDLC BASELINE:" counts how many actually emitted.
+    for i in $(seq 1 50); do
+        ( invoke "$cache" '{"prompt":"p","session_id":"sess-CONCURRENT"}' >> "$agg" ) &
+        pids+=($!)
+    done
+    for p in "${pids[@]}"; do
+        wait "$p" || true
+    done
+    local count
+    count=$(grep -c "^SDLC BASELINE:" "$agg" 2>/dev/null || echo 0)
+    if [ "$count" = "1" ]; then
+        pass "50 parallel same-session fires emit BASELINE exactly once (atomic claim)"
+    else
+        fail "concurrency race: ${count} BASELINE outputs across 50 fires (expected 1)"
+    fi
+}
+
+# ---- Test 10: jq missing — session_id extraction must not depend on jq.
+#        Codex round 1 P1: jq-coupled extraction silently dropped the gate
+#        when jq was unavailable. Now grep+sed extracts session_id directly.
+test_session_id_works_without_jq() {
+    # Build a PATH with no jq for this test only. Keep coreutils +
+    # bash/grep/sed/find available via a temp dir of symlinks.
+    local nojq_path="$WORKSPACE/path-no-jq"
+    rm -rf "$nojq_path"
+    mkdir -p "$nojq_path"
+    # Use `type -P` (executable path only) — `command -v` returns function
+    # names when the user's shell wraps tools (e.g. CC's grep wrapper) and
+    # ln -sf <funcname> creates a dangling self-referencing symlink.
+    for tool in bash sh cat printf sed grep head awk find mkdir touch chmod tr date wc stat ln rm ls mv cp tee dirname pwd; do
+        local src
+        src=$(type -P "$tool" 2>/dev/null)
+        [ -n "$src" ] && [ -x "$src" ] && ln -sf "$src" "$nojq_path/$tool"
+    done
+    # Confirm jq is NOT in the restricted PATH
+    if PATH="$nojq_path" command -v jq > /dev/null 2>&1; then
+        fail "test setup error: jq leaked into restricted PATH"
+        rm -rf "$nojq_path"
+        return
+    fi
+
+    local cache="$WORKSPACE/cache-10"
+    rm -rf "$cache"
+    local out1 out2
+    out1=$( PATH="$nojq_path" \
+        bash -c "cd '$WORKSPACE' && CLAUDE_PROJECT_DIR='$WORKSPACE' SDLC_WIZARD_CACHE_DIR='$cache' bash '$HOOK' <<<'{\"prompt\":\"x\",\"session_id\":\"sess-NOJQ\"}'" 2>/dev/null )
+    out2=$( PATH="$nojq_path" \
+        bash -c "cd '$WORKSPACE' && CLAUDE_PROJECT_DIR='$WORKSPACE' SDLC_WIZARD_CACHE_DIR='$cache' bash '$HOOK' <<<'{\"prompt\":\"y\",\"session_id\":\"sess-NOJQ\"}'" 2>/dev/null )
+    rm -rf "$nojq_path"
+
+    if echo "$out1" | grep -q "SDLC BASELINE:" && ! echo "$out2" | grep -q "SDLC BASELINE:"; then
+        pass "session_id gate works without jq (first emits, second suppresses)"
+    else
+        fail "no-jq path broke gate. Out1 has BASELINE: $(echo "$out1" | grep -q 'SDLC BASELINE:' && echo yes || echo no). Out2 has BASELINE: $(echo "$out2" | grep -q 'SDLC BASELINE:' && echo yes || echo no)"
+    fi
+}
+
+test_first_fire_emits_baseline
+test_second_fire_suppresses_baseline
+test_different_session_re_emits
+test_no_session_id_back_compat
+test_setup_missing_always_fires
+test_effort_bump_always_fires
+test_sentinel_isolated_per_cache
+test_suppressed_fire_is_smaller
+test_concurrency_same_session_emits_once
+test_session_id_works_without_jq
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All BASELINE-fires-once tests passed."


### PR DESCRIPTION
## Summary

- `hooks/sdlc-prompt-check.sh` BASELINE block (~250 tokens) was firing on every `UserPromptSubmit` — pure duplication after the SDLC skill auto-invokes. ~12K tokens/session wasted for users with >3 prompts.
- Now gated on a per-`session_id` sentinel under `$SDLC_WIZARD_CACHE_DIR/baseline-shown-<id>`, atomic-claimed via subshell `set -C` (noclobber). N parallel fires emit exactly once. SETUP-not-complete + EFFORT-bump warnings still fire every prompt (dynamic state).
- Discovered during ROADMAP #236 functional-bloat audit. Other hooks (`model-effort-check`, `precompact-seam-check`, `token-spike-check`) audited and earned their keep — silent at healthy state.

## Behavior matrix

| Scenario | BASELINE emits? |
|---|---|
| First prompt of CC session | ✅ |
| Subsequent prompt, same session_id | ❌ (suppressed) |
| New CC session, different session_id | ✅ (re-emits) |
| No session_id in stdin (legacy/test) | ✅ every fire (back-compat) |
| Cache dir unwritable | ✅ every fire (best-effort fallback) |
| `SETUP NOT COMPLETE` warning | ✅ every fire (dynamic state) |
| `EFFORT BUMP REQUIRED` nudge | ✅ every fire (dynamic state) |

## Cross-model review

Codex round 1 (gpt-5.5 xhigh) caught 2 P1s:
1. **Concurrency race** — 50 parallel same-session fires emitted BASELINE 13× because sentinel was written *after* the cat block. Fixed with atomic `(set -C; : > sentinel)` claim.
2. **session_id ignored when jq missing** — extraction was jq-coupled. Decoupled to `grep | head | sed` so the gate works without jq. Prompt parsing still uses jq (multi-line content).

Round 2: **CERTIFIED 9/10**, no blocking findings. Round-1/round-2 reviews archived under `.reviews/baseline-fires-once-001/`.

## Test plan

- [x] `tests/test-baseline-fires-once.sh` (new) — 10 cases, 8/8 baseline + 2 P1 regressions: 50-parallel concurrency + restricted-PATH-no-jq
- [x] `tests/test-hooks.sh` — 154/154 pass (no regression)
- [x] `tests/test-prompt-hook-fires-once.sh` — 6/6 pass (ROADMAP #224 instrumentation regression including byte-identical assertion)
- [x] `tests/test-audit-session-load.sh` — 9/9 pass (`skills/update/SKILL.md` still under 5K-token threshold after changelog entry)
- [x] `tests/test-cli.sh` — 78/78 pass
- [x] `tests/test-plugin.sh` — 25/25 pass
- [x] `tests/test-doc-consistency.sh` — 35/35 pass

## Files

- `hooks/sdlc-prompt-check.sh` — atomic-claim sentinel + jq-decoupled session_id extraction
- `tests/test-baseline-fires-once.sh` (new — 10 cases)
- `.github/workflows/ci.yml` — wires new test into validate job
- `CHANGELOG.md`, `SDLC.md`, `skills/update/SKILL.md`, `package.json`, `.claude-plugin/plugin.json` + `marketplace.json`, `CLAUDE_CODE_SDLC_WIZARD.md` (1.68.0 → 1.69.0)
- `.reviews/preflight-baseline-fires-once-001.md`, `.reviews/baseline-fires-once-001/round-{1,2}-review.md` (force-added past `.reviews/` gitignore for repo history)