### PR TITLE
feat(sdlc): /goal SDLC-discipline gates — 95% confidence floor + DLC binding (PR-D)

### DIFF
--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -110,7 +110,7 @@ Use plan mode for: multi-file changes, new features, LOW confidence, bugs needin
 
 ## Long-Running Goals (`/goal`)
 
-Native `/goal <condition>` (**requires v2.1.143+**). Haiku evaluator re-checks transcript per turn. **Pre-flight:** trusted workspace; `disableAllHooks`/`allowManagedHooksOnly` both off (it's a Stop hook). **Condition = SDLC contract:** measurable end state + check + constraints + hard turn/time bound (no native cap); e.g. `/goal "npm test=0, stop after 20 turns"`. **Anti-pattern:** evaluator **cannot call tools** — judges transcript only; don't use for off-transcript work. `--resume` resets counters.
+Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript per turn. **Confidence gate — NEVER invoke below HIGH 95%**; below that the evaluator rubber-stamps flailing as progress. **DLC binding — condition MUST name the DLC** (`/sdlc`, `/gdlc`, `/ldlc`, etc.) so the evaluator anchors on "doing it right." **Pre-flight:** trusted workspace; `disableAllHooks`/`allowManagedHooksOnly` both off. **Condition = contract:** end state + check + constraints + hard turn/time bound (no native cap); e.g. `/goal "tests pass + clean tree following /sdlc, stop after 20 turns"`. **Anti-pattern:** evaluator can't call tools — transcript-only. `--resume` resets counters.
 
 ## Recommended Model
 
@@ -141,7 +141,7 @@ PROTOCOL is universal across domains; only `review_instructions` and `verificati
 
 **Convergence:** 2 rounds sweet spot, 3 max (research: 14 repos + 7 papers). After 3 still NOT CERTIFIED → escalate.
 
-**Multi-reviewer / non-code domains:** when running multiple reviewers in parallel (e.g. Claude review + Codex + human), respond per-reviewer (different blind spots, no shared anchoring). For non-code domains (research, persuasion, medical), keep the same handoff format and add `"audience"` + `"stakes"` keys.
+**Multi-reviewer:** parallel reviewers → respond per-reviewer (different blind spots, no shared anchoring). **Non-code domains:** same handoff + add `"audience"`/`"stakes"` keys.
 
 ### Release Review Focus
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -817,10 +817,15 @@ test_sdlc_skill_has_goal_wrapper() {
     grep -qiE 'trusted|untrusted' "$SKILL" || missing+=" trusted-workspace-preflight"
     grep -qF 'disableAllHooks' "$SKILL" || missing+=" disableAllHooks-preflight"
     grep -qiE 'turn(/| )?time bound|hard.*bound|stop after' "$SKILL" || missing+=" hard-bound-guidance"
-    grep -qiE 'evaluator.*not call tools|evaluator can.*not.*tool|cannot run tools|cannot call tools' "$SKILL" || missing+=" anti-pattern-off-transcript"
+    grep -qiE 'cannot call tools|can.t call tools|transcript[ -]only' "$SKILL" || missing+=" anti-pattern-off-transcript"
     grep -qiE 'resume.*reset|--resume.*counters|counters.*reset' "$SKILL" || missing+=" resume-caveat"
+    # PR-D additions: 95% confidence gate + DLC binding in condition.
+    # Without these, /goal becomes "20 turns of flailing" — the evaluator
+    # has no anchor for correctness, only for completion.
+    grep -qiE 'confidence gate|HIGH 95%|below.*95%|95%.*confidence' "$SKILL" || missing+=" 95-percent-confidence-gate"
+    grep -qiE 'DLC binding|name the (active )?DLC|condition MUST name' "$SKILL" || missing+=" DLC-binding-rule"
     if [ -z "$missing" ]; then
-        pass "skills/sdlc/SKILL.md /goal wrapper has all required quality elements (#347)"
+        pass "skills/sdlc/SKILL.md /goal wrapper has all required quality elements (#347 + PR-D)"
     else
         fail "skills/sdlc/SKILL.md /goal wrapper missing:$missing"
     fi


### PR DESCRIPTION
## Summary

Native \`/goal\` is now table-stakes across CC (v2.1.139+), Codex CLI, and likely others. Without SDLC discipline baked into the goal CONDITION itself, the Haiku evaluator rubber-stamps "did the agent flail for 20 turns" instead of "is the goal met correctly."

This PR extends the /goal wrapper in \`/sdlc\` skill with two new load-bearing gates.

## The two new rules

### 1. Confidence gate — NEVER invoke \`/goal\` below HIGH 95%

Mirrors the existing Confidence Check rule. Below 95%, plan first, then \`/goal\`. The evaluator has no anchor for "is this correct"; only for "did the agent stop." Invoking at MEDIUM/LOW lets the evaluator certify wishful thinking.

### 2. DLC binding — condition MUST name the active DLC

\`/sdlc\` for code, \`/gdlc\` for games, \`/ldlc\` for legal, etc. Without the DLC name in the condition string, the evaluator anchors on completion only ("did the work end") instead of correctness ("did it follow the contract").

**Example:**

```
/goal "tests pass + clean tree following /sdlc, stop after 20 turns"
```

The "following /sdlc" clause makes the evaluator judge SDLC compliance per turn, not just task completion.

## Why now

Native \`/goal\` shipped in CC v2.1.139 (~mid-May 2026), missed by wizard's autoupdate pipeline (the gap #350 fixes). Now that it's universal across agentic tools, anchoring it in SDLC discipline is the right wizard play — turns a "let it cook" primitive into a "let it cook properly" primitive.

## What changed

- \`skills/sdlc/SKILL.md\` — two new rules in the \`## Long-Running Goals (/goal)\` section
- \`tests/test-doc-consistency.sh::test_sdlc_skill_has_goal_wrapper\` — extended grep to enforce both new keywords (\`95%\`/\`confidence gate\` + \`DLC binding\`/\`name the DLC\`)
- Compensating trims to stay under #236 5K-token cap: condensed /goal example, collapsed Multi-reviewer paragraph

## Test plan

- [x] 40/40 \`test-doc-consistency.sh\` (new test_sdlc_skill_has_goal_wrapper checks 9 keywords now: section-header, version-floor, trusted-workspace, disableAllHooks, hard-bound, anti-pattern, resume-caveat, 95%-confidence-gate, DLC-binding)
- [x] 10/10 \`test-audit-session-load.sh\` (skill at 4989/5000 tokens — under cap)
- [ ] CI \`validate\` green