### PR TITLE
feat(ci): cc-version-drift.yml — open issue when CC baseline drifts >5 patch releases (closes #350)

### DIFF
--- a/.github/workflows/cc-version-drift.yml
+++ b/.github/workflows/cc-version-drift.yml
@@ -1,0 +1,249 @@
+name: CC Version Drift
+
+# ROADMAP #350: cheap GitHub-API-only detector that opens a tracking
+# issue when the wizard's CC baseline (in SDLC.md) has drifted >5
+# patch releases behind npm latest. No LLM, no API spend. Mirrors the
+# weekly-api-update.yml shepherd pattern.
+#
+# Context: in #231 Phase 3d (v1.54.0) the in-CI Claude release ranker
+# was deleted to take weekly-update.yml to $0. The fallback was
+# "maintainer runs `claude --print` on Max weekly." That ran zero
+# times in 5 weeks, and native `/goal` (CC v2.1.139) slipped past
+# unnoticed until a user filed #347 — wizard then published wrong
+# research saying "no /goal exists." This workflow exists so the next
+# 5-week miss surfaces as a GH issue/notification instead of silence.
+#
+# Design constraints (each enforced by tests/test-cc-version-drift.sh):
+#
+#   1. Standalone workflow — NOT extending weekly-update.yml. Per
+#      Codex review (.reviews/176-followup-prio-codex.md #350.1):
+#      weekly-update.yml's cron is commented out and tests assert
+#      `issues: write` is absent (deliberate #212/#231 guardrails).
+#
+#   2. Cron staggered from neighboring workflows. weekly-update.yml
+#      uses 09:00 UTC Mon (documented but disabled); weekly-api-update.yml
+#      uses 10:00 UTC Mon. We slot at 09:30 UTC Mon.
+#
+#   3. Idempotency via label `cc-version-drift` + machine-readable
+#      marker in issue body. Edit existing open issue rather than
+#      comment-spam; only re-open a closed issue if delta has WIDENED
+#      since close (the maintainer's "won't fix for now" stays
+#      respected as long as the gap doesn't grow).
+#
+#   4. Baseline source: `<!-- Claude Code Baseline: vX.Y.Z -->`
+#      anchor in SDLC.md. Single-purpose, machine-parseable. Do NOT
+#      reuse `<!-- SDLC Wizard Version -->` (that's the wizard's own
+#      package version, not the CC feature baseline).
+#
+#   5. No `|| true` / `|| echo` failure-suppression. The whole point
+#      of #350 is "don't let drift detection silently fail." If
+#      jq/gh/npm break, fail loud with ::error:: annotations.
+
+on:
+  schedule:
+    - cron: '30 9 * * 1'  # Mon 09:30 UTC, staggered from weekly + weekly-api
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: 'Override drift threshold (patch-release gap). Default 5.'
+        required: false
+        default: '5'
+
+permissions:
+  contents: read  # SDLC.md + scripts/cc-drift-check.sh — read-only
+  issues: write   # open / update the tracking issue (the only side effect)
+
+env:
+  REVIEW_LABEL: 'cc-version-drift'
+  # Policy lives in git, in env: rather than repo variable so it's
+  # auditable and overridable by workflow_dispatch input.
+  CC_DRIFT_THRESHOLD: '5'
+
+jobs:
+  detect-drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read wizard's CC baseline from SDLC.md
+        id: baseline
+        run: |
+          set -euo pipefail
+          # Single-purpose anchor — see header comment block.
+          BASELINE=$(grep -oE '<!-- Claude Code Baseline: v?[0-9]+\.[0-9]+\.[0-9]+ -->' SDLC.md | head -1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "${BASELINE:-}" ]; then
+            echo "::error::Could not parse '<!-- Claude Code Baseline: vX.Y.Z -->' anchor from SDLC.md"
+            echo "::error::Add the line near the existing version-tracking comments, then re-run."
+            exit 1
+          fi
+          echo "baseline=${BASELINE#v}" >> "$GITHUB_OUTPUT"
+          echo "wizard baseline: ${BASELINE}"
+
+      - name: Fetch latest Claude Code version from npm
+        id: latest
+        run: |
+          set -euo pipefail
+          # `npm view` writes to stdout on success and to stderr on
+          # network/404 failure. Run under pipefail so any non-zero
+          # exit code stops the step instead of silently emitting "".
+          LATEST=$(npm view @anthropic-ai/claude-code version)
+          if [ -z "${LATEST:-}" ]; then
+            echo "::error::npm view returned empty version for @anthropic-ai/claude-code — registry issue?"
+            exit 1
+          fi
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "npm latest: ${LATEST}"
+
+      - name: Compute drift
+        id: drift
+        env:
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
+          LATEST: ${{ steps.latest.outputs.latest }}
+          THRESHOLD: ${{ inputs.threshold || env.CC_DRIFT_THRESHOLD }}
+        run: |
+          set -euo pipefail
+          ./scripts/cc-drift-check.sh \
+            --baseline "$BASELINE" \
+            --latest "$LATEST" \
+            --threshold "$THRESHOLD" \
+            > /tmp/drift.json
+          cat /tmp/drift.json
+          # Surface fields to subsequent steps.
+          {
+            echo "alert=$(jq -r '.alert' /tmp/drift.json)"
+            echo "component=$(jq -r '.component' /tmp/drift.json)"
+            echo "patch_delta=$(jq -r '.patch_delta' /tmp/drift.json)"
+            echo "threshold_used=$(jq -r '.threshold' /tmp/drift.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.alert == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
+          LATEST: ${{ steps.latest.outputs.latest }}
+          COMPONENT: ${{ steps.drift.outputs.component }}
+          PATCH_DELTA: ${{ steps.drift.outputs.patch_delta }}
+          THRESHOLD: ${{ steps.drift.outputs.threshold_used }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent). Mirrors
+          # weekly-api-update.yml: capture stdout+stderr to find the
+          # known 'already_exists' response; any other failure is loud.
+          # `gh api` writes JSON error bodies to STDOUT on non-2xx.
+          label_out=$(mktemp)
+          if ! gh api "repos/${REPO}/labels" --method POST \
+               -f name="${REVIEW_LABEL}" \
+               -f color='F9D71C' \
+               -f description='Wizard CC baseline is drifting from npm latest (ROADMAP #350)' \
+               >"$label_out" 2>&1; then
+            if grep -q 'already_exists' "$label_out"; then
+              echo "label ${REVIEW_LABEL} already exists — continuing"
+            else
+              cat "$label_out" >&2
+              rm -f "$label_out"
+              exit 1
+            fi
+          fi
+          rm -f "$label_out"
+
+          # Title and body.
+          TITLE="CC version drift: baseline v${BASELINE}, latest v${LATEST} (${PATCH_DELTA}-release gap)"
+          if [ "$COMPONENT" != "patch" ]; then
+            TITLE="CC version drift: baseline v${BASELINE}, latest v${LATEST} (${COMPONENT} jump)"
+          fi
+
+          {
+            # Machine-readable marker FIRST — used for re-comparison
+            # on next cron tick. If a future cron reads this issue back
+            # it can extract the previous baseline/latest/delta and
+            # decide whether the drift has widened.
+            echo "<!-- cc-version-drift baseline=v${BASELINE} latest=v${LATEST} delta=${PATCH_DELTA} threshold=${THRESHOLD} component=${COMPONENT} -->"
+            echo ""
+            echo "**Wizard's documented CC baseline is drifting from npm latest.**"
+            echo ""
+            if [ "$COMPONENT" = "major" ]; then
+              echo "- ⚠️  **MAJOR jump detected.** Always alert regardless of threshold."
+            elif [ "$COMPONENT" = "minor" ]; then
+              echo "- ⚠️  **SemVer-minor jump detected.** Always alert regardless of threshold."
+            else
+              echo "- Patch-release gap: **${PATCH_DELTA}** (threshold: ${THRESHOLD})"
+            fi
+            echo "- Wizard baseline: \`v${BASELINE}\` (from \`SDLC.md\` \`<!-- Claude Code Baseline: ... -->\` anchor)"
+            echo "- npm latest: \`v${LATEST}\` (\`npm view @anthropic-ai/claude-code version\`)"
+            echo ""
+            echo "## What to do"
+            echo ""
+            echo "1. Open a Claude Code session on your maintainer machine (Max subscription)."
+            echo "2. Run the changelog analysis on Max:"
+            echo "   \`\`\`bash"
+            echo "   claude --print --allowedTools \"WebFetch,Read,Bash\" \"\$(cat .github/prompts/analyze-release.md)\""
+            echo "   \`\`\`"
+            echo "3. For each new feature flagged HIGH/MEDIUM relevance, run the full SDLC loop (TDD → tests → review → PR)."
+            echo "4. Update \`SDLC.md\` — bump BOTH the \`<!-- Claude Code Baseline: ... -->\` anchor AND the \`Claude Code Recommended\` row."
+            echo "5. Close this issue. If drift recurs, the next Monday cron will open a fresh one."
+            echo ""
+            echo "## Sources"
+            echo ""
+            echo "- [Claude Code CHANGELOG (raw)](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md)"
+            echo "- [.github/prompts/analyze-release.md](.github/prompts/analyze-release.md) — local Max analysis prompt"
+            echo "- Incident context: [\`.reviews/cc-feature-inventory-2026-05-24.md\`](.reviews/cc-feature-inventory-2026-05-24.md) (the 32-version miss that motivated this workflow)"
+          } > /tmp/issue_body.md
+
+          # Find existing open issue (idempotency: edit, don't spam).
+          EXISTING=$(gh issue list \
+            --repo "${REPO}" \
+            --state open \
+            --label "${REVIEW_LABEL}" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #${EXISTING} (no new issue, no comment spam)"
+            gh issue edit "$EXISTING" \
+              --repo "${REPO}" \
+              --title "$TITLE" \
+              --body-file /tmp/issue_body.md
+            exit 0
+          fi
+
+          # No open issue. Check for the most recent closed issue —
+          # only re-open if the drift has WIDENED since close (maintainer's
+          # "won't fix for now" stays respected as long as gap is stable).
+          CLOSED=$(gh issue list \
+            --repo "${REPO}" \
+            --state closed \
+            --label "${REVIEW_LABEL}" \
+            --limit 1 \
+            --json number,body \
+            --jq '.[0] // {}')
+          CLOSED_DELTA=$(echo "$CLOSED" | jq -r '.body // ""' | grep -oE 'delta=[0-9]+' | head -1 | sed 's/delta=//' || echo '-1')
+          CLOSED_DELTA="${CLOSED_DELTA:--1}"
+          # Components other than patch always alert again; for patch,
+          # only re-open if PATCH_DELTA > closed delta.
+          if [ "$COMPONENT" != "patch" ] || [ "$PATCH_DELTA" -gt "$CLOSED_DELTA" ]; then
+            echo "Creating new tracking issue (closed delta=${CLOSED_DELTA}, current=${PATCH_DELTA}, component=${COMPONENT})"
+            gh issue create \
+              --repo "${REPO}" \
+              --title "$TITLE" \
+              --body-file /tmp/issue_body.md \
+              --label "${REVIEW_LABEL}" \
+              --label "auto-generated"
+          else
+            echo "Drift already acknowledged at closed delta=${CLOSED_DELTA}; current=${PATCH_DELTA} has not widened. Staying silent."
+          fi
+
+      - name: No drift
+        if: steps.drift.outputs.alert != 'true'
+        run: |
+          echo "No drift: baseline=${BASELINE} latest=${LATEST} delta=${PATCH_DELTA} threshold=${THRESHOLD_USED}"
+        env:
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
+          LATEST: ${{ steps.latest.outputs.latest }}
+          PATCH_DELTA: ${{ steps.drift.outputs.patch_delta }}
+          THRESHOLD_USED: ${{ steps.drift.outputs.threshold_used }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,12 @@ jobs:
       - name: Run release workflow tests
         run: ./tests/test-release-workflow.sh
 
+      - name: Run cc-drift-check script unit tests (#350)
+        run: ./tests/test-cc-drift-check.sh
+
+      - name: Run cc-version-drift workflow tests (#350)
+        run: ./tests/test-cc-version-drift.sh
+
       - name: Run domain detection tests
         run: ./tests/test-domain-detection.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-cli.sh && ./tests/test-setup-path.sh && \
    ./tests/test-docs-usability.sh && ./tests/test-plugin.sh && \
    ./tests/test-install-script.sh && ./tests/test-release-workflow.sh && \
+   ./tests/test-cc-drift-check.sh && ./tests/test-cc-version-drift.sh && \
    ./tests/test-domain-detection.sh && \
    ./tests/test-autocompact-methodology.sh && \
    ./tests/test-node24-compliance.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,6 +1,9 @@
 <!-- SDLC Wizard Version: 1.76.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
+<!-- Claude Code Baseline: v2.1.150 -->
+<!-- ROADMAP #350: this single-line anchor is the source of truth for cc-version-drift.yml. -->
+<!-- Update both this comment AND the "Claude Code Recommended" row when bumping CC support. -->
 # SDLC Configuration
 
 ## Wizard Version Tracking

--- a/scripts/cc-drift-check.sh
+++ b/scripts/cc-drift-check.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# cc-drift-check.sh — release-gap delta between two SemVer strings.
+#
+# Source: ROADMAP #350. Called from .github/workflows/cc-version-drift.yml
+# to compute whether the wizard's CC baseline has drifted far enough from
+# npm latest to open a "CC version drift" tracking issue.
+#
+# Codex design constraint (.reviews/176-followup-prio-codex.md #350.4):
+# the meaningful gap for CC is PATCH-level within a `MAJOR.MINOR.x` line
+# (e.g. 2.1.150 → 2.1.180 = 30-release gap). Naming it "minor" is wrong;
+# this script uses "patch_delta" / "release_gap".
+#
+# Output: single-line JSON to stdout. Exit codes:
+#   0 — JSON written successfully (including "below_threshold" results)
+#   2 — input invalid (non-SemVer, latest < baseline, etc.)
+#
+# JSON shape:
+#   {
+#     "baseline": "2.1.150",
+#     "latest": "2.1.180",
+#     "threshold": 5,
+#     "patch_delta": 30,
+#     "component": "patch" | "minor" | "major",
+#     "threshold_exceeded": true | false,
+#     "alert": true | false   // true on threshold_exceeded OR any minor/major jump
+#   }
+#
+# bash 3-compatible (macOS default ships bash 3.x — no associative arrays).
+
+set -eo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: cc-drift-check.sh --baseline VERSION --latest VERSION [--threshold N]
+
+Computes release-gap between two SemVer strings (vX.Y.Z or X.Y.Z).
+Default threshold is 5 (patch-level releases beyond the baseline).
+
+Exits 0 on success (JSON to stdout), 2 on invalid input.
+EOF
+    exit "${1:-1}"
+}
+
+BASELINE=""
+LATEST=""
+THRESHOLD=5
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --baseline) BASELINE="$2"; shift 2 ;;
+        --latest)   LATEST="$2";   shift 2 ;;
+        --threshold) THRESHOLD="$2"; shift 2 ;;
+        -h|--help)  usage 0 ;;
+        *) echo "::error::unknown arg: $1" >&2; usage 2 ;;
+    esac
+done
+
+if [ -z "$BASELINE" ] || [ -z "$LATEST" ]; then
+    echo "::error::--baseline and --latest are required" >&2
+    usage 2
+fi
+
+# Strip optional 'v' prefix (both 'v2.1.150' and '2.1.150' are accepted).
+strip_v() { echo "${1#v}"; }
+B=$(strip_v "$BASELINE")
+L=$(strip_v "$LATEST")
+
+# Validate threshold: non-negative integer. Anything else (empty, "foo",
+# "-3", "10.5") triggers exit 2 — silent fallback would hide config bugs.
+case "$THRESHOLD" in
+    ''|*[!0-9]*) echo "::error::--threshold must be a non-negative integer (got: '$THRESHOLD')" >&2; exit 2 ;;
+esac
+
+# Validate SemVer shape: MAJOR.MINOR.PATCH where each part is digits.
+# Refuses prerelease tags (e.g. 2.1.150-beta.1) — npm releases of CC
+# don't ship those to `latest`, and adding prerelease ordering here
+# would let bugs leak past comparisons. Be strict; reject anything else.
+validate_semver() {
+    case "$1" in
+        ''|*[!0-9.]*) return 1 ;;
+    esac
+    local maj min pat
+    maj=$(echo "$1" | cut -d. -f1)
+    min=$(echo "$1" | cut -d. -f2)
+    pat=$(echo "$1" | cut -d. -f3)
+    # All three parts must be present, non-empty, and pure digits.
+    [ -n "$maj" ] && [ -n "$min" ] && [ -n "$pat" ] \
+        && case "${maj}${min}${pat}" in *[!0-9]*) return 1 ;; esac
+}
+
+if ! validate_semver "$B"; then
+    echo "::error::invalid baseline SemVer: '$BASELINE'" >&2
+    exit 2
+fi
+if ! validate_semver "$L"; then
+    echo "::error::invalid latest SemVer: '$LATEST'" >&2
+    exit 2
+fi
+
+B_MAJ=$(echo "$B" | cut -d. -f1)
+B_MIN=$(echo "$B" | cut -d. -f2)
+B_PAT=$(echo "$B" | cut -d. -f3)
+L_MAJ=$(echo "$L" | cut -d. -f1)
+L_MIN=$(echo "$L" | cut -d. -f2)
+L_PAT=$(echo "$L" | cut -d. -f3)
+
+# Refuse to compute on regressions (latest < baseline). The wizard
+# would never set its baseline higher than npm latest deliberately, so
+# this means the workflow caller passed swapped arguments or the npm
+# detection misfired. Better to fail loud than emit a misleading
+# "negative gap is fine" JSON.
+if [ "$L_MAJ" -lt "$B_MAJ" ] \
+    || { [ "$L_MAJ" -eq "$B_MAJ" ] && [ "$L_MIN" -lt "$B_MIN" ]; } \
+    || { [ "$L_MAJ" -eq "$B_MAJ" ] && [ "$L_MIN" -eq "$B_MIN" ] && [ "$L_PAT" -lt "$B_PAT" ]; }; then
+    echo "::error::latest ($LATEST) is older than baseline ($BASELINE) — check inputs" >&2
+    exit 2
+fi
+
+COMPONENT="patch"
+PATCH_DELTA=0
+ALERT="false"
+EXCEEDED="false"
+
+if [ "$L_MAJ" -gt "$B_MAJ" ]; then
+    COMPONENT="major"
+    # Major-jump always alerts; patch delta is meaningless across major
+    # lines so report 0 and let the consumer surface "MAJOR jump".
+    PATCH_DELTA=0
+    ALERT="true"
+    EXCEEDED="true"
+elif [ "$L_MIN" -gt "$B_MIN" ]; then
+    COMPONENT="minor"
+    # Same as major: minor-jump always alerts regardless of threshold.
+    PATCH_DELTA=0
+    ALERT="true"
+    EXCEEDED="true"
+else
+    # Same major.minor line — compute true patch delta.
+    PATCH_DELTA=$(( L_PAT - B_PAT ))
+    # Codex constraint: threshold of N means "alert when delta > N";
+    # exactly N does NOT alert. Strict greater-than.
+    if [ "$PATCH_DELTA" -gt "$THRESHOLD" ]; then
+        EXCEEDED="true"
+        ALERT="true"
+    fi
+fi
+
+# Emit single-line JSON. Use printf (not echo -n) for POSIX portability
+# and to avoid bash-3 quirks with \n handling inside echo arguments.
+printf '{"baseline":"%s","latest":"%s","threshold":%d,"patch_delta":%d,"component":"%s","threshold_exceeded":%s,"alert":%s}\n' \
+    "$B" "$L" "$THRESHOLD" "$PATCH_DELTA" "$COMPONENT" "$EXCEEDED" "$ALERT"

