### PR TITLE
feat(#323): `--preserve-customized` flag (option 2, v2)

### DIFF
--- a/cli/bin/sdlc-wizard.js
+++ b/cli/bin/sdlc-wizard.js
@@ -11,6 +11,7 @@ const flags = {
   force: args.includes('--force'),
   dryRun: args.includes('--dry-run'),
   json: args.includes('--json'),
+  preserveCustomized: args.includes('--preserve-customized'),
 };
 
 const positional = args.filter((a) => !a.startsWith('--'));
@@ -31,11 +32,12 @@ if (args.includes('--help') || args.includes('-h') || !command) {
     sdlc-wizard complexity [path]            Print mixed-mode tier heuristic (roadmap #233)
 
   Options:
-    --force       Overwrite existing files (init only)
-    --dry-run     Preview changes without writing (init only)
-    --json        Output as JSON (check / complexity)
-    --version     Show version
-    --help        Show this help
+    --force                  Overwrite existing files (init only)
+    --preserve-customized    With --force, skip files that have local edits (init only)
+    --dry-run                Preview changes without writing (init only)
+    --json                   Output as JSON (check / complexity)
+    --version                Show version
+    --help                   Show this help
   `.trim());
   process.exit(0);
 }

--- a/cli/init.js
+++ b/cli/init.js
@@ -130,8 +130,22 @@ function mergeSettings(existingPath, templatePath, force) {
   }
 }
 
-function planOperations(targetDir, { force }) {
+function planOperations(targetDir, { force, preserveCustomized = false }) {
   const ops = [];
+
+  // #323 option 2: preserve mode requires hashing each existing file to
+  // distinguish CUSTOMIZED from MATCH. Only meaningful with --force; without
+  // --force, existing files are SKIP regardless of hash.
+  const isCustomized = (srcPath, destPath) => {
+    if (!preserveCustomized || !force) return false;
+    try {
+      const srcHash = crypto.createHash('sha256').update(fs.readFileSync(srcPath)).digest('hex');
+      const destHash = crypto.createHash('sha256').update(fs.readFileSync(destPath)).digest('hex');
+      return srcHash !== destHash;
+    } catch (_) {
+      return false;
+    }
+  };
 
   for (const file of FILES) {
     const destPath = path.join(targetDir, file.dest);
@@ -154,11 +168,16 @@ function planOperations(targetDir, { force }) {
       // Invalid JSON — fall through to normal SKIP/OVERWRITE
     }
 
+    let action;
+    if (!exists) action = 'CREATE';
+    else if (isCustomized(srcPath, destPath)) action = 'PRESERVE';
+    else action = force ? 'OVERWRITE' : 'SKIP';
+
     ops.push({
       src: srcPath,
       dest: destPath,
       relativeDest: file.dest,
-      action: exists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+      action,
       executable: file.executable || false,
     });
   }
@@ -166,11 +185,15 @@ function planOperations(targetDir, { force }) {
   // Wizard doc
   const wizardDest = path.join(targetDir, 'CLAUDE_CODE_SDLC_WIZARD.md');
   const wizardExists = fs.existsSync(wizardDest);
+  let wizardAction;
+  if (!wizardExists) wizardAction = 'CREATE';
+  else if (isCustomized(WIZARD_DOC, wizardDest)) wizardAction = 'PRESERVE';
+  else wizardAction = force ? 'OVERWRITE' : 'SKIP';
   ops.push({
     src: WIZARD_DOC,
     dest: wizardDest,
     relativeDest: 'CLAUDE_CODE_SDLC_WIZARD.md',
-    action: wizardExists ? (force ? 'OVERWRITE' : 'SKIP') : 'CREATE',
+    action: wizardAction,
     executable: false,
   });
 
@@ -183,7 +206,7 @@ function ensureDir(filePath) {
 
 function executeOperations(ops) {
   for (const op of ops) {
-    if (op.action === 'SKIP') continue;
+    if (op.action === 'SKIP' || op.action === 'PRESERVE') continue;
     ensureDir(op.dest);
     if (op.action === 'MERGE') {
       fs.writeFileSync(op.dest, op.mergedContent);
@@ -230,12 +253,18 @@ function updateGitignore(targetDir, { dryRun }) {
 }
 
 function printOps(ops) {
+  let preserveCount = 0;
   for (const op of ops) {
     const color = op.action === 'CREATE' ? GREEN
       : op.action === 'SKIP' ? YELLOW
       : op.action === 'MERGE' ? MAGENTA
+      : op.action === 'PRESERVE' ? YELLOW
       : CYAN;
     console.log(`  ${color}${op.action}${RESET}  ${op.relativeDest}`);
+    if (op.action === 'PRESERVE') preserveCount++;
+  }
+  if (preserveCount > 0) {
+    console.log(`\n  ${YELLOW}PRESERVED ${preserveCount} customized file(s)${RESET} — review with \`init --dry-run\` to see what differs from the latest template.`);
   }
 }
 
