### PR TITLE
feat(#323): `--preserve-customized` flag (option 2)

### DIFF
--- a/cli/bin/sdlc-wizard.js
+++ b/cli/bin/sdlc-wizard.js
@@ -11,6 +11,7 @@ const flags = {
   force: args.includes('--force'),
   dryRun: args.includes('--dry-run'),
   json: args.includes('--json'),
+  preserveCustomized: args.includes('--preserve-customized'),
 };
 
 const positional = args.filter((a) => !a.startsWith('--'));
@@ -31,11 +32,12 @@ if (args.includes('--help') || args.includes('-h') || !command) {
     sdlc-wizard complexity [path]            Print mixed-mode tier heuristic (roadmap #233)
 
   Options:
-    --force       Overwrite existing files (init only)
-    --dry-run     Preview changes without writing (init only)
-    --json        Output as JSON (check / complexity)
-    --version     Show version
-    --help        Show this help
+    --force                  Overwrite existing files (init only)
+    --preserve-customized    With --force, skip files that have local edits (init only)
+    --dry-run                Preview changes without writing (init only)
+    --json                   Output as JSON (check / complexity)
+    --version                Show version
+    --help                   Show this help
   `.trim());
   process.exit(0);
 }

--- a/cli/init.js
+++ b/cli/init.js
@@ -130,8 +130,22 @@ function mergeSettings(existingPath, templatePath, force) {
   }
 }
 
-function planOperations(targetDir, { force }) {
+function planOperations(targetDir, { force, preserveCustomized = false }) {
   const ops = [];
+
+  // #323 option 2: preserve mode requires hashing each existing file to
+  // distinguish CUSTOMIZED from MATCH. Only meaningful with --force; without
+  // --force, existing files are SKIP regardless of hash.
+  const isCustomized = (srcPath, destPath) => {
+    if (!preserveCustomized || !force) return false;
+    try {
+      const srcHash = crypto.createHash('sha256').update(fs.readFileSync(srcPath)).digest('hex');
+      const destHash = crypto.createHash('sha256').update(fs.readFileSync(destPath)).digest('hex');
+      return srcHash !== destHash;
+    } catch (_) {
+      return false;
+    }
+  };
 
   for (const file of FILES) {
     const destPath = path.join(targetDir, file.dest);
@@ -154,11 +168,16 @@ function planOperations(targetDir, { force }) {
       // Invalid JSON — fall through to normal SKIP/OVERWRITE
     }
 
+    let action;
+    if (!exists) action = 'CREATE';
+    else if (isCustomized(srcPath, destPath)) action = 'PRESERVE';
+    else action = force ? 'OVERWRITE' : 'SKIP';
+
     ops.push({
       src: srcPath,
       dest: destPath,
       relativeDest: file.dest,
-      action: exists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+      action,
       executable: file.executable || false,
     });
   }
@@ -166,11 +185,15 @@ function planOperations(targetDir, { force }) {
   // Wizard doc
   const wizardDest = path.join(targetDir, 'CLAUDE_CODE_SDLC_WIZARD.md');
   const wizardExists = fs.existsSync(wizardDest);
+  let wizardAction;
+  if (!wizardExists) wizardAction = 'CREATE';
+  else if (isCustomized(WIZARD_DOC, wizardDest)) wizardAction = 'PRESERVE';
+  else wizardAction = force ? 'OVERWRITE' : 'SKIP';
   ops.push({
     src: WIZARD_DOC,
     dest: wizardDest,
     relativeDest: 'CLAUDE_CODE_SDLC_WIZARD.md',
-    action: wizardExists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+    action: wizardAction,
     executable: false,
   });
 
@@ -183,7 +206,7 @@ function ensureDir(filePath) {
 
 function executeOperations(ops) {
   for (const op of ops) {
-    if (op.action === 'SKIP') continue;
+    if (op.action === 'SKIP' || op.action === 'PRESERVE') continue;
     ensureDir(op.dest);
     if (op.action === 'MERGE') {
       fs.writeFileSync(op.dest, op.mergedContent);
@@ -230,12 +253,18 @@ function updateGitignore(targetDir, { dryRun }) {
 }
 
 function printOps(ops) {
+  let preserveCount = 0;
   for (const op of ops) {
     const color = op.action === 'CREATE' ? GREEN
       : op.action === 'SKIP' ? YELLOW
       : op.action === 'MERGE' ? MAGENTA
+      : op.action === 'PRESERVE' ? YELLOW
       : CYAN;
     console.log(`  ${color}${op.action}${RESET}  ${op.relativeDest}`);
+    if (op.action === 'PRESERVE') preserveCount++;
+  }
+  if (preserveCount > 0) {
+    console.log(`\n  ${YELLOW}PRESERVED ${preserveCount} customized file(s)${RESET} — review with \`init --dry-run\` to see what differs from the latest template.`);
   }
 }
 
@@ -254,7 +283,7 @@ function invalidateVersionCache({ dryRun }) {
   return true;
 }
 
