### PR TITLE
bloat: TDD CHECK nudge fires once per CC session (v1.70.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.69.0",
+      "version": "1.70.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,9 @@ jobs:
       - name: Run baseline-fires-once-per-session tests (token bloat audit)
         run: ./tests/test-baseline-fires-once.sh
 
+      - name: Run tdd-pretool-fires-once tests (token bloat audit)
+        run: ./tests/test-tdd-pretool-fires-once.sh
+
       - name: Run community scanner tests (#207)
         run: ./tests/test-community-scanner.sh
 

--- a/.reviews/preflight-tdd-pretool-fires-once-001.md
+++ b/.reviews/preflight-tdd-pretool-fires-once-001.md
@@ -1,0 +1,47 @@
+# Preflight Self-Review: tdd-pretool-check.sh fires once per CC session
+
+## What changed
+
+`hooks/tdd-pretool-check.sh`:
+- Extract `session_id` from stdin JSON via `grep -o | head -1 | sed` (jq-independent, same pattern as v1.69.0 sdlc-prompt-check.sh).
+- Gate the TDD CHECK JSON output on a per-session sentinel `$SDLC_WIZARD_CACHE_DIR/tdd-shown-<safe_sid>`.
+- Atomic claim via subshell `set -C` (noclobber) `: > sentinel` — same proven pattern from v1.69.0.
+- Fallback when claim fails AND file missing (cache unwritable) → emit (best-effort, never lose nudge).
+- Prune sentinels older than 7d on emit.
+- Sanitize session_id with `tr -cd 'A-Za-z0-9._-'` before filename use.
+
+## What did NOT change
+
+- File-path matching (`*"/src/"*`) — non-src files still produce zero output.
+- The TDD CHECK message text (still emits same JSON when fired).
+- jq dependency for file_path extraction (file paths can have escapes; UUIDs cannot).
+
+## Self-review checklist
+
+- [x] `tests/test-tdd-pretool-fires-once.sh` — 9/9 PASS (first-fire, suppression, different-session, no-session_id back-compat, non-src/ no-emit, non-src/-doesn't-consume-sentinel, cache-isolation, 50-parallel concurrency, suppressed-fire-empty)
+- [x] `tests/test-hooks.sh` — 154/154 PASS (no regression in existing hook tests; old tests don't pass session_id, so back-compat path keeps them green)
+- [x] `tests/test-baseline-fires-once.sh` — 10/10 PASS (v1.69.0 sibling)
+- [x] `tests/test-audit-session-load.sh` — 9/9 PASS (SKILL.md still under 5K threshold)
+- [x] `tests/test-cli.sh`, `test-plugin.sh`, `test-doc-consistency.sh` — all green
+- [x] `tests/test-workflow-triggers.sh` — green after wiring new test into ci.yml + CONTRIBUTING.md
+- [x] Version bumped 1.69.0 → 1.70.0 across 7 metadata sites
+- [x] CHANGELOG.md v1.70.0 entry written
+- [x] CI wiring: `.github/workflows/ci.yml` runs new test
+- [x] CONTRIBUTING.md lists new test in dev-loop checklist
+
+## Specific things to verify in review
+
+1. **Non-src/ edit doesn't consume sentinel** — Test 6 covers this. The sentinel write only happens INSIDE the `*"/src/"*` branch. Confirm no path where non-src/ edit could pre-claim the sentinel.
+
+2. **Concurrency same as v1.69.0** — atomic noclobber claim at the top of the src/ branch. Verify the conditional tree (claim succeeds → emit / claim fails AND file exists → suppress / claim fails AND file missing → emit fallback) is identical in semantics to the v1.69.0 BASELINE gate.
+
+3. **session_id grep extraction** — same regex as v1.69.0. Verify it doesn't false-match an escaped `"session_id"` inside `tool_input.content` (which CC sends as part of Write tool calls).
+
+4. **Suppressed fire is empty stdout** — Test 9 asserts. CC's PreToolUse contract treats empty stdout as "allow tool to proceed unmodified". Suppression must NOT emit `{}` or empty JSON wrapper.
+
+5. **Hook still requires jq for file_path** — non-jq users would see no output for any edit, which is the existing behavior. Acceptable.
+
+## Known limitations
+
+- TDD nudge fires once per session, even if the user does 30 unrelated src/ edits over 2 hours. Acceptable trade-off — once Claude has the SDLC skill loaded, the nudge is duplicate.
+- Sentinel survives CC restarts (7d prune). User who somehow reuses a session_id post-restart sees no nudge first prompt. CC session_ids are UUIDs — collision is implausible.

--- a/.reviews/response.json
+++ b/.reviews/response.json
@@ -1,19 +1,13 @@
 {
-  "review_id": "baseline-fires-once-001",
+  "review_id": "tdd-pretool-fires-once-001",
   "round": 2,
-  "responding_to": ".reviews/baseline-fires-once-001/round-1-review.md",
+  "responding_to": ".reviews/tdd-pretool-fires-once-001/round-1-review.md",
   "responses": [
     {
       "finding": "1",
       "action": "FIXED",
-      "summary": "Atomic claim via subshell `set -C` (noclobber) + `: > sentinel` redirect. Across N parallel fires with the same session_id, exactly one wins the claim and emits; the rest see file-exists and suppress. New regression test (test_concurrency_same_session_emits_once) fires 50 parallel invocations and asserts exactly 1 BASELINE in aggregated stdout.",
-      "evidence": "hooks/sdlc-prompt-check.sh:131 (claim block), tests/test-baseline-fires-once.sh:166-189 (50-parallel test)"
-    },
-    {
-      "finding": "2",
-      "action": "FIXED",
-      "summary": "Decoupled session_id extraction from jq. Stdin is now read whenever stdin is non-tty (regardless of jq); session_id extracted via grep/sed. Prompt extraction still requires jq (multi-line + arbitrary escape content). New regression test (test_session_id_works_without_jq) builds a restricted PATH excluding jq, fires hook twice with valid session_id JSON stdin, asserts first emits / second suppresses.",
-      "evidence": "hooks/sdlc-prompt-check.sh:46-66 (decoupled extraction), tests/test-baseline-fires-once.sh:191-228 (no-jq regression test using type -P for binary-only resolution)"
+      "summary": "Staged the new test file. `git status --short tests/test-tdd-pretool-fires-once.sh` now shows `A  tests/test-tdd-pretool-fires-once.sh`. The file will land on origin in the same commit as the rest of the change.",
+      "evidence": "tests/test-tdd-pretool-fires-once.sh (now staged in git index)"
     }
   ]
 }

--- a/.reviews/tdd-pretool-fires-once-001/round-1-review.md
+++ b/.reviews/tdd-pretool-fires-once-001/round-1-review.md
@@ -1,0 +1,18 @@
+**Findings**
+1. **P1 - New CI-referenced test is untracked**
+Evidence: `git status --short tests/test-tdd-pretool-fires-once.sh .github/workflows/ci.yml CONTRIBUTING.md` shows `?? tests/test-tdd-pretool-fires-once.sh`; `git ls-files --error-unmatch tests/test-tdd-pretool-fires-once.sh` returns `pathspec ... did not match any file(s) known to git`. CI references it at [.github/workflows/ci.yml](/Users/stefanayala/sdlc-wizard/.github/workflows/ci.yml:220).
+Certify condition: add `tests/test-tdd-pretool-fires-once.sh` to git before certification/commit.
+
+**Checklist Evidence**
+- (a) Sentinel logic is inside the `src/` branch: [hooks/tdd-pretool-check.sh](/Users/stefanayala/sdlc-wizard/hooks/tdd-pretool-check.sh:30), sentinel starts at line 40, emit block at line 63. Manual probe: `non_src_stdout_bytes=0`, `after_non_src_sentinels=0`, then first src edit `src_tdd_count=1`.
+- (b) `session_id` extraction uses `grep | head | sed`, no jq: [hooks/tdd-pretool-check.sh](/Users/stefanayala/sdlc-wizard/hooks/tdd-pretool-check.sh:23). Matches prior pattern in [hooks/sdlc-prompt-check.sh](/Users/stefanayala/sdlc-wizard/hooks/sdlc-prompt-check.sh:58).
+- (c) Atomic noclobber claim present: [hooks/tdd-pretool-check.sh](/Users/stefanayala/sdlc-wizard/hooks/tdd-pretool-check.sh:53). Fallback tree lines 53-59. Manual unwritable-cache probe: `rc=0`, `stdout_tdd_count=1`, `stderr_bytes=0`, `sentinel_exists=no`.
+- (d) Non-src does not consume sentinel: test at [tests/test-tdd-pretool-fires-once.sh](/Users/stefanayala/sdlc-wizard/tests/test-tdd-pretool-fires-once.sh:124); focused test output: `PASS: non-src/ edit doesn't consume sentinel`.
+- (e) 50-parallel test exists at [tests/test-tdd-pretool-fires-once.sh](/Users/stefanayala/sdlc-wizard/tests/test-tdd-pretool-fires-once.sh:153). Manual run: `parallel_tdd_count=1`, `parallel_failures=0`, `parallel_sentinels=1`.
+- (f) CI and contributor docs are wired: [.github/workflows/ci.yml](/Users/stefanayala/sdlc-wizard/.github/workflows/ci.yml:220), [CONTRIBUTING.md](/Users/stefanayala/sdlc-wizard/CONTRIBUTING.md:44). `./tests/test-workflow-triggers.sh`: `Passed: 169`, `Failed: 0`.
+- (g) Version bump complete at 7 required sites: `rg` found `1.70.0` in `package.json`, `plugin.json`, `marketplace.json`, `SDLC.md` x2, `CLAUDE_CODE_SDLC_WIZARD.md` x2; `rg` found no remaining `1.69.0` in those version sites.
+
+Focused validation passed: `./tests/test-tdd-pretool-fires-once.sh` passed 9/9, `./tests/test-hooks.sh` passed 154/154, workflow YAML parsed cleanly.
+
+Score: **8/10**  
+**NOT CERTIFIED**

--- a/.reviews/tdd-pretool-fires-once-001/round-2-review.md
+++ b/.reviews/tdd-pretool-fires-once-001/round-2-review.md
@@ -1,0 +1,26 @@
+**Findings**
+None.
+
+Finding 1 is **FIXED**: `tests/test-tdd-pretool-fires-once.sh` is now in the git index (`100755`) and `git ls-files --error-unmatch` succeeds, satisfying the original certify condition.
+
+Prior pass criteria still hold:
+- TDD nudge emits once per `session_id`.
+- Non-`src/` edits are silent and do not pre-consume the sentinel.
+- No `session_id` preserves emit-every-fire behavior.
+- Cache writes are best-effort.
+- 50 parallel same-session `src/` edits emit exactly once.
+- Suppressed fires produce empty stdout.
+- CI/docs wiring and all 7 version bumps are present.
+
+Validation run:
+- `./tests/test-tdd-pretool-fires-once.sh` passed 9/9
+- `./tests/test-hooks.sh` passed 154/154
+- `./tests/test-workflow-triggers.sh` passed 169/169
+- `.github/workflows/ci.yml` parsed as YAML
+- `git diff --check` and `git diff --cached --check` clean
+
+**Notes for next review**
+Most implementation files remain unstaged while the new test is staged. Non-blocking for this targeted recheck, but commit packaging should include all intended files.
+
+Score: **9/10**  
+**CERTIFIED**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.70.0] - 2026-05-05
+
+### Token-bloat fix: TDD CHECK nudge fires once per CC session
+
+`hooks/tdd-pretool-check.sh` was emitting a ~50-token JSON nudge ("TDD CHECK: Are you writing IMPLEMENTATION before a FAILING TEST?") on every Write/Edit/MultiEdit touching `src/**`. After the SDLC skill auto-invokes (which already covers TDD RED/GREEN), the per-Edit nudge is duplicate context — typical SDLC session has 10-30 src Edits = ~0.5-1.5K wasted tokens.
+
+Now gated on per-`session_id` sentinel under `$SDLC_WIZARD_CACHE_DIR/tdd-shown-<id>`, atomic-claimed via subshell `set -C` (noclobber). Same pattern as v1.69.0 BASELINE gate.
+
+### Behavior
+
+- **First src/ edit of a CC session** → TDD CHECK emits as before.
+- **Subsequent src/ edits (same session_id)** → TDD CHECK suppressed.
+- **New CC session (different session_id)** → TDD CHECK re-emits.
+- **Non-src/ files** → no output (existing behavior, regardless of sentinel). Editing README first does NOT consume the sentinel slot — TDD CHECK still fires on first src/ edit afterward.
+- **No session_id in stdin** (legacy CC, direct shell tests) → emits every src/ edit (back-compat preserved).
+- **N parallel src/ edits with same session_id** → exactly 1 TDD CHECK emit (atomic claim).
+
+### Files
+
+- `hooks/tdd-pretool-check.sh` — atomic-claim sentinel + jq-decoupled session_id extraction.
+- `tests/test-tdd-pretool-fires-once.sh` (new — 9 cases including 50-parallel concurrency, non-src/ doesn't consume sentinel, suppressed-fire-empty assertion).
+- `.github/workflows/ci.yml`, `CONTRIBUTING.md` — wire new test into validate job + contributor checklist.
+- `CHANGELOG.md`, `SDLC.md`, `skills/update/SKILL.md`, `package.json`, `.claude-plugin/plugin.json` + `marketplace.json`, `CLAUDE_CODE_SDLC_WIZARD.md` (1.69.0 → 1.70.0).
+
+### Notes
+
+ROADMAP #236 functional-bloat audit, phase 2. Phase 1 (v1.69.0) trimmed the BASELINE block (~12K tokens/session). Phase 2 trims the per-Edit nudge. Combined savings on a 50-prompt + 20-Edit session: ~13.5K tokens. Audit method continues — measure cost × frequency, judge value, don't blind-delete. Other always-on hooks (`model-effort-check`, `precompact-seam-check`, `token-spike-check`) remain silent at healthy state and are not bloat.
+
 ## [1.69.0] - 2026-05-04
 
 ### Token-bloat fix: BASELINE block fires once per CC session

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2976,7 +2976,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.69.0 -->
+<!-- SDLC Wizard Version: 1.70.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4055,7 +4055,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.69.0 -->
+<!-- SDLC Wizard Version: 1.70.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-repo-complexity.sh && \
    ./tests/test-prompt-hook-fires-once.sh && \
    ./tests/test-baseline-fires-once.sh && \
+   ./tests/test-tdd-pretool-fires-once.sh && \
    ./tests/test-community-scanner.sh && \
    ./tests/test-community-fetch.sh && \
    ./tests/test-ground-truth.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.69.0 -->
+<!-- SDLC Wizard Version: 1.70.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,7 +7,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.69.0 |
+| Wizard Version | 1.70.0 |
 | Last Updated | 2026-05-04 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |

--- a/hooks/tdd-pretool-check.sh
+++ b/hooks/tdd-pretool-check.sh
@@ -17,13 +17,59 @@ TOOL_INPUT=$(cat)
 # Extract the file path being edited (requires jq)
 FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty')
 
+# session_id extraction is jq-independent (same pattern as sdlc-prompt-check.sh
+# v1.69.0 — Codex round 1 P1 from that PR proved jq-coupling silently disabled
+# the gate when jq was missing/broken). UUIDs are simple strings, no escapes.
+SESSION_ID=$(printf '%s' "$TOOL_INPUT" \
+    | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed 's/.*"\([^"]*\)"$/\1/')
+
 # CUSTOMIZE: Change this pattern to match YOUR source directory
 # Examples: "/src/", "/app/", "/lib/", "/packages/", "/server/"
 if [[ "$FILE_PATH" == *"/src/"* ]]; then
-  # Output additionalContext that Claude will read
-  cat << 'EOF'
+  # Token-bloat fix (v1.70.0): nudge fires once per CC session. Once Claude
+  # has the SDLC skill auto-invoked (covers TDD RED/GREEN), the per-Edit
+  # nudge becomes duplicate context — typical session has 10-30 src Edits
+  # = ~0.5-1.5K wasted tokens. Same atomic-noclobber claim pattern as
+  # sdlc-prompt-check.sh BASELINE gate.
+  #
+  # No-session_id stdin (legacy CC, direct shell tests) → emit every fire,
+  # preserving back-compat with existing tests in test-hooks.sh that don't
+  # pass session_id.
+  SHOULD_EMIT=1
+  if [ -n "$SESSION_ID" ]; then
+    CACHE_DIR="${SDLC_WIZARD_CACHE_DIR:-$HOME/.cache/sdlc-wizard}"
+    SAFE_SID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9._-')
+    if [ -n "$SAFE_SID" ]; then
+      SENTINEL="$CACHE_DIR/tdd-shown-${SAFE_SID}"
+      mkdir -p "$CACHE_DIR" 2>/dev/null || true
+      # Atomic claim: subshell `set -C` makes `: > path` create-or-fail.
+      # Conditional tree:
+      #   - claim succeeds → emit (we won the race)
+      #   - claim fails AND file exists → suppress (someone else won)
+      #   - claim fails AND file missing → cache unwritable; fall back
+      #     to emit so user never loses cold-start nudge.
+      if (set -C; : > "$SENTINEL") 2>/dev/null; then
+        SHOULD_EMIT=1
+      elif [ -f "$SENTINEL" ]; then
+        SHOULD_EMIT=0
+      else
+        SHOULD_EMIT=1
+      fi
+    fi
+  fi
+
+  if [ "$SHOULD_EMIT" -eq 1 ]; then
+    # Output additionalContext that Claude will read
+    cat << 'EOF'
 {"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "TDD CHECK: Are you writing IMPLEMENTATION before a FAILING TEST? If yes, STOP. Write the test first (TDD RED), then implement (TDD GREEN)."}}
 EOF
+    # Prune sentinels older than 7d so cache doesn't grow forever.
+    if [ -n "$SESSION_ID" ] && [ -n "$SAFE_SID" ]; then
+      find "$CACHE_DIR" -name 'tdd-shown-*' -type f -mtime +7 -delete 2>/dev/null || true
+    fi
+  fi
 fi
 
 # No output = allow the tool to proceed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,10 +93,11 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.69.0
+Latest:    1.70.0
 
 What changed:
-- [1.69.0] token-bloat fix — `hooks/sdlc-prompt-check.sh` BASELINE block (the ~250-token "TodoWrite FIRST / STATE CONFIDENCE / AUTO-INVOKE" reminder) now fires once per CC `session_id` instead of every prompt. Saves ~12K tokens/session for any user with >3 prompts. SETUP-not-complete + EFFORT-bump warnings still fire every prompt (dynamic state). Sentinel pruned at 7d. No-session-id stdin keeps current behavior (legacy CC + tests).
+- [1.70.0] token-bloat fix phase 2 — `hooks/tdd-pretool-check.sh` TDD CHECK JSON nudge (the per-`Write/Edit` "Are you writing IMPLEMENTATION before a FAILING TEST?" reminder) now fires once per CC `session_id` instead of every src/ edit. Saves ~0.5-1.5K tokens/session (10-30 src Edits × ~50 tok). Same atomic-noclobber claim pattern as v1.69.0 BASELINE gate. Non-src/ edits don't consume the sentinel slot.
+- [1.69.0] token-bloat fix phase 1 — `hooks/sdlc-prompt-check.sh` BASELINE block (the ~250-token "TodoWrite FIRST / STATE CONFIDENCE / AUTO-INVOKE" reminder) now fires once per CC `session_id`. Saves ~12K tokens/session. SETUP-not-complete + EFFORT-bump warnings still fire every prompt (dynamic state).
 - [1.68.0–1.65.0] roadmap hygiene — five paperwork closes: #97 Anthropic Policy NO-GO + AAR-paper validating parallel; #99 AutoGPT NO-GO; #95 Nous NO-GO; #243 token-history liveness verified; #210 Node-24 false-green; #235 Thoughtworks AI Evals NO-GO. **6/6 external-product audits NO-GO** (continues #76, #77). Research write-ups in `.reviews/research-*.md`.
 - [1.64.0] XDLC ecosystem cross-references — README, wizard doc, and ROADMAP now cross-reference all three sibling packages (`agentic-sdlc-wizard`, `codex-sdlc-wizard`, `claude-gdlc-wizard`). New "Ecosystem (Sibling Projects)" section in README. 3 new doc-consistency tests prevent drift.
 - [1.63.0] cache-cost observability closeout (#204 absorbed by #220) — `tests/test-token-spike.sh` gains explicit cache-miss regression test + negative-control test. SDLC skill + wizard doc gain "Cache-Cost Surprises" sections covering 10-20× silent cost blowups (mid-session CLAUDE.md edits, idle pruning, upstream cache bugs) and detection via `hooks/token-spike-check.sh`'s `costly_tokens` metric.

--- a/tests/test-tdd-pretool-fires-once.sh
+++ b/tests/test-tdd-pretool-fires-once.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# Roadmap #236 phase 2: regression test for tdd-pretool-check.sh
+# "TDD CHECK nudge fires once per session" optimization.
+#
+# Background: hooks/tdd-pretool-check.sh fires on every Write|Edit|MultiEdit
+# touching src/** and emits a ~50-token JSON nudge ("TDD CHECK: Are you
+# writing IMPLEMENTATION before a FAILING TEST?"). After the SDLC skill
+# auto-invokes (which already covers TDD RED/GREEN), this nudge is duplicate
+# context — typical SDLC session has 10-30 src Edits = 0.5-1.5K wasted tokens.
+#
+# Fix: when stdin JSON includes a session_id, atomic-claim a sentinel under
+# $SDLC_WIZARD_CACHE_DIR/tdd-shown-<safe_sid>. First src/ Edit per session
+# emits the nudge; subsequent fires suppress.
+#
+# Behavior preserved:
+#   - file_path NOT in src/ → no output (existing behavior, regardless of sentinel)
+#   - no session_id stdin → emit every fire (legacy CC + direct shell tests)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/tdd-pretool-check.sh"
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+echo "=== tdd-pretool-check.sh fires-once-per-session Tests ==="
+echo ""
+
+WORKSPACE="${TMPDIR:-/tmp}/sdlc-tdd-once-$$"
+mkdir -p "$WORKSPACE"
+trap 'rm -rf "$WORKSPACE"' EXIT
+
+invoke() {
+    local cache="$1"
+    local payload="$2"
+    SDLC_WIZARD_CACHE_DIR="$cache" bash "$HOOK" <<<"$payload" 2>/dev/null
+}
+
+SRC_PAYLOAD_A='{"tool_input":{"file_path":"/proj/src/foo.ts"},"session_id":"sess-A"}'
+SRC_PAYLOAD_A2='{"tool_input":{"file_path":"/proj/src/bar.ts"},"session_id":"sess-A"}'
+SRC_PAYLOAD_B='{"tool_input":{"file_path":"/proj/src/baz.ts"},"session_id":"sess-B"}'
+NON_SRC_PAYLOAD='{"tool_input":{"file_path":"/proj/README.md"},"session_id":"sess-A"}'
+NO_SID_PAYLOAD='{"tool_input":{"file_path":"/proj/src/foo.ts"}}'
+
+# ---- Test 1: First src/ edit with session_id emits TDD CHECK ----
+test_first_fire_emits() {
+    local cache="$WORKSPACE/cache-1"
+    rm -rf "$cache"
+    local out
+    out=$(invoke "$cache" "$SRC_PAYLOAD_A")
+    if echo "$out" | grep -q "TDD CHECK"; then
+        pass "first src/ edit (session=A) emits TDD CHECK nudge"
+    else
+        fail "first src/ edit should emit TDD CHECK. Output: $out"
+    fi
+}
+
+# ---- Test 2: Second src/ edit same session_id suppresses ----
+test_second_fire_suppresses() {
+    local cache="$WORKSPACE/cache-2"
+    rm -rf "$cache"
+    invoke "$cache" "$SRC_PAYLOAD_A" > /dev/null
+    local out
+    out=$(invoke "$cache" "$SRC_PAYLOAD_A2")
+    if echo "$out" | grep -q "TDD CHECK"; then
+        fail "second src/ edit (same session) should NOT emit. Output: $out"
+    else
+        pass "second src/ edit (session=A, same sentinel) suppresses TDD CHECK"
+    fi
+}
+
+# ---- Test 3: Different session_id re-emits ----
+test_different_session_re_emits() {
+    local cache="$WORKSPACE/cache-3"
+    rm -rf "$cache"
+    invoke "$cache" "$SRC_PAYLOAD_A" > /dev/null
+    local out
+    out=$(invoke "$cache" "$SRC_PAYLOAD_B")
+    if echo "$out" | grep -q "TDD CHECK"; then
+        pass "different session_id (A → B, same cache) re-emits TDD CHECK"
+    else
+        fail "different session_id should emit. Output: $out"
+    fi
+}
+
+# ---- Test 4: No session_id → emit every fire (back-compat) ----
+test_no_session_id_back_compat() {
+    local cache="$WORKSPACE/cache-4"
+    rm -rf "$cache"
+    local out1 out2
+    out1=$(invoke "$cache" "$NO_SID_PAYLOAD")
+    out2=$(invoke "$cache" "$NO_SID_PAYLOAD")
+    if echo "$out1" | grep -q "TDD CHECK" && echo "$out2" | grep -q "TDD CHECK"; then
+        pass "no session_id → TDD CHECK fires every src/ edit (legacy/test compat)"
+    else
+        fail "without session_id, TDD CHECK must emit every src/ edit. Out1=$out1 / Out2=$out2"
+    fi
+}
+
+# ---- Test 5: Non-src/ file produces no output regardless of sentinel ----
+test_non_src_never_emits() {
+    local cache="$WORKSPACE/cache-5"
+    rm -rf "$cache"
+    local out1 out2
+    out1=$(invoke "$cache" "$NON_SRC_PAYLOAD")
+    out2=$(invoke "$cache" "$NON_SRC_PAYLOAD")
+    if [ -z "$out1" ] && [ -z "$out2" ]; then
+        pass "non-src/ file edits produce no output (existing behavior preserved)"
+    else
+        fail "non-src/ should be silent. Out1=$out1 / Out2=$out2"
+    fi
+}
+
+# ---- Test 6: Non-src/ does NOT consume the sentinel slot ----
+#       I.e. if user edits README first, then src/foo, TDD CHECK should still
+#       fire on src/foo because no src/ edit has happened yet.
+test_non_src_doesnt_consume_sentinel() {
+    local cache="$WORKSPACE/cache-6"
+    rm -rf "$cache"
+    invoke "$cache" "$NON_SRC_PAYLOAD" > /dev/null  # README — should not claim sentinel
+    local out
+    out=$(invoke "$cache" "$SRC_PAYLOAD_A")
+    if echo "$out" | grep -q "TDD CHECK"; then
+        pass "non-src/ edit doesn't consume sentinel (TDD CHECK still fires on first src/)"
+    else
+        fail "non-src/ edit should not pre-claim sentinel. src/ output: $out"
+    fi
+}
+
+# ---- Test 7: Sentinel isolated per cache dir ----
+test_sentinel_isolated_per_cache() {
+    local cache_a="$WORKSPACE/cache-7a"
+    local cache_b="$WORKSPACE/cache-7b"
+    rm -rf "$cache_a" "$cache_b"
+    invoke "$cache_a" "$SRC_PAYLOAD_A" > /dev/null
+    local out
+    out=$(invoke "$cache_b" "$SRC_PAYLOAD_A")
+    if echo "$out" | grep -q "TDD CHECK"; then
+        pass "sentinel isolated per SDLC_WIZARD_CACHE_DIR"
+    else
+        fail "different cache dir should re-emit TDD CHECK. Output: $out"
+    fi
+}
+
+# ---- Test 8: Concurrency — 50 parallel same-session fires emit exactly once ----
+test_concurrency_same_session_emits_once() {
+    local cache="$WORKSPACE/cache-8"
+    rm -rf "$cache"
+    local agg="$WORKSPACE/cache-8-outputs"
+    rm -f "$agg"
+    local i pids=()
+    for i in $(seq 1 50); do
+        ( invoke "$cache" "$SRC_PAYLOAD_A" >> "$agg" ) &
+        pids+=($!)
+    done
+    for p in "${pids[@]}"; do
+        wait "$p" || true
+    done
+    local count
+    count=$(grep -c "TDD CHECK" "$agg" 2>/dev/null || echo 0)
+    if [ "$count" = "1" ]; then
+        pass "50 parallel same-session src/ edits emit TDD CHECK exactly once (atomic claim)"
+    else
+        fail "concurrency race: ${count} TDD CHECK outputs across 50 fires (expected 1)"
+    fi
+}
+
+# ---- Test 9: Suppressed fire is empty (no leftover JSON shell) ----
+test_suppressed_fire_is_empty() {
+    local cache="$WORKSPACE/cache-9"
+    rm -rf "$cache"
+    invoke "$cache" "$SRC_PAYLOAD_A" > /dev/null
+    local out
+    out=$(invoke "$cache" "$SRC_PAYLOAD_A2")
+    if [ -z "$out" ]; then
+        pass "suppressed fire produces no stdout (clean — no empty JSON wrapper)"
+    else
+        fail "suppressed fire leaked stdout: '$out'"
+    fi
+}
+
+test_first_fire_emits
+test_second_fire_suppresses
+test_different_session_re_emits
+test_no_session_id_back_compat
+test_non_src_never_emits
+test_non_src_doesnt_consume_sentinel
+test_sentinel_isolated_per_cache
+test_concurrency_same_session_emits_once
+test_suppressed_fire_is_empty
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: $PASSED${NC}"
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+    exit 1
+fi
+echo "All tdd-pretool-fires-once tests passed."


### PR DESCRIPTION
## Summary

Phase 2 of ROADMAP #236 functional-bloat audit. `hooks/tdd-pretool-check.sh` was emitting a ~50-token JSON nudge on every Write/Edit/MultiEdit touching `src/**`. After SDLC skill auto-invokes (already covers TDD RED/GREEN), per-Edit nudge is duplicate. Typical session has 10-30 src Edits = ~0.5-1.5K wasted tokens.

Now gated on per-`session_id` sentinel via the same atomic-noclobber pattern proven in v1.69.0 (BASELINE gate). New sentinel at `$SDLC_WIZARD_CACHE_DIR/tdd-shown-<id>`.

**Combined savings (v1.69.0 + v1.70.0):** ~13.5K tokens on a 50-prompt + 20-Edit session.

## Behavior matrix

| Scenario | TDD CHECK emits? |
|---|---|
| First src/ edit of CC session | ✅ |
| Subsequent src/ edit, same session_id | ❌ (suppressed) |
| New CC session (different session_id) | ✅ (re-emits) |
| Non-src/ file (README.md etc.) | ❌ (existing behavior) |
| Non-src/ edit BEFORE first src/ edit | ❌ for non-src/, ✅ for src/ (sentinel not pre-consumed — Test 6) |
| 50 parallel src/ Edits, same session | ✅ exactly once (atomic claim) |
| No session_id stdin (legacy/test) | ✅ every fire (back-compat) |

## Cross-model review

Codex round 1 caught 1 P1: new test file untracked at review time. Fixed by staging before round 2. **Round 2 CERTIFIED 9/10**.

## Test plan

- [x] `tests/test-tdd-pretool-fires-once.sh` (new) — 9 cases
- [x] `tests/test-hooks.sh` — 154/154 pass (no regression)
- [x] `tests/test-baseline-fires-once.sh` — 10/10 pass (v1.69.0 sibling untouched)
- [x] `tests/test-prompt-hook-fires-once.sh` — 6/6 pass
- [x] `tests/test-audit-session-load.sh` — 9/9 pass (SKILL.md under 5K)
- [x] `tests/test-cli.sh` — 78/78 pass
- [x] `tests/test-plugin.sh` — 25/25 pass
- [x] `tests/test-doc-consistency.sh` — 35/35 pass
- [x] `tests/test-workflow-triggers.sh` — 169/169 pass (CONTRIBUTING.md + ci.yml wiring verified locally)

## Files

- `hooks/tdd-pretool-check.sh` — atomic-claim sentinel + jq-decoupled session_id extraction
- `tests/test-tdd-pretool-fires-once.sh` (new — 9 cases including 50-parallel concurrency, non-src/-doesn't-consume-sentinel, suppressed-fire-empty)
- `.github/workflows/ci.yml`, `CONTRIBUTING.md` — wires new test
- `CHANGELOG.md`, `SDLC.md`, `skills/update/SKILL.md`, `package.json`, `.claude-plugin/plugin.json` + `marketplace.json`, `CLAUDE_CODE_SDLC_WIZARD.md` (1.69.0 → 1.70.0)
- `.reviews/preflight-*.md`, `.reviews/tdd-pretool-fires-once-001/round-{1,2}-review.md` (force-added past `.reviews/` gitignore)