@@ -254,7 +283,7 @@ function invalidateVersionCache({ dryRun }) {
   return true;
 }
 
-function init(targetDir, { force = false, dryRun = false } = {}) {
+function init(targetDir, { force = false, dryRun = false, preserveCustomized = false } = {}) {
   if (!dryRun && !force) {
     const pluginPaths = detectPluginInstall();
     if (pluginPaths.length > 0) {
@@ -273,7 +302,7 @@ function init(targetDir, { force = false, dryRun = false } = {}) {
     }
   }
 
-  const ops = planOperations(targetDir, { force });
+  const ops = planOperations(targetDir, { force, preserveCustomized });
 
   if (dryRun) {
     console.log('Dry run — no files will be written:\n');
@@ -418,8 +447,9 @@ function buildUpdateRecommendation(updateInfo, customizedCount) {
   ];
   if (customizedCount > 0) {
     lines.push(`         ${YELLOW}WARNING${RESET}: ${customizedCount} file(s) CUSTOMIZED — \`init --force\` will overwrite them`);
-    lines.push(`         Preview first: npx agentic-sdlc-wizard init --dry-run`);
-    lines.push(`         (Review the dry-run output before running \`init --force\`.)`);
+    lines.push(`         Preview first:  npx agentic-sdlc-wizard init --dry-run`);
+    lines.push(`         Or upgrade safely: npx agentic-sdlc-wizard init --force --preserve-customized`);
+    lines.push(`         (\`--preserve-customized\` skips CUSTOMIZED files and updates only MATCH ones.)`);
   } else {
     lines.push('         Run: npx agentic-sdlc-wizard init --force');
   }

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -511,9 +511,6 @@ console.log(JSON.stringify({ null: a, undefined: b }));
 }
 
 # Test 22d (#325 P2 follow-up): undefined customizedCount falls through to --force path
-# (defensive — if a future caller forgets the second arg, behavior shouldn't silently
-# flip to the warning path, which would be surprising. customizedCount=undefined
-# should be treated like "0 known customized" and recommend --force.)
 test_check_recommendation_undefined_count() {
     local result
     result=$(node -e "
@@ -527,6 +524,131 @@ console.log(lines.join('\n'));
     else
         fail "#325 P2: undefined customizedCount should default to --force path. Got: $result"
     fi
+}
+
+# Test 22e (#323 option 2): init --force --preserve-customized skips CUSTOMIZED files
+test_init_preserve_customized_skips_customized() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user customization" >> "$d/.claude/hooks/sdlc-prompt-check.sh"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    (cd "$d" && node "$CLI" init --force --preserve-customized > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    if [ "$before_hash" = "$after_hash" ]; then
+        pass "#323 option 2: init --force --preserve-customized skips CUSTOMIZED files (file hash unchanged)"
+    else
+        fail "#323 option 2: --preserve-customized should NOT overwrite CUSTOMIZED files. Hash changed."
+    fi
+    rm -rf "$d"
+}
+
+# Test 22f (#323 option 2): --preserve-customized still creates MISSING files
+test_init_preserve_customized_creates_missing() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    rm "$d/.claude/hooks/tdd-pretool-check.sh"
+    (cd "$d" && node "$CLI" init --force --preserve-customized > /dev/null 2>&1)
+    if [ -f "$d/.claude/hooks/tdd-pretool-check.sh" ]; then
+        pass "#323 option 2: --preserve-customized creates MISSING files (preserve != skip-everything)"
+    else
+        fail "#323 option 2: --preserve-customized should still create MISSING files"
+    fi
+    rm -rf "$d"
+}
+
+# Test 22g (#323 option 2): regression guard — --force alone still overwrites CUSTOMIZED
+test_init_force_alone_still_overwrites() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user customization" >> "$d/.claude/hooks/sdlc-prompt-check.sh"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    (cd "$d" && node "$CLI" init --force > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    if [ "$before_hash" != "$after_hash" ]; then
+        pass "#323 option 2: regression guard — --force alone (no --preserve-customized) still overwrites CUSTOMIZED"
+    else
+        fail "#323 option 2: --force alone should still overwrite (existing behavior unchanged)"
+    fi
+    rm -rf "$d"
+}
+
+# Test 22h (#327 round-2 P2): --preserve-customized without --force is a no-op
+# (existing files all SKIP regardless; the flag composes with --force, doesn't replace it)
+test_preserve_customized_without_force_is_noop() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user customization" >> "$d/.claude/hooks/sdlc-prompt-check.sh"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    # No --force, just --preserve-customized
+    (cd "$d" && node "$CLI" init --preserve-customized > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/.claude/hooks/sdlc-prompt-check.sh" | awk '{print $1}')
+    if [ "$before_hash" = "$after_hash" ]; then
+        pass "#323 option 2: --preserve-customized without --force is no-op (existing files unchanged)"
+    else
+        fail "#323 option 2: --preserve-customized without --force should not modify files. Hash changed."
+    fi
+    rm -rf "$d"
+}
+
+# Test 22i (#327 round-2 P2): settings.json still MERGEs under --force --preserve-customized
+# (MERGE branch in planOperations runs BEFORE the customized hash check — settings should
+# get its custom-hooks-preserving merge, not be PRESERVED-as-blob)
+test_settings_merges_under_preserve_customized() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    # Add a custom hook to settings.json that the merge logic should preserve
+    python3 -c "
+import json
+with open('$d/.claude/settings.json') as f: data = json.load(f)
+data.setdefault('hooks', {}).setdefault('UserPromptSubmit', []).append({
+    'hooks': [{'type': 'command', 'command': 'echo custom-hook'}]
+})
+with open('$d/.claude/settings.json', 'w') as f: json.dump(data, f)
+"
+    local output
+    output=$(cd "$d" && node "$CLI" init --force --preserve-customized 2>&1)
+    # MERGE action should appear for settings.json (not PRESERVE — merge runs first)
+    if echo "$output" | grep -E '(MERGE|OVERWRITE)' | grep -q 'settings.json'; then
+        # And the custom hook should still be present after the merge
+        if grep -q 'custom-hook' "$d/.claude/settings.json"; then
+            pass "#323 option 2: settings.json MERGEs under --force --preserve-customized (custom hooks preserved)"
+        else
+            fail "#323 option 2: settings.json merge dropped custom hook"
+        fi
+    else
+        fail "#323 option 2: settings.json should be MERGEd (or OVERWRITTEN), not PRESERVEd as blob. Got: $output"
+    fi
+    rm -rf "$d"
+}
+
+# Test 22j (#327 round-2 P2): WIZARD_DOC parity — customized wizard doc gets PRESERVED
+test_wizard_doc_preserved_when_customized() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    echo "# user added section" >> "$d/CLAUDE_CODE_SDLC_WIZARD.md"
+    local before_hash
+    before_hash=$(shasum -a 256 "$d/CLAUDE_CODE_SDLC_WIZARD.md" | awk '{print $1}')
+    (cd "$d" && node "$CLI" init --force --preserve-customized > /dev/null 2>&1)
+    local after_hash
+    after_hash=$(shasum -a 256 "$d/CLAUDE_CODE_SDLC_WIZARD.md" | awk '{print $1}')
+    if [ "$before_hash" = "$after_hash" ]; then
+        pass "#323 option 2: WIZARD_DOC also respects --preserve-customized (parity with FILES loop)"
+    else
+        fail "#323 option 2: WIZARD_DOC should be PRESERVEd when customized. Hash changed."
+    fi
+    rm -rf "$d"
 }
 
 # Test 22: check detects missing .gitignore entries (DRIFT)