-function init(targetDir, { force = false, dryRun = false } = {}) {
+function init(targetDir, { force = false, dryRun = false, preserveCustomized = false } = {}) {
   if (!dryRun && !force) {
     const pluginPaths = detectPluginInstall();
     if (pluginPaths.length > 0) {
@@ -273,7 +302,7 @@ function init(targetDir, { force = false, dryRun = false } = {}) {
     }
   }
 
-  const ops = planOperations(targetDir, { force });
+  const ops = planOperations(targetDir, { force, preserveCustomized });
 
   if (dryRun) {
     console.log('Dry run — no files will be written:\n');
@@ -418,8 +447,9 @@ function buildUpdateRecommendation(updateInfo, customizedCount) {
   ];
   if (customizedCount > 0) {
     lines.push(`         ${YELLOW}WARNING${RESET}: ${customizedCount} file(s) CUSTOMIZED — \`init --force\` will overwrite them`);
-    lines.push(`         Preview first: npx agentic-sdlc-wizard init --dry-run`);
-    lines.push(`         (Review the dry-run output before running \`init --force\`.)`);
+    lines.push(`         Preview first:  npx agentic-sdlc-wizard init --dry-run`);
+    lines.push(`         Or upgrade safely: npx agentic-sdlc-wizard init --force --preserve-customized`);
+    lines.push(`         (\`--preserve-customized\` skips CUSTOMIZED files and updates only MATCH ones.)`);
   } else {
     lines.push('         Run: npx agentic-sdlc-wizard init --force');
   }

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -493,6 +493,59 @@ console.log(lines.join('\n'));
     fi
 }
 
+# Test 22e (#323 option 2): init --force --preserve-customized skips CUSTOMIZED files
+test_init_preserve_customized_skips_customized() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user customization" >> "$d/.claude/hooks/sdlc-prompt-check.sh"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    (cd "$d" && node "$CLI" init --force --preserve-customized > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    if [ "$before_hash" = "$after_hash" ]; then
+        pass "#323 option 2: init --force --preserve-customized skips CUSTOMIZED files (file hash unchanged)"
+    else
+        fail "#323 option 2: --preserve-customized should NOT overwrite CUSTOMIZED files. Hash changed."
+    fi
+    rm -rf "$d"
+}
+
+# Test 22f (#323 option 2): --preserve-customized still creates MISSING files
+test_init_preserve_customized_creates_missing() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    rm "$d/.claude/hooks/tdd-pretool-check.sh"
+    (cd "$d" && node "$CLI" init --force --preserve-customized > /dev/null 2>&1)
+    if [ -f "$d/.claude/hooks/tdd-pretool-check.sh" ]; then
+        pass "#323 option 2: --preserve-customized creates MISSING files (preserve != skip-everything)"
+    else
+        fail "#323 option 2: --preserve-customized should still create MISSING files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 22g (#323 option 2): regression guard — --force alone still overwrites CUSTOMIZED
+test_init_force_alone_still_overwrites() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user customization" >> "$d/.claude/hooks/sdlc-prompt-check.sh"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    (cd "$d" && node "$CLI" init --force > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    if [ "$before_hash" != "$after_hash" ]; then
+        pass "#323 option 2: regression guard — --force alone (no --preserve-customized) still overwrites CUSTOMIZED"
+    else
+        fail "#323 option 2: --force alone should still overwrite (existing behavior unchanged)"
+    fi
+    rm -rf "$d"
+}
+
 # Test 22: check detects missing .gitignore entries (DRIFT)
 test_check_drift_gitignore() {
     local d
@@ -792,6 +845,9 @@ test_check_drift_permissions
 test_check_drift_gitignore
 test_check_recommends_dry_run_when_customized
 test_check_recommends_force_when_no_customized
+test_init_preserve_customized_skips_customized
+test_init_preserve_customized_creates_missing
+test_init_force_alone_still_overwrites
 test_setup_wizard_frontmatter
 test_merge_settings_output
 test_merge_preserves_keys


### PR DESCRIPTION
Follow-up to #325. Implements option 2 from #323's ranked solutions.

## What

New flag: `npx agentic-sdlc-wizard init --force --preserve-customized`

When set with `--force`:
- **CUSTOMIZED** files (sha256 mismatch with source) → action `PRESERVE`, skipped during write, reported in summary
- **MATCH** files → `OVERWRITE` (refresh; effectively no-op since hash already matches)
- **MISSING** files → `CREATE` (new files in latest version still get installed)

`--preserve-customized` only takes effect WITH `--force` — without `--force`, all existing files are `SKIP` regardless. This composes the existing semantics rather than introducing a third mode.

## Updated `check` recommendation

Before (from #325, option 1):
```
UPDATE  v1.31.0 -> v1.71.0
       WARNING: 6 file(s) CUSTOMIZED — `init --force` will overwrite them
       Preview first: npx agentic-sdlc-wizard init --dry-run
       (Review the dry-run output before running `init --force`.)
```

After:
```
UPDATE  v1.31.0 -> v1.71.0
       WARNING: 6 file(s) CUSTOMIZED — `init --force` will overwrite them
       Preview first:  npx agentic-sdlc-wizard init --dry-run
       Or upgrade safely: npx agentic-sdlc-wizard init --force --preserve-customized
       (`--preserve-customized` skips CUSTOMIZED files and updates only MATCH ones.)
```

## Output during `init --force --preserve-customized`

```
  PRESERVE  .claude/hooks/sdlc-prompt-check.sh
  PRESERVE  .claude/skills/sdlc/SKILL.md
  OVERWRITE .claude/hooks/tdd-pretool-check.sh
  CREATE    .claude/skills/feedback/SKILL.md

  PRESERVED 2 customized file(s) — review with `init --dry-run` to see what differs from the latest template.
```

## Test plan

- [x] `test_init_preserve_customized_skips_customized` — file hash unchanged after run
- [x] `test_init_preserve_customized_creates_missing` — MISSING files still get created
- [x] `test_init_force_alone_still_overwrites` — regression guard: bare `--force` still overwrites
- [x] `./tests/test-cli.sh` 83/83 green
- [ ] CI validate green
- [ ] Codex cross-model review

## Deferred

Option 3 from #323 (real `update` subcommand with backup + per-file diff prompt). Options 1 + 2 together cover the core footgun without the design overhead of a new subcommand + backup convention.