### PR TITLE
docs(sdlc): bump CC baseline v2.1.150 → v2.1.159 (closes #367, refs #368)

### DIFF
--- a/SDLC.md
+++ b/SDLC.md
@@ -1,7 +1,7 @@
 <!-- SDLC Wizard Version: 1.77.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
-<!-- Claude Code Baseline: v2.1.150 -->
+<!-- Claude Code Baseline: v2.1.159 -->
 <!-- ROADMAP #350: this single-line anchor is the source of truth for cc-version-drift.yml. -->
 <!-- Update both this comment AND the "Claude Code Recommended" row when bumping CC support. -->
 # SDLC Configuration
@@ -11,9 +11,9 @@
 | Property | Value |
 |----------|-------|
 | Wizard Version | 1.77.0 |
-| Last Updated | 2026-05-24 |
+| Last Updated | 2026-06-01 |
 | Claude Code Minimum | v2.1.111+ (required for Opus 4.7 / `opus[1m]`); v2.1.105+ for `PreCompact` hook |
-| Claude Code Recommended | v2.1.150+ (latest at 2026-05-24) — unlocks native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
+| Claude Code Recommended | v2.1.159+ (latest at 2026-06-01) — unlocks Opus 4.8 (v2.1.154 — wizard holds on 4.7 pending #365 A/B), `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
 | Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |
 | Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |
 


### PR DESCRIPTION
## Summary

`cc-version-drift.yml` (PR #354) opened #367 when our `<!-- Claude Code Baseline -->` marker fell 9 versions behind npm latest. Review of v2.1.151–v2.1.159 changelog and selective adoption of wizard-relevant features.

## Per-release classification

| Version | Wizard-relevant? | Decision |
|---|---|---|
| v2.1.151 | n/a (skipped — not in changelog) | none |
| v2.1.152 | Maybe (hook event additions, unspecified) | note in baseline row |
| v2.1.153 | No (plugin marketplace internal) | none |
| v2.1.154 | **YES** — Opus 4.8 here, defaults to high effort, dynamic workflows, 4.8 fast mode cost reductions | note availability; **hold model recommendation per #365 A/B** |
| v2.1.155 | n/a (skipped) | none |
| v2.1.156 | No (bug fix for 4.8 thinking blocks) | none |
| v2.1.157 | **YES** — `.claude/skills` plugin auto-load (no marketplace), `claude plugin init` scaffold, `agent` field in settings.json honored, `tool_decision` telemetry includes `tool_parameters` with `OTEL_LOG_TOOL_DETAILS=1`, EnterWorktree mid-session switching, worktrees unlocked when agent finishes | note in baseline row; no code change (our skills already live in `.claude/skills/`, telemetry is opt-in) |
| v2.1.158 | No (Bedrock/Vertex/Foundry auto mode via `CLAUDE_CODE_ENABLE_AUTO_MODE=1`) | none |
| v2.1.159 | No (internal infra only) | none |

## Why minimal-adoption is the right call here

- **`.claude/skills` auto-load** (v2.1.157): our skills already live there via `cli/init.js`. CC's runtime behavior change doesn't require any wizard code change — users get the auto-load for free.
- **Opus 4.8** (v2.1.154): per #365's gate-2 deferral. Sentiment is converging positive but the system-card-flagged prompt-injection regression (Gray Swan +60% vs 4.7) hits wizard hook-heavy use. Model recommendation stays at 4.7 until A/B parity proven.
- **`tool_decision` telemetry** (v2.1.157): opt-in observability via env var, not a wizard mandate. Noted for users who want it.
- Everything else is bug fixes, deployment-channel additions, or internal CC infra — out of wizard scope.

## Companion #368 triage

12 entries total: **10 duplicates from #359** (already closed last week with the same triage outcome) + **2 new**:

- **2026-05-29** — Managed Agents (webhooks, multi-agent, self-hosted sandboxes): **no-op** — managed-agents API path, not CC wizard.
- **2026-05-28** — Opus 4.8 launch: **already tracked via #365**.

Deprecation re-verification (zero usage in repo):
- `context-1m-2025-08-07` — 0 hits
- `claude-3-haiku-20240307` — 0 hits
- `managed-agents-2026-04-01` header — 0 hits

#368 will be closed with the triage comment after merge.

## Verification

- **Drift workflow goes silent**: `scripts/cc-drift-check.sh --baseline v2.1.159 --latest 2.1.159` returns `alert:false threshold_exceeded:false`. Post-merge `cc-version-drift.yml` cron will skip the issue-update step.
- **Test plan**:
  - [x] `tests/test-cc-drift-check.sh` — 18/18
  - [x] `tests/test-cc-version-drift.sh` — 22/22
  - [x] `tests/test-doc-consistency.sh` — 41/41
  - [x] `tests/test-self-update.sh` — 153/153
  - [x] `tests/test-hooks.sh` — 160/160
  - [x] `tests/test-docs-usability.sh` — 29/29
  - [ ] CI green on `validate`
  - [ ] Squash-merge
  - [ ] Manual `gh workflow run cc-version-drift.yml` post-merge to verify silent

## Closes

- Closes #367