@@ -830,6 +952,12 @@ test_check_recommends_dry_run_when_customized
 test_check_recommends_force_when_no_customized
 test_check_recommendation_null_updateinfo
 test_check_recommendation_undefined_count
+test_init_preserve_customized_skips_customized
+test_init_preserve_customized_creates_missing
+test_init_force_alone_still_overwrites
+test_preserve_customized_without_force_is_noop
+test_settings_merges_under_preserve_customized
+test_wizard_doc_preserved_when_customized
 test_setup_wizard_frontmatter
 test_merge_settings_output
 test_merge_preserves_keys


### PR DESCRIPTION
**Replaces #327** — same code, rebased on current main + 3 additional tests addressing Codex round-1 P2 findings.

Closes #323 (option 1 shipped in #325, this is option 2).

## What

New flag: `npx agentic-sdlc-wizard init --force --preserve-customized`

When set with `--force`:
- **CUSTOMIZED** files (sha256 mismatch with source) → action `PRESERVE`, skipped during write, reported in summary
- **MATCH** files → `OVERWRITE` (refresh; effectively no-op)
- **MISSING** files → `CREATE`

Composes existing `--force` semantics rather than introducing a new mode.

## Codex round-1 (PR #327) findings addressed

- **F1 (P1)** Merge conflict with #326's tests — rebased onto current main, conflicts in `tests/test-cli.sh` resolved keeping both #326's P2 tests AND this PR's option 2 tests
- **F2 (P2)** Three coverage gaps — added in this PR:
  - `test_preserve_customized_without_force_is_noop` — flag without `--force` is a no-op
  - `test_settings_merges_under_preserve_customized` — settings.json still uses MERGE branch (preserves user custom hooks)
  - `test_wizard_doc_preserved_when_customized` — WIZARD_DOC parity with FILES loop

