### PR TITLE
release: v1.73.0 — precompact REBASE_HEAD fix + 15-file gc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.72.0",
+      "version": "1.73.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.73.0] - 2026-05-06
+
+### Fix: PreCompact hook no longer false-positives on stale `.git/REBASE_HEAD`
+
+`hooks/precompact-seam-check.sh` was treating any presence of `.git/REBASE_HEAD` as "rebase in progress" and blocking manual `/compact`. But `REBASE_HEAD` is just a rebase-related ref (the stopped/replayed commit) that git can leave behind after a clean rebase finishes — the authoritative "rebase in progress" signal is the `rebase-merge/` or `rebase-apply/` directory (which is what `git status` keys on too). Hit live in this repo 2026-05-05 — yesterday's clean rebase left `REBASE_HEAD` behind, the user's manual `/compact` was blocked, and clearing it required `rm .git/REBASE_HEAD` by hand.
+
+The OR-chain at line 227 now drops the `REBASE_HEAD` predicate; only the `rebase-{merge,apply}/` dir checks remain. Two new tests cover the fix:
+
+- `test_precompact_silent_on_stale_rebase_head_alone` — positive: `rc=0` + empty stderr when only `REBASE_HEAD` exists
+- `test_precompact_blocks_on_rebase_head_with_rebase_merge_dir` — negative control: still blocks on real in-flight rebase (REBASE_HEAD + rebase-merge dir together)
+
+156/156 hook tests green. Codex round 1 CERTIFIED 9/10 (one P2 comment-accuracy nit caught — fixed: `REBASE_HEAD` is the stopped/replayed commit, not the original branch tip, which is `ORIG_HEAD`).
+
+PR #330.
+
+### GC: -460 LOC of stale review/plan artifacts (#236 bloat hunt)
+
+`.reviews/` is gitignored, but 14 handoff/preflight/round-N review files for now-merged PRs were committed before that gitignore line landed. They held no ongoing reference value. `plans/CATCHUP.md` captured the v2.1.15 → v2.1.81 catch-up (March 2026) — historical context lives in CHANGELOG (v1.8.0 entry); the plan doc was dead weight.
+
+Deleted (15 files):
+
+- `.reviews/baseline-fires-once-001/{round-1,round-2}-review.md`
+- `.reviews/skill-cross-model-trim-001/{round-1,round-2,round-3}-review.md`
+- `.reviews/tdd-pretool-fires-once-001/{round-1,round-2}-review.md`
+- `.reviews/preflight-{allowed-tools-permissions,baseline-fires-once,model-pin-opt-in,precompact-seam,skill-cross-model-trim,staleness-nudge,tdd-pretool-fires-once}-001.md`
+- `plans/CATCHUP.md`
+
+Kept (still load-bearing):
+
+- `.reviews/research-95/97/99/206/235.md` (cited from ROADMAP rows)
+- `.reviews/experiment-tracking.md` (asserted by `tests/test-workflow-triggers.sh:2189`)
+- `plans/AUTO_SELF_UPDATE.md` (still annotated with #231 phase notes)
+
+Hooks 156/156, cli 88/88, workflow 176/176, docs 35/35 — all green post-deletion.
+
+PR #331.
+
+---
+
 ## [1.72.0] - 2026-05-05
 
 ### Closes #323: `init --force` no longer silently overwrites CUSTOMIZED files

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2976,7 +2976,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.72.0 -->
+<!-- SDLC Wizard Version: 1.73.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4070,7 +4070,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Wizard Version: 1.72.0 -->
+<!-- SDLC Wizard Version: 1.73.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.72.0 -->
+<!-- SDLC Wizard Version: 1.73.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 # SDLC Configuration
@@ -7,8 +7,8 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.72.0 |
-| Last Updated | 2026-05-04 |
+| Wizard Version | 1.73.0 |
+| Last Updated | 2026-05-06 |
 | Claude Code Baseline | v2.1.111+ (required for Opus 4.7 / `opus[1m]`) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |
 | Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,13 +93,12 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.72.0
+Latest:    1.73.0
 
 What changed:
+- [1.73.0] precompact stale REBASE_HEAD fix + bloat sweep — `hooks/precompact-seam-check.sh` no longer false-positive HOLDs `/compact` when a finished rebase left REBASE_HEAD behind without `rebase-{merge,apply}/` dirs (hit live 2026-05-05). 15 tracked review/plan artifacts deleted (-460 LOC).
 - [1.72.0] #323 closed — customization-aware `check` recommendation + new `--preserve-customized` flag. `init --force --preserve-customized` skips CUSTOMIZED files (action `PRESERVE`), still OVERWRITEs MATCH and CREATEs MISSING. Default `init --force` unchanged. 10 tests.
-- [1.71.0] token-bloat phase 3 — `skills/sdlc/SKILL.md` Cross-Model Review trimmed (~70 → ~20 lines, -427 tokens). Full protocol + examples moved to canonical `CLAUDE_CODE_SDLC_WIZARD.md` "Cross-Model Review Loop" section.
-- [1.70.0] token-bloat fix phase 2 — `hooks/tdd-pretool-check.sh` TDD CHECK JSON nudge fires once per CC `session_id` instead of every src/ edit. Saves ~0.5-1.5K tokens/session.
-- [1.69.0] token-bloat fix phase 1 — `hooks/sdlc-prompt-check.sh` BASELINE block fires once per CC `session_id`. Saves ~12K tokens/session.
+- [1.71.0–1.69.0] token-bloat sweep #236 — three phases: BASELINE block fires once per `session_id` (-12K/session), TDD CHECK fires once per `session_id` (-0.5-1.5K/session), `skills/sdlc/SKILL.md` Cross-Model Review trimmed (full protocol moved to canonical wizard doc).
 - [1.68.0–1.65.0] roadmap hygiene — five paperwork closes: #97 Anthropic Policy NO-GO + AAR-paper validating parallel; #99 AutoGPT NO-GO; #95 Nous NO-GO; #243 token-history liveness verified; #210 Node-24 false-green; #235 Thoughtworks AI Evals NO-GO. **6/6 external-product audits NO-GO** (continues #76, #77). Research write-ups in `.reviews/research-*.md`.
 - [1.64.0] XDLC ecosystem cross-references — README, wizard doc, and ROADMAP now cross-reference all three sibling packages (`agentic-sdlc-wizard`, `codex-sdlc-wizard`, `claude-gdlc-wizard`). New "Ecosystem (Sibling Projects)" section in README. 3 new doc-consistency tests prevent drift.
 - [1.63.0] cache-cost observability closeout (#204 absorbed by #220) — `tests/test-token-spike.sh` gains explicit cache-miss regression test + negative-control test. SDLC skill + wizard doc gain "Cache-Cost Surprises" sections covering 10-20× silent cost blowups (mid-session CLAUDE.md edits, idle pruning, upstream cache bugs) and detection via `hooks/token-spike-check.sh`'s `costly_tokens` metric.


### PR DESCRIPTION
## Summary

Two PRs roll up:

- **PR #330** — `hooks/precompact-seam-check.sh` no longer false-positive HOLDs `/compact` on stale `.git/REBASE_HEAD` (left behind after a clean rebase). Authoritative signal is the `rebase-{merge,apply}/` dir; `REBASE_HEAD` is just a ref to the stopped/replayed commit. Hit live 2026-05-05.
- **PR #331** — gc(#236): -460 LOC across 15 stale review/plan artifacts committed before `.reviews/` made it into `.gitignore`. All for now-merged work; load-bearing files preserved.

## Test plan

- [x] cli 88/88, hooks 156/156, self-update 76/76, docs 35/35, audit 10/10
- [x] `scripts/audit-session-load.sh` reports 0 trim candidates (skills/update/SKILL.md held under 5K tokens by consolidating 1.69.0–1.71.0 entries)
- [x] Both included PRs already passed Codex review on their own branches before merging