### PR TITLE
fix(hooks): precompact stale REBASE_HEAD false-positive

### DIFF
--- a/hooks/precompact-seam-check.sh
+++ b/hooks/precompact-seam-check.sh
@@ -218,7 +218,13 @@ esac
 # Unknown value (e.g. typo "bogus") → also falls through to real check
 # rather than silently bypassing safety. The safer-than-the-typo path.
 if [ "$DRY_RUN_GIT_HANDLED" -eq 0 ] && [ -d "$GITDIR" ]; then
-    if [ -e "$GITDIR/REBASE_HEAD" ] || [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
+    # Only the rebase-{merge,apply}/ dir is authoritative for "rebase in progress."
+    # .git/REBASE_HEAD is a reference to the original HEAD pre-rebase and can
+    # persist as a stale marker after a rebase finishes cleanly — git removes
+    # the dir but leaves REBASE_HEAD around for diff/log lookups. Including it
+    # in the OR-chain caused false-positive HOLDs that blocked manual /compact
+    # for users whose previous rebase had completed (hit live 2026-05-05).
+    if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
         HOLD_REASONS="${HOLD_REASONS}  - Git rebase in progress. Compacting mid-rebase loses the operation's context.
     Resolve: finish or abort the rebase before /compact."$'\n'
     fi

--- a/hooks/precompact-seam-check.sh
+++ b/hooks/precompact-seam-check.sh
@@ -219,11 +219,12 @@ esac
 # rather than silently bypassing safety. The safer-than-the-typo path.
 if [ "$DRY_RUN_GIT_HANDLED" -eq 0 ] && [ -d "$GITDIR" ]; then
     # Only the rebase-{merge,apply}/ dir is authoritative for "rebase in progress."
-    # .git/REBASE_HEAD is a reference to the original HEAD pre-rebase and can
-    # persist as a stale marker after a rebase finishes cleanly — git removes
-    # the dir but leaves REBASE_HEAD around for diff/log lookups. Including it
-    # in the OR-chain caused false-positive HOLDs that blocked manual /compact
-    # for users whose previous rebase had completed (hit live 2026-05-05).
+    # .git/REBASE_HEAD is a rebase-related ref (the stopped/replayed commit) that
+    # is not authoritative on its own — it can persist as a stale marker after a
+    # rebase finishes cleanly: git removes the dir but leaves REBASE_HEAD around
+    # for diff/log lookups. Including it in the OR-chain caused false-positive
+    # HOLDs that blocked manual /compact for users whose previous rebase had
+    # completed (hit live 2026-05-05). `git status` keys on the dirs too.
     if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
         HOLD_REASONS="${HOLD_REASONS}  - Git rebase in progress. Compacting mid-rebase loses the operation's context.
     Resolve: finish or abort the rebase before /compact."$'\n'

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -355,6 +355,47 @@ test_precompact_blocks_on_cherry_pick_in_progress() {
     fi
 }
 
+test_precompact_silent_on_stale_rebase_head_alone() {
+    # Bug: .git/REBASE_HEAD can persist as a stale marker after a rebase
+    # has finished cleanly. The authoritative "rebase in progress" signal
+    # is .git/rebase-merge/ or .git/rebase-apply/ — REBASE_HEAD alone is
+    # just a reference to the original HEAD pre-rebase, not an in-flight
+    # state. Hit live 2026-05-05: yesterday's clean rebase left REBASE_HEAD
+    # behind and blocked the user's manual /compact for no real reason.
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.git"
+    echo "abc123" > "$tmpdir/.git/REBASE_HEAD"
+    # NO rebase-merge/ or rebase-apply/ — actual rebase has finished
+    local stderr_out rc=0
+    stderr_out=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/precompact-seam-check.sh" < /dev/null 2>&1 >/dev/null) || rc=$?
+    rm -rf "$tmpdir"
+    if [ "$rc" -eq 0 ] && [ -z "$stderr_out" ]; then
+        pass "precompact hook is silent on stale REBASE_HEAD without rebase-{merge,apply} dirs"
+    else
+        fail "precompact should be silent on stale REBASE_HEAD alone (rc=$rc, stderr='$stderr_out')"
+    fi
+}
+
+test_precompact_blocks_on_rebase_head_with_rebase_merge_dir() {
+    # Negative control: REBASE_HEAD + rebase-merge/ together = real rebase
+    # in progress (git wrote REBASE_HEAD when it created the dir). MUST
+    # still block. Distinguishes the stale-alone case above from a live one.
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.git/rebase-merge"
+    echo "abc123" > "$tmpdir/.git/REBASE_HEAD"
+    echo "dummy" > "$tmpdir/.git/rebase-merge/head-name"
+    local stderr_out rc=0
+    stderr_out=$(CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/precompact-seam-check.sh" < /dev/null 2>&1 >/dev/null) || rc=$?
+    rm -rf "$tmpdir"
+    if [ "$rc" -eq 2 ] && echo "$stderr_out" | grep -qi "rebase"; then
+        pass "precompact still blocks on REBASE_HEAD + rebase-merge dir (real rebase)"
+    else
+        fail "precompact should block on REBASE_HEAD + rebase-merge dir (rc=$rc, stderr='$stderr_out')"
+    fi
+}
+
 test_precompact_size_cap() {
     # Worst case: all 4 blockers fire simultaneously (PENDING_RECHECK + rebase + merge + cherry-pick).
     # Should still emit a token-efficient HOLD message.
@@ -1671,6 +1712,8 @@ test_precompact_blocks_on_git_rebase_in_progress
 test_precompact_blocks_on_git_rebase_apply_in_progress
 test_precompact_blocks_on_git_merge_in_progress
 test_precompact_blocks_on_cherry_pick_in_progress
+test_precompact_silent_on_stale_rebase_head_alone
+test_precompact_blocks_on_rebase_head_with_rebase_merge_dir
 test_precompact_size_cap
 test_precompact_self_heals_on_merged_pr
 test_precompact_still_blocks_on_open_pr

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -359,9 +359,9 @@ test_precompact_silent_on_stale_rebase_head_alone() {
     # Bug: .git/REBASE_HEAD can persist as a stale marker after a rebase
     # has finished cleanly. The authoritative "rebase in progress" signal
     # is .git/rebase-merge/ or .git/rebase-apply/ — REBASE_HEAD alone is
-    # just a reference to the original HEAD pre-rebase, not an in-flight
-    # state. Hit live 2026-05-05: yesterday's clean rebase left REBASE_HEAD
-    # behind and blocked the user's manual /compact for no real reason.
+    # just a rebase-related ref (the stopped/replayed commit), not an
+    # in-flight state. Hit live 2026-05-05: yesterday's clean rebase left
+    # REBASE_HEAD behind and blocked the user's manual /compact for no real reason.
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.git"


### PR DESCRIPTION
## Summary

- `.git/REBASE_HEAD` persists as a stale marker after a rebase finishes cleanly (git keeps it for diff/log lookups but removes the `rebase-{merge,apply}/` dir).
- The hook's OR-chain triggered HOLD on stale REBASE_HEAD alone, blocking the user's manual `/compact` yesterday despite no actual rebase in progress.
- Fix: drop `REBASE_HEAD` from the rebase check; the `rebase-{merge,apply}/` dir is the authoritative signal (matches `git status`).

## Test plan

- [x] TDD test added: `test_precompact_silent_on_stale_rebase_head_alone` — silent rc=0 when only REBASE_HEAD exists
- [x] Negative control: `test_precompact_blocks_on_rebase_head_with_rebase_merge_dir` — still blocks on real in-flight rebase
- [x] Existing rebase-merge / rebase-apply tests still pass (156/156 hook tests)
- [x] Audit clean (`scripts/audit-session-load.sh` reports 0 trim candidates)

Hit live in this repo 2026-05-05: yesterday's clean rebase left REBASE_HEAD behind, blocking `/compact` until manually `rm`'d.