### PR TITLE
bloat(#236): audit script scans .claude/skills/ (consumer install path)

### DIFF
--- a/scripts/audit-session-load.sh
+++ b/scripts/audit-session-load.sh
@@ -15,9 +15,11 @@
 #
 # What's inventoried (when present at $ROOT):
 #   - CLAUDE.md / SDLC.md / TESTING.md / ARCHITECTURE.md / MEMORY.md
-#   - All hooks/*.sh (script size, NOT runtime stdout — that's separately
-#     gated by the existing brevity-cap tests in tests/test-hooks.sh)
-#   - All skills/*/SKILL.md
+#   - All hooks/*.sh (dev-repo path) AND .claude/hooks/*.sh (consumer install
+#     via cli/init.js). Script size, NOT runtime stdout — that's separately
+#     gated by the existing brevity-cap tests in tests/test-hooks.sh.
+#   - All skills/*/SKILL.md (dev-repo path) AND .claude/skills/*/SKILL.md
+#     (consumer install path; cli/init.js:32-35 copies SKILL.md files there).
 #
 # Output columns: SIZE_CHARS, EST_TOKENS (chars/4), TYPE, FLAG, PATH
 # FLAG = "OK" if <5K tokens, "TRIM" if >=5K tokens.
@@ -82,6 +84,19 @@ fi
 if [ -d "$ROOT/skills" ]; then
     for s in "$ROOT/skills"/*/SKILL.md; do
         [ -f "$s" ] && add_entry "$s" "skill"
+    done
+fi
+# Also check .claude/skills/ if separate (consumer install path).
+# cli/init.js:32-35 copies SKILL.md files to .claude/skills/<name>/SKILL.md
+# at install time. Without this scan, the audit silently ignores all
+# bloat in real consumer projects. Mirrors the .claude/hooks/ pattern
+# above (will double-count in dogfood where .claude/skills/ symlinks
+# back to skills/, same trade-off as hooks).
+if [ -d "$ROOT/.claude/skills" ] && [ "$ROOT/.claude/skills" != "$ROOT/skills" ]; then
+    for skill_dir in "$ROOT/.claude/skills"/*/; do
+        [ -d "$skill_dir" ] || continue
+        skill_md="${skill_dir}SKILL.md"
+        [ -f "$skill_md" ] && add_entry "$skill_md" "skill"
     done
 fi
 

--- a/tests/test-audit-session-load.sh
+++ b/tests/test-audit-session-load.sh
@@ -173,6 +173,49 @@ print("\n".join(flagged))
     fi
 }
 
+test_audit_scans_consumer_install_layout() {
+    # Codex strategic review caught a measurement blind spot: the audit
+    # scans root `skills/*/SKILL.md`, but `cli/init.js:32-35` copies
+    # SKILL.md files to `.claude/skills/<name>/SKILL.md` in real
+    # consumer installs. Without parallel scanning, the audit can't
+    # see bloat in installed projects — only in dev maintainer repos.
+    #
+    # Mirrors the existing `.claude/hooks/` consumer-install fallback
+    # at `scripts/audit-session-load.sh`. Negative control: deleting
+    # the new audit-script block makes this test fail (path won't
+    # appear in the JSON output, predicate fails).
+    local d output
+    d=$(make_temp)
+    # Consumer install layout: .claude/skills/<name>/SKILL.md exists,
+    # root skills/ does NOT (dev-only path).
+    make_file_with_size "$d/.claude/skills/sdlc/SKILL.md" 21000
+
+    output=$(SDLC_AUDIT_ROOT="$d" "$AUDIT" --json 2>&1)
+    rm -rf "$d"
+
+    # Strict predicate (per Codex sign-off): require entry whose path
+    # ENDS in `.claude/skills/sdlc/SKILL.md` AND has flag "TRIM".
+    # Substring match would also accept noise like a real `skills/`
+    # path that happens to contain `claude` somewhere in its prefix.
+    if echo "$output" | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read())
+except json.JSONDecodeError:
+    sys.exit(1)
+hit = [
+    e for e in data.get("entries", [])
+    if e.get("path", "").endswith("/.claude/skills/sdlc/SKILL.md")
+    and e.get("flag") == "TRIM"
+]
+sys.exit(0 if hit else 1)
+' 2>/dev/null; then
+        pass "audit scans .claude/skills/ in consumer install layout (>5K SKILL.md flagged TRIM)"
+    else
+        fail "audit did not inventory .claude/skills/sdlc/SKILL.md from consumer-install fixture. Output: $output"
+    fi
+}
+
 test_audit_exists_and_executable
 test_audit_flags_oversized_skill_as_trim_candidate
 test_audit_does_not_flag_small_files
