### PR TITLE
fix(docs): append < /dev/null to codex exec invocations (stdin-hang)

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2347,8 +2347,12 @@ PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Self-Review
       review the listed files. Output each finding with: an ID (1, 2, ...), \
       severity (P0/P1/P2), description, and a 'certify condition' stating \
       what specific change would resolve it. \
-      End with CERTIFIED or NOT CERTIFIED."
+      End with CERTIFIED or NOT CERTIFIED." \
+     < /dev/null
    ```
+
+   > **Always append `< /dev/null`** to `codex exec` calls run from background, hooks, CI, or any non-interactive parent. Without it, codex blocks on stdin reads even when the prompt is given as an argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file. Validated on codex-cli 0.130.0 / macOS 14, May 15, 2026. For live progress visibility, add `--json` and redirect stdout to a file (`> .reviews/events.jsonl`), then `tail -f` shows event-by-event flow.
+
 3. If CERTIFIED → proceed to CI. If NOT CERTIFIED → go to Round 2.
 
 ### Round 2+: Dialogue Loop
@@ -2389,7 +2393,8 @@ When the reviewer finds issues, respond per-finding instead of silently fixing e
       ACCEPTED → verify it was applied. \
       Do NOT raise new findings unless P0 (critical/security). \
       New observations go in 'Notes for next review' (non-blocking). \
-      End with CERTIFIED or NOT CERTIFIED."
+      End with CERTIFIED or NOT CERTIFIED." \
+     < /dev/null
    ```
 
 4. If CERTIFIED → done. If NOT CERTIFIED (rejected disputes or failed fixes) → fix rejected items and repeat.
@@ -3716,7 +3721,8 @@ codex exec \
    review the listed files. Output each finding with: an ID (1, 2, ...), \
    severity (P0/P1/P2), description, and a 'certify condition' stating \
    what specific change would resolve it. \
-   End with CERTIFIED or NOT CERTIFIED."
+   End with CERTIFIED or NOT CERTIFIED." \
+  < /dev/null
 ```
 
 4. If CERTIFIED → done. If NOT CERTIFIED → enter the dialogue loop.
@@ -3774,7 +3780,8 @@ codex exec \
    ACCEPTED → verify it was applied. \
    Do NOT raise new findings unless P0 (critical/security). \
    New observations go in 'Notes for next review' (non-blocking). \
-   End with CERTIFIED or NOT CERTIFIED."
+   End with CERTIFIED or NOT CERTIFIED." \
+  < /dev/null
 ```
 
 **The key constraint:** Rechecks are scoped to previous findings only. The reviewer cannot block certification with new P2 observations discovered during recheck. This prevents scope creep and ensures convergence.

--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ That's it. Codex picks up your OpenAI account's best available model automatical
 ```bash
 codex exec -c 'model_reasoning_effort="xhigh"' -s danger-full-access \
   -o .reviews/latest-review.md \
-  "Read .reviews/handoff.json and review per the checklist. Output findings + CERTIFIED or NOT CERTIFIED."
+  "Read .reviews/handoff.json and review per the checklist. Output findings + CERTIFIED or NOT CERTIFIED." \
+  < /dev/null
 ```
