### PR TITLE
fix(#323): customized-aware update recommendation in `check`

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -396,12 +396,34 @@ function check(targetDir, { json = false } = {}) {
       }
     }
     if (updateInfo) {
-      console.log(`\n  ${YELLOW}UPDATE${RESET}  v${updateInfo.current} -> v${updateInfo.latest}`);
-      console.log('         Run: npx agentic-sdlc-wizard init --force');
+      const customizedCount = results.filter((r) => r.status === 'CUSTOMIZED').length;
+      for (const line of buildUpdateRecommendation(updateInfo, customizedCount)) {
+        console.log(line);
+      }
     }
   }
 
   return { results, updateInfo, hasDrift, marketplace };
+}
+
+// #323: when `check` finds CUSTOMIZED files alongside an available update,
+// the historical recommendation `init --force` would silently clobber them.
+// This builds an update-recommendation block that's customization-aware:
+// no-CUSTOMIZED → recommend --force as before. Has-CUSTOMIZED → warn and
+// recommend `--dry-run` first so the user can preview the diff.
+function buildUpdateRecommendation(updateInfo, customizedCount) {
+  if (!updateInfo) return [];
+  const lines = [
+    `\n  ${YELLOW}UPDATE${RESET}  v${updateInfo.current} -> v${updateInfo.latest}`,
+  ];
+  if (customizedCount > 0) {
+    lines.push(`         ${YELLOW}WARNING${RESET}: ${customizedCount} file(s) CUSTOMIZED — \`init --force\` will overwrite them`);
+    lines.push(`         Preview first: npx agentic-sdlc-wizard init --dry-run`);
+    lines.push(`         (Review the dry-run output before running \`init --force\`.)`);
+  } else {
+    lines.push('         Run: npx agentic-sdlc-wizard init --force');
+  }
+  return lines;
 }
 
 function checkFile(srcPath, destPath, relativeDest, shouldBeExecutable) {
@@ -519,4 +541,4 @@ function checkMarketplacePaths() {
   return results;
 }
 
-module.exports = { init, check, planOperations, detectPluginInstall, GITIGNORE_ENTRIES };
+module.exports = { init, check, planOperations, detectPluginInstall, buildUpdateRecommendation, GITIGNORE_ENTRIES };

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -461,6 +461,38 @@ test_check_drift_permissions() {
     rm -rf "$d"
 }
 
+# Test 22a (#323): check recommends --dry-run when CUSTOMIZED files + UPDATE available
+test_check_recommends_dry_run_when_customized() {
+    local result
+    result=$(node -e "
+const { buildUpdateRecommendation } = require('$SCRIPT_DIR/../cli/init.js');
+const lines = buildUpdateRecommendation({ current: '1.0.0', latest: '2.0.0' }, 3);
+console.log(lines.join('\n'));
+" 2>&1) || true
+    if echo "$result" | grep -q 'init --dry-run' \
+        && echo "$result" | grep -qiE 'customized|preview|overwrite'; then
+        pass "#323: check recommends 'init --dry-run' + warning when CUSTOMIZED files exist"
+    else
+        fail "#323: should recommend --dry-run + warn about customized files. Got: $result"
+    fi
+}
+
+# Test 22b (#323): check still recommends --force when no CUSTOMIZED files
+test_check_recommends_force_when_no_customized() {
+    local result
+    result=$(node -e "
+const { buildUpdateRecommendation } = require('$SCRIPT_DIR/../cli/init.js');
+const lines = buildUpdateRecommendation({ current: '1.0.0', latest: '2.0.0' }, 0);
+console.log(lines.join('\n'));
+" 2>&1) || true
+    if echo "$result" | grep -q 'init --force' \
+        && ! echo "$result" | grep -q 'init --dry-run'; then
+        pass "#323: check recommends 'init --force' when no CUSTOMIZED files (no behavior change)"
+    else
+        fail "#323: no-customized case should recommend --force, not --dry-run. Got: $result"
+    fi
+}
+
 # Test 22: check detects missing .gitignore entries (DRIFT)
 test_check_drift_gitignore() {
     local d
@@ -758,6 +790,8 @@ test_check_all_missing
 test_check_json
 test_check_drift_permissions
 test_check_drift_gitignore
+test_check_recommends_dry_run_when_customized
+test_check_recommends_force_when_no_customized
 test_setup_wizard_frontmatter
 test_merge_settings_output
 test_merge_preserves_keys


### PR DESCRIPTION
Closes #323.

## Summary

When `npx agentic-sdlc-wizard check` finds CUSTOMIZED files alongside an available update, the historical recommendation was `init --force` — which silently overwrites every customization with no warning. Reporter (2026-05-05) hit this with 6 customized hooks/skills.

## Fix (option 1 from #323's ranked solutions — minimum viable)

New pure function `buildUpdateRecommendation(updateInfo, customizedCount)` exported from `cli/init.js`:

- **0 customized files** → unchanged. Recommends `init --force` as before.
- **≥1 customized files** → warns about overwrite risk and recommends `init --dry-run` first so the user can preview the diff. Mentions that `init --force` is the destructive path so the trade-off is visible.

Doesn't change `init --force` behavior — still respects the explicit flag. Only changes the SUGGESTED command in `check` output.

## Sample output

Before (current main):
```
CUSTOMIZED  .claude/hooks/tdd-pretool-check.sh
CUSTOMIZED  .claude/skills/sdlc/SKILL.md
...

  UPDATE  v1.31.0 -> v1.71.0
         Run: npx agentic-sdlc-wizard init --force
```

After:
```
CUSTOMIZED  .claude/hooks/tdd-pretool-check.sh
CUSTOMIZED  .claude/skills/sdlc/SKILL.md
...

  UPDATE  v1.31.0 -> v1.71.0
         WARNING: 6 file(s) CUSTOMIZED — `init --force` will overwrite them
         Preview first: npx agentic-sdlc-wizard init --dry-run
         (Review the dry-run output before running `init --force`.)
```

## Deferred (per #323)

- Option 2: `init --preserve-customized` flag
- Option 3: real `update` subcommand with backup + per-file diff prompt

These are bigger scope; option 1 closes the immediate footgun.

## Test plan

- [x] TDD: 2 unit tests via direct call to exported function
- [x] `./tests/test-cli.sh` 80/80 green
- [ ] CI validate green