@@ -181,6 +224,7 @@ test_audit_json_output_includes_trim_count
 test_audit_threshold_override
 test_audit_empty_repo_no_crash
 test_audit_ranks_by_size_descending
+test_audit_scans_consumer_install_layout
 test_wizard_own_skills_below_threshold
 
 echo ""


### PR DESCRIPTION
## Summary

Last #236 cleanup: fix a measurement blind spot in `scripts/audit-session-load.sh`. The audit scanned only root `skills/*/SKILL.md`, but `cli/init.js:32-35` copies SKILL.md files to `.claude/skills/<name>/SKILL.md` at install time. So the audit was silently invisible to bloat in real consumer projects — only the dev-maintainer dual-purpose layout was checked.

(Replaces #319, which got stranded after origin/main was force-updated mid-flow.)

Caught by Codex strategic review on the "should we keep going on bloat?" question. Codex flagged the asymmetry between hooks (already dual-path scanned via `.claude/hooks/` block) and skills (root-only). Mirrors that existing pattern.

## Why this matters

`tests/test-audit-session-load.sh:174` enforces "wizard repo's own SKILL.md files all stay below 5000-token threshold." A consumer who customized their `.claude/skills/sdlc/SKILL.md` to >5K tokens would never trip the audit's TRIM flag — the tool wouldn't see them. That undermines the audit's own Prove-It framing ("a tool that surfaces real issues whose owner ignores them is just a louder lint warning").

## Implementation (Codex-signed-off, 4 deltas applied)

1. `scripts/audit-session-load.sh`: new `.claude/skills/` scan block mirroring `.claude/hooks/`.
2. Inventory comment block updated to mention both paths.
3. `tests/test-audit-session-load.sh`: new `test_audit_scans_consumer_install_layout` using existing `make_temp` + `make_file_with_size` helpers.
4. Test wired into the explicit-call runner block.
5. Python predicate uses `path.endswith("/.claude/skills/sdlc/SKILL.md")` + `flag == "TRIM"` (strict, not substring match).

## Test plan

- [x] `tests/test-audit-session-load.sh` — 10/10 PASS (was 9/9, +1 new regression). TDD RED confirmed.
- [x] `tests/test-cli.sh` — 78/78 PASS
- [x] `tests/test-plugin.sh` — 25/25 PASS
- [x] `tests/test-doc-consistency.sh` — 35/35 PASS
- [x] `tests/test-workflow-triggers.sh` — 169/169 PASS

Live audit shows both layouts inventoried. Dogfood double-counts (`.claude/skills/` symlinks resolve to same files as `skills/`) — same trade-off the `.claude/hooks/` scan already accepts.

## No version bump

`scripts/` + `tests/` aren't in `package.json` `files:`. Same precedent as orphan-delete PR #318.

## Close-out

Final #236 PR for this session. Combined session impact:
- ~14K tokens/heavy-session saved (v1.69 BASELINE + v1.70 TDD CHECK + v1.71 SDLC SKILL trim)
- 85 lines of orphan dev script deleted (PR #318)
- Audit tool now scans the path real consumers use (this PR)