--- a/tests/test-cc-drift-check.sh
+++ b/tests/test-cc-drift-check.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Unit tests for scripts/cc-drift-check.sh — version-delta logic
+# isolated from GitHub API calls. Per Codex design review
+# .reviews/176-followup-prio-codex.md #350.6, this is split from
+# tests/test-cc-version-drift.sh which covers the workflow YAML.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/cc-drift-check.sh"
+
+PASSED=0
+FAILED=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+# ----------------------------------------------------------------------
+# Existence
+# ----------------------------------------------------------------------
+
+test_script_exists() {
+    if [ -x "$SCRIPT" ]; then
+        pass "scripts/cc-drift-check.sh exists and is executable"
+    else
+        fail "scripts/cc-drift-check.sh missing or not executable"
+        return 1
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Happy path: same major.minor line, patch deltas
+# ----------------------------------------------------------------------
+
+test_same_version() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.150)
+    if echo "$out" | jq -e '.patch_delta == 0 and .alert == false and .threshold_exceeded == false and .component == "patch"' >/dev/null; then
+        pass "same version: patch_delta=0, alert=false"
+    else
+        fail "same version: expected no alert, got: $out"
+    fi
+}
+
+test_below_threshold() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.153)
+    if echo "$out" | jq -e '.patch_delta == 3 and .alert == false and .threshold_exceeded == false' >/dev/null; then
+        pass "below threshold: patch_delta=3 (default 5), alert=false"
+    else
+        fail "below threshold check failed: $out"
+    fi
+}
+
+test_at_threshold_no_alert() {
+    # Codex constraint: alert only when delta > threshold; exactly threshold does NOT alert.
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.155)
+    if echo "$out" | jq -e '.patch_delta == 5 and .alert == false and .threshold_exceeded == false' >/dev/null; then
+        pass "at threshold (delta=5, threshold=5): no alert (strict >)"
+    else
+        fail "at-threshold should NOT alert: $out"
+    fi
+}
+
+test_above_threshold() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.180)
+    if echo "$out" | jq -e '.patch_delta == 30 and .alert == true and .threshold_exceeded == true and .component == "patch"' >/dev/null; then
+        pass "above threshold: patch_delta=30, alert=true"
+    else
+        fail "above threshold check failed: $out"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Cross-component jumps always alert regardless of threshold
+# ----------------------------------------------------------------------
+
+test_minor_jump_always_alerts() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.2.0)
+    if echo "$out" | jq -e '.component == "minor" and .alert == true and .threshold_exceeded == true' >/dev/null; then
+        pass "minor jump alerts (component=minor, alert=true regardless of threshold)"
+    else
+        fail "minor jump should alert: $out"
+    fi
+}
+
+test_major_jump_always_alerts() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 3.0.0)
+    if echo "$out" | jq -e '.component == "major" and .alert == true and .threshold_exceeded == true' >/dev/null; then
+        pass "major jump alerts (component=major, alert=true regardless of threshold)"
+    else
+        fail "major jump should alert: $out"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 'v' prefix stripping — npm view returns '1.2.3', git tags use 'v1.2.3'
+# ----------------------------------------------------------------------
+
+test_v_prefix_baseline() {
+    local out
+    out=$("$SCRIPT" --baseline v2.1.150 --latest 2.1.180)
+    if echo "$out" | jq -e '.baseline == "2.1.150" and .patch_delta == 30' >/dev/null; then
+        pass "'v' prefix stripped from baseline"
+    else
+        fail "'v' prefix stripping failed: $out"
+    fi
+}
+
+test_v_prefix_latest() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest v2.1.180)
+    if echo "$out" | jq -e '.latest == "2.1.180" and .patch_delta == 30' >/dev/null; then
+        pass "'v' prefix stripped from latest"
+    else
+        fail "'v' prefix stripping failed: $out"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Configurable threshold
+# ----------------------------------------------------------------------
+
+test_custom_threshold_above() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.155 --threshold 3)
+    if echo "$out" | jq -e '.threshold == 3 and .alert == true' >/dev/null; then
+        pass "custom threshold=3 with delta=5: alerts"
+    else
+        fail "custom threshold path failed: $out"
+    fi
+}
+
+test_custom_threshold_below() {
+    local out
+    out=$("$SCRIPT" --baseline 2.1.150 --latest 2.1.157 --threshold 10)
+    if echo "$out" | jq -e '.threshold == 10 and .alert == false' >/dev/null; then
+        pass "custom threshold=10 with delta=7: no alert"
+    else
+        fail "custom threshold below path failed: $out"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Error paths — invalid input must exit 2, not silently default
+# ----------------------------------------------------------------------
+
+test_invalid_baseline() {
+    if "$SCRIPT" --baseline foo --latest 2.1.150 >/dev/null 2>&1; then
+        fail "invalid baseline should exit 2, got success"
+    else
+        local rc=$?
+        if [ "$rc" -eq 2 ]; then
+            pass "invalid baseline exits 2"
+        else
+            fail "invalid baseline should exit 2, got $rc"
+        fi
+    fi
+}
+
+test_invalid_latest() {
+    if "$SCRIPT" --baseline 2.1.150 --latest bar >/dev/null 2>&1; then
+        fail "invalid latest should exit 2, got success"
+    else
+        [ "$?" -eq 2 ] && pass "invalid latest exits 2" \
+            || fail "invalid latest should exit 2"
+    fi
+}
+
+test_missing_args() {
+    if "$SCRIPT" >/dev/null 2>&1; then
+        fail "no args should exit non-zero"
+    else
+        pass "no args exits non-zero"
+    fi
+}
+
+test_invalid_threshold_negative() {
+    if "$SCRIPT" --baseline 2.1.150 --latest 2.1.180 --threshold -3 >/dev/null 2>&1; then
+        fail "negative threshold should exit 2"
+    else
+        [ "$?" -eq 2 ] && pass "negative threshold exits 2" \
+            || fail "negative threshold should exit 2"
+    fi
+}
+
+test_invalid_threshold_non_integer() {
+    if "$SCRIPT" --baseline 2.1.150 --latest 2.1.180 --threshold "ten" >/dev/null 2>&1; then
+        fail "non-integer threshold should exit 2"
+    else
+        [ "$?" -eq 2 ] && pass "non-integer threshold exits 2" \
+            || fail "non-integer threshold should exit 2"
+    fi
+}
+
+test_latest_older_than_baseline() {
+    # Common misconfig: caller swapped --baseline and --latest. Must fail
+    # loud rather than emit a misleading "negative gap is fine" payload.
+    if "$SCRIPT" --baseline 2.1.180 --latest 2.1.150 >/dev/null 2>&1; then
+        fail "regression (latest < baseline) should exit 2, got success"
+    else
+        [ "$?" -eq 2 ] && pass "latest < baseline exits 2 (caller error)" \
+            || fail "latest < baseline should exit 2"
+    fi
+}
+
+test_rejects_prerelease() {
+    # CC ships clean SemVer to npm `latest`. Prerelease tags would
+    # signal a custom-built CLI or pipeline bug — fail loud.
+    if "$SCRIPT" --baseline 2.1.150 --latest 2.1.150-beta.1 >/dev/null 2>&1; then
+        fail "prerelease tag should exit 2"
+    else
+        [ "$?" -eq 2 ] && pass "prerelease tag exits 2 (out of scope)" \
+            || fail "prerelease should exit 2"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Run
+# ----------------------------------------------------------------------
+
+test_script_exists
+test_same_version
+test_below_threshold
+test_at_threshold_no_alert
+test_above_threshold
+test_minor_jump_always_alerts
+test_major_jump_always_alerts
+test_v_prefix_baseline
+test_v_prefix_latest
+test_custom_threshold_above
+test_custom_threshold_below
+test_invalid_baseline
+test_invalid_latest
+test_missing_args
+test_invalid_threshold_negative
+test_invalid_threshold_non_integer
+test_latest_older_than_baseline
+test_rejects_prerelease
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+[ "$FAILED" -gt 0 ] && exit 1
+echo "All cc-drift-check.sh unit tests passed!"

--- a/tests/test-cc-version-drift.sh
+++ b/tests/test-cc-version-drift.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# Quality tests for .github/workflows/cc-version-drift.yml and the
+# associated SDLC.md anchor — ROADMAP #350.
+#
+# Each test asserts a Codex-design-review constraint (Prove-It Gate,
+# .reviews/176-followup-prio-codex.md #350). Existence tests would
+# pass trivially against a stub; these check BEHAVIOR.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WF="$REPO_ROOT/.github/workflows/cc-version-drift.yml"
+SDLC_MD="$REPO_ROOT/SDLC.md"
+SCRIPT="$REPO_ROOT/scripts/cc-drift-check.sh"
+
+PASSED=0
+FAILED=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+
+# ----------------------------------------------------------------------
+# 1. Files exist + YAML parses
+# ----------------------------------------------------------------------
+
+test_workflow_exists() {
+    [ -f "$WF" ] && pass "cc-version-drift.yml exists" || { fail "missing"; return 1; }
+}
+
+test_yaml_valid() {
+    python3 -c "import yaml; yaml.safe_load(open('$WF'))" 2>/dev/null \
+        && pass "cc-version-drift.yml is valid YAML" \
+        || fail "invalid YAML"
+}
+
+# ----------------------------------------------------------------------
+# 2. Triggers — weekly cron + workflow_dispatch
+# ----------------------------------------------------------------------
+
+test_has_schedule() {
+    python3 -c "
+import yaml; d = yaml.safe_load(open('$WF'))
+on = d.get(True, d.get('on'))
+sched = on.get('schedule')
+assert sched and len(sched) >= 1, 'no schedule entries'
+" 2>/dev/null && pass "has schedule trigger" || fail "missing schedule trigger"
+}
+
+test_cron_is_staggered() {
+    # Codex constraint: '30 9 * * 1' (Mon 09:30 UTC), staggered from
+    # weekly-update.yml (09:00) and weekly-api-update.yml (10:00).
+    if grep -qE "cron:[[:space:]]*'30 9 \\* \\* 1'" "$WF"; then
+        pass "cron staggered at Mon 09:30 UTC (between 09:00 and 10:00 neighbors)"
+    else
+        fail "cron must be '30 9 * * 1' to stagger from existing weekly workflows"
+    fi
+}
+
+test_has_workflow_dispatch() {
+    python3 -c "
+import yaml; d = yaml.safe_load(open('$WF'))
+on = d.get(True, d.get('on'))
+assert 'workflow_dispatch' in on
+" 2>/dev/null && pass "has workflow_dispatch trigger" || fail "missing workflow_dispatch"
+}
+
+# ----------------------------------------------------------------------
+# 3. Permissions — issues: write (required) + contents: read; NO id-token
+# ----------------------------------------------------------------------
+
+test_permissions_issues_write() {
+    python3 -c "
+import yaml; d = yaml.safe_load(open('$WF'))
+p = d.get('permissions', {})
+assert p.get('issues') == 'write', 'permissions.issues must be write'
+assert p.get('contents') == 'read', 'permissions.contents must be read'
+" 2>/dev/null && pass "permissions: issues: write + contents: read" \
+        || fail "permissions must declare 'issues: write' and 'contents: read'"
+}
+
+test_no_id_token() {
+    # Match active code only (allow explanatory comments).
+    if grep -qE '^[[:space:]]*[^#[:space:]].*id-token:[[:space:]]*write' "$WF"; then
+        fail "id-token: write must not be declared (no OIDC consumer)"
+    else
+        pass "no active id-token: write declaration"
+    fi
+}
+
+test_no_pull_requests_write() {
+    if grep -qE '^[[:space:]]*[^#[:space:]].*pull-requests:[[:space:]]*write' "$WF"; then
+        fail "pull-requests: write should not be declared (this workflow doesn't open PRs)"
+    else
+        pass "no pull-requests: write (only opens issues)"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 4. NOT in weekly-update.yml — standalone (Codex constraint #350.1)
+# ----------------------------------------------------------------------
+
+test_not_in_weekly_update_yml() {
+    local weekly="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if grep -qE 'cc-version-drift|cc-drift-check\.sh|Claude Code Baseline' "$weekly" 2>/dev/null; then
+        fail "weekly-update.yml mentions CC drift logic — must stay standalone (#212/#231 guardrails)"
+    else
+        pass "drift detection lives in standalone workflow, not weekly-update.yml"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 5. No LLM / no Anthropic action — pure GH-API + curl
+# ----------------------------------------------------------------------
+
+test_no_claude_code_action() {
+    if grep -qE '^[[:space:]]*[^#[:space:]].*anthropics/claude-code-action' "$WF"; then
+        fail "must not use anthropics/claude-code-action (zero-API requirement, ROADMAP #231)"
+    else
+        pass "no anthropics/claude-code-action (zero-API)"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 6. SDLC.md baseline anchor (Codex constraint #350.2)
+# ----------------------------------------------------------------------
+
+test_sdlc_baseline_anchor_present() {
+    if grep -qE '<!-- Claude Code Baseline: v?[0-9]+\.[0-9]+\.[0-9]+ -->' "$SDLC_MD"; then
+        pass "SDLC.md has single-purpose '<!-- Claude Code Baseline: vX.Y.Z -->' anchor"
+    else
+        fail "SDLC.md must contain '<!-- Claude Code Baseline: vX.Y.Z -->' anchor for the cron to parse"
+    fi
+}
+
+test_sdlc_baseline_exactly_once() {
+    local count
+    count=$(grep -cE '<!-- Claude Code Baseline: v?[0-9]+\.[0-9]+\.[0-9]+ -->' "$SDLC_MD")
+    if [ "$count" = "1" ]; then
+        pass "exactly one CC Baseline anchor in SDLC.md (unambiguous)"
+    else
+        fail "expected 1 CC Baseline anchor in SDLC.md, found $count"
+    fi
+}
+
+test_baseline_matches_recommended_row() {
+    # Codex constraint: anchor must match the first SemVer in the
+    # "Claude Code Recommended" row so they don't drift internally.
+    local anchor row
+    anchor=$(grep -oE '<!-- Claude Code Baseline: v?[0-9]+\.[0-9]+\.[0-9]+ -->' "$SDLC_MD" | head -1 \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+    row=$(grep -E '^\| Claude Code Recommended' "$SDLC_MD" | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+    if [ -n "$anchor" ] && [ -n "$row" ] && [ "$anchor" = "$row" ]; then
+        pass "Baseline anchor (v${anchor}) matches Recommended row (v${row})"
+    else
+        fail "Baseline anchor (v${anchor:-MISSING}) must match Claude Code Recommended row (v${row:-MISSING})"
+    fi
+}
+
+test_workflow_parses_anchor() {
+    # Workflow must grep the anchor with the exact format we ship.
+    if grep -qE 'Claude Code Baseline' "$WF"; then
+        pass "workflow parses '<!-- Claude Code Baseline: ... -->' from SDLC.md"
+    else
+        fail "workflow must reference 'Claude Code Baseline' anchor name"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 7. Label + idempotency — edit existing, dedupe via label
+# ----------------------------------------------------------------------
+
+test_label_name() {
+    # Match 'cc-version-drift' or "cc-version-drift" after REVIEW_LABEL:.
+    # Use grep -F-style literal substring inside a wider grep -E to dodge
+    # bash quote-escape interactions inside the alternation class.
+    if grep -E "REVIEW_LABEL:[[:space:]]*['\"]cc-version-drift['\"]" "$WF" >/dev/null 2>&1; then
+        pass "uses label 'cc-version-drift'"
+    else
+        fail "must declare REVIEW_LABEL: 'cc-version-drift'"
+    fi
+}
+
+test_edit_existing_not_comment() {
+    # If an open issue exists, edit it (do NOT post a comment). Comment-
+    # spam pattern would be `gh issue comment`.
+    if grep -qE 'gh issue edit' "$WF" && ! grep -qE 'gh issue comment' "$WF"; then
+        pass "edits existing issue instead of comment-spamming"
+    else
+        fail "must use 'gh issue edit' on existing open issue; must NOT use 'gh issue comment'"
+    fi
+}
+
+test_machine_readable_marker_in_body() {
+    # Marker format from Codex pseudocode: cc-version-drift baseline=... latest=... delta=... threshold=... component=...
+    if grep -qE 'cc-version-drift baseline=' "$WF"; then
+        pass "issue body contains machine-readable marker (baseline=/latest=/delta=)"
+    else
+        fail "issue body must contain machine-readable marker for re-comparison on next cron"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 8. Threshold configurability
+# ----------------------------------------------------------------------
+
+test_threshold_default_5() {
+    if grep -qE "CC_DRIFT_THRESHOLD:[[:space:]]*'5'" "$WF"; then
+        pass "default threshold is 5 (env var, in-git policy)"
+    else
+        fail "must default CC_DRIFT_THRESHOLD to '5'"
+    fi
+}
+
+test_threshold_input_override() {
+    # Workflow_dispatch should allow ad-hoc threshold override.
+    if grep -qE 'threshold:' "$WF" && grep -qE 'inputs\.threshold' "$WF"; then
+        pass "workflow_dispatch accepts threshold input override"
+    else
+        fail "must allow workflow_dispatch input to override threshold"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 9. Script integration
+# ----------------------------------------------------------------------
+
+test_invokes_drift_script() {
+    if grep -qE 'scripts/cc-drift-check\.sh' "$WF"; then
+        pass "workflow invokes scripts/cc-drift-check.sh (logic is unit-tested in test-cc-drift-check.sh)"
+    else
+        fail "workflow must call scripts/cc-drift-check.sh for version-delta logic"
+    fi
+}
+
+test_drift_script_exists_and_executable() {
+    if [ -x "$SCRIPT" ]; then
+        pass "scripts/cc-drift-check.sh exists and is executable"
+    else
+        fail "scripts/cc-drift-check.sh must exist and be executable"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# 10. Fail loud — no `|| true` suppression
+# ----------------------------------------------------------------------
+
+test_no_silent_failures() {
+    # Look for `|| true` or `|| echo` in ACTIVE code (not comments)
+    # that would suppress gh/npm/jq failures. These are bug-magnets per
+    # #231 lessons. Codex constraint #350.8 explicitly forbids them.
+    # The workflow's HEADER comment names these patterns to explain WHY
+    # they're absent — that documentation should not trip the test, so
+    # we anchor on uncommented lines using the same pattern as
+    # test_no_node_auth_token in tests/test-release-dry-run-workflow.sh.
+    local hits
+    hits=$(grep -E '^[[:space:]]*[^#[:space:]].*\|\|[[:space:]]*(true|echo)' "$WF" 2>/dev/null || true)
+    if [ -z "$hits" ]; then
+        pass "no active || true / || echo failure-suppression (comments allowed)"
+        return
+    fi
+    # Allow ONE exception: closed-issue marker parsing has a sentinel
+    # default that intentionally falls back when the marker is missing
+    # (first cron run after introducing the marker format). Allow
+    # `|| echo '-1'` ONLY.
+    local non_sentinel
+    non_sentinel=$(echo "$hits" | grep -vE "echo '-1'" || true)
+    if [ -z "$non_sentinel" ]; then
+        pass "no active || true / || echo (one sentinel echo '-1' exception accepted)"
+    else
+        fail "found || true / || echo suppression in active code: $non_sentinel"
+    fi
+}
+
+# ----------------------------------------------------------------------
+# Run
+# ----------------------------------------------------------------------
+
+test_workflow_exists
+test_yaml_valid
+test_has_schedule
+test_cron_is_staggered
+test_has_workflow_dispatch
+test_permissions_issues_write
+test_no_id_token
+test_no_pull_requests_write
+test_not_in_weekly_update_yml
+test_no_claude_code_action
+test_sdlc_baseline_anchor_present
+test_sdlc_baseline_exactly_once
+test_baseline_matches_recommended_row
+test_workflow_parses_anchor
+test_label_name
+test_edit_existing_not_comment
+test_machine_readable_marker_in_body
+test_threshold_default_5
+test_threshold_input_override
+test_invokes_drift_script
+test_drift_script_exists_and_executable
+test_no_silent_failures
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+[ "$FAILED" -gt 0 ] && exit 1
+echo "All cc-version-drift workflow tests passed!"


### PR DESCRIPTION
## Summary

ROADMAP #350: the fix for the exact gap that let native \`/goal\` (CC v2.1.139) slip past for 32 versions / 5 weeks. Pure GH-API detector — no LLM, no API spend. Mirrors weekly-api-update.yml shepherd pattern.

## What's in the box

| File | Purpose |
|---|---|
| \`scripts/cc-drift-check.sh\` | Version-delta logic. Bash 3 compatible. JSON output. Strict > on threshold. Major/minor jumps always alert. Refuses prerelease tags and regressions. |
| \`.github/workflows/cc-version-drift.yml\` | Mon 09:30 UTC cron + workflow_dispatch. Parses SDLC.md anchor → npm view → script → idempotent issue. |
| \`tests/test-cc-drift-check.sh\` | 18 unit tests for the script (same/below/at/above threshold, minor/major jumps, v-prefix, custom threshold, all error paths). |
| \`tests/test-cc-version-drift.sh\` | 22 quality tests for the workflow (triggers, permissions, label, marker, idempotency pattern, baseline-anchor match, no LLM/no id-token/no silent failures). |
| \`SDLC.md\` | Adds \`<!-- Claude Code Baseline: v2.1.150 -->\` anchor + maintainer note. |

## Cross-model design (Codex gpt-5.5 xhigh, .reviews/176-followup-prio-codex.md)

Codex caught 3 things I had wrong:

1. **Standalone, NOT extending weekly-update.yml.** The handoff claimed weekly-update.yml runs $0 cron — actually FALSE: cron is commented out, tests assert \`issues: write\` is absent (deliberate #212/#231 guardrails). Reversing would require deliberate test/doc rewrites.
2. **"Patch gap" not "minor versions".** v2.1.150 → v2.1.180 is a SemVer patch delta, not a minor delta. Workflow text says "release gap" / "patch gap" consistently.
3. **Idempotency via machine marker.** Issue body contains \`<!-- cc-version-drift baseline=... latest=... delta=... threshold=... component=... -->\` so the next cron tick can re-compare against the closed issue without parsing free-form text.

## Key behaviors

- **Single open issue at a time.** Workflow edits existing open issue instead of comment-spamming.
- **Respects "won't fix for now".** If a closed issue exists with delta=N and current delta ≤ N, stays silent. Only re-opens if drift WIDENED.
- **Major/minor jumps always alert** regardless of threshold (semver-significant changes shouldn't wait for patch-count to accumulate).
- **Fail loud.** No \`|| true\` or \`|| echo\` suppression except ONE sentinel for missing-marker fallback (tested).

## Test plan

- [x] TDD RED on both test suites before workflow + script existed
- [x] TDD GREEN: 18/18 unit, 22/22 workflow, 40/40 doc-consistency
- [x] Wired both new tests into ci.yml + CONTRIBUTING.md
- [ ] CI \`validate\` green on this PR

## Follow-up

After this lands + v1.77.0 release bundles A1+#350, the cron starts firing Mon 09:30 UTC. First firing should be silent (baseline=2.1.150, latest≈2.1.150). Real test: bump CC, observe next Monday's cron either silent (if delta ≤5) or opens an issue.