## Output during `init --force --preserve-customized`

```
  PRESERVE  .claude/hooks/sdlc-prompt-check.sh
  PRESERVE  .claude/skills/sdlc/SKILL.md
  OVERWRITE .claude/hooks/tdd-pretool-check.sh
  CREATE    .claude/skills/feedback/SKILL.md

  PRESERVED 2 customized file(s) — review with `init --dry-run` to see what differs from the latest template.
```

## Updated `check` recommendation

When CUSTOMIZED files exist:
```
UPDATE  v1.31.0 -> v1.71.0
       WARNING: 6 file(s) CUSTOMIZED — `init --force` will overwrite them
       Preview first:  npx agentic-sdlc-wizard init --dry-run
       Or upgrade safely: npx agentic-sdlc-wizard init --force --preserve-customized
       (`--preserve-customized` skips CUSTOMIZED files and updates only MATCH ones.)
```

## Test plan

- [x] `./tests/test-cli.sh` 88/88 green
- [x] 6 new tests covering: skips CUSTOMIZED, creates MISSING, regression guard for bare `--force`, no-op without `--force`, settings.json MERGE behavior, WIZARD_DOC parity
- [ ] CI validate green

## Deferred

Option 3 from #323 (real `update` subcommand with backup + per-file diff prompt). Options 1 + 2 cover the core footgun.