+
+> **Always append `< /dev/null`** when running `codex exec` from background, hooks, CI, or any non-interactive parent. Without it, codex blocks on stdin reads even when the prompt is given as an argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file (it's only written on completion). Validated on codex-cli 0.130.0 / macOS 14, May 15, 2026.
 
 `xhigh` reasoning is **non-negotiable** — lower settings miss subtle bugs. See [CLAUDE_CODE_SDLC_WIZARD.md](CLAUDE_CODE_SDLC_WIZARD.md#cross-model-review-loop-optional) for the full protocol (handoff format, round-2 dialogue loop, preflight docs). Real-world: this catches P0/P1 issues in 2-3 out of 10 reviews that Claude's self-review rated as clean.
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -296,10 +296,13 @@ codex exec \
    Output each finding with: ID (1, 2, ...), severity (P0/P1/P2), evidence, \
    and a 'certify condition' (what specific change resolves it). \
    Re-verify any prior-round passes still hold. \
-   End with: score (1-10), CERTIFIED or NOT CERTIFIED."
+   End with: score (1-10), CERTIFIED or NOT CERTIFIED." \
+  < /dev/null
 ```
 
 **Always use `xhigh` reasoning effort.** Lower settings miss subtle errors (wrong-generation references, stale pricing, cross-file inconsistencies).
+
+**Always append `< /dev/null`** when invoking `codex exec` from a hook, CI step, background process, or any non-interactive parent (including the Claude Code Bash tool). Without it, codex blocks on stdin reads even when the prompt is given as a positional argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file (the file is only written on completion, so a hang gives zero visibility). Validated on codex-cli 0.130.0 / macOS 14, May 15, 2026, after two ~30+ min silent hangs. For live progress visibility add `--json` and redirect stdout to a file (`> .reviews/events.jsonl`); `tail -f` then shows the event stream.
 
 **Sandbox note:** Codex's Rust binary requires access to macOS system configuration APIs (`SCDynamicStore`) during sandbox initialization. Claude Code's sandbox blocks this access, causing `codex exec` to crash with `system-configuration panicked: Attempted to create a NULL object`. When running `codex exec` from within Claude Code, you MUST use `dangerouslyDisableSandbox: true` on the Bash tool call. This is safe — Codex has its own sandbox (`-s danger-full-access` is already specified), and the CC sandbox bypass only affects the Codex process. This is a known Codex issue ([#15640](https://github.com/openai/codex/issues/15640)).
 
@@ -342,7 +345,8 @@ Respond per-finding — don't silently fix everything:
       Do NOT raise new findings unless P0 (critical/security). \
       New observations go in 'Notes for next review' (non-blocking). \
       Re-verify all prior passes still hold. \
-      End with: score (1-10), CERTIFIED or NOT CERTIFIED."
+      End with: score (1-10), CERTIFIED or NOT CERTIFIED." \
+     < /dev/null
    ```
 
 ### Convergence


### PR DESCRIPTION
## Summary

Patches the documented `codex exec` invocations in README.md, CLAUDE_CODE_SDLC_WIZARD.md, and skills/sdlc/SKILL.md to append `< /dev/null`. Without it, codex blocks on stdin reads even when the prompt is given as a positional argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file, and a hang is indistinguishable from "still running."

Reported in issue #341 with full repro, validated on codex-cli 0.130.0 / macOS 14.

## What changed

- 5 `codex exec` invocation blocks across 3 files: appended `\\` + `< /dev/null` on a new line at end of each block.
- Added a callout next to the first occurrence in each user-facing doc (README, wizard, skill): *"Always append `< /dev/null`..."* + the `--json` + redirect-to-file tip for live progress visibility.
- Docs lint (`tests/test-docs-usability.sh`) passes: 26/26.

## Why

Two 30+ minute silent hangs in the anticheat repo (May 15, 2026):
- DCA-margin adversarial review: 94 minutes at 0:00.03 CPU / S state / 0-byte output before kill
- Tier-2-elevation review: 32 minutes, same signature

`ps -o stat,time,%cpu` showed S/SN, sub-second cumulative CPU, zero TCP connections to OpenAI. Stderr revealed *"Reading additional input from stdin..."* — codex was waiting for the parent's open stdin to close. One-character fix per invocation.

## Repro (10 seconds, deterministic)

```bash
# Hangs forever:
codex exec -s read-only "Reply with exactly 'A'." &

# Completes in ~8s:
codex exec -s read-only "Reply with exactly 'A'." < /dev/null
```

## Test plan

- [x] `bash tests/test-docs-usability.sh` — 26 passed, 0 failed
- [x] All 5 invocation blocks render correctly in preview
- [x] Validated end-to-end on anticheat repo: r1 → r2 full Codex dialogue loop completed in ~3 minutes after the fix (commit `f405bca` in anticheat CLAUDE.md applied the same pattern)

Closes #341.