### PR TITLE
feat(model): bump recommendation Opus 4.7 → 4.8 + v1.78.0 (closes #365)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.77.0",
+      "version": "1.78.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.78.0] - 2026-06-02
+
+### Changed
+
+- **Bumped recommended model from Opus 4.7 → Opus 4.8** (closes #365). Opus 4.8 launched 2026-05-28; day 5 in-the-wild sentiment settled positive, proof-of-life via `claude --print --model claude-opus-4-8` confirmed reachability, and the `opus[1m]` alias auto-resolves to latest Opus on CC v2.1.154+ (no settings.json template change needed — alias does the work). Updated prose across `SDLC.md` (Recommended Model row + effort warning), `CLAUDE_CODE_SDLC_WIZARD.md` (~11 mentions in effort table + autocompact + mixed-mode tier + 1M-context section), `skills/sdlc/SKILL.md`, `skills/setup/SKILL.md` (mixed-mode + flagship tier suggestions), `skills/update/SKILL.md`, `hooks/model-effort-check.sh` (warning text), and `cli/lib/repo-complexity.js` (tier comments). Min CC bumped v2.1.111+ → v2.1.154+ (required to resolve `opus[1m]` to 4.8). Effort semantics preserved — strict effort behavior introduced in 4.7 carried forward to 4.8, so `max` remains the recommended default and `xhigh` the floor.
+
+### Notes
+
+- **Un-run gates 2+3 tracked as post-deploy follow-up obligations on #365.** Gate 2 (A/B coder quality vs 4.7 on real PRs) and Gate 3 (dogfood for 24h before bump) were both deferred. If real-world use surfaces the system-card-flagged regressions for 4.8 — prompt-injection +60% on Gray Swan, file-deletion tendency, or eval-awareness affecting wizard output — revert via a single PR that flips the 4.7↔4.8 prose. Settings.json template unchanged means revert is prose-only.
+
 ## [1.77.0] - 2026-05-24
 
 ### Added

--- a/CI_CD.md
+++ b/CI_CD.md
@@ -250,7 +250,7 @@ The `review` job is **skipped on `BaseInfinity/claude-sdlc-wizard` self-PRs** �
 
 ## Local Codex Audit of CI Logs (Cross-Model)
 
-The GH `pr-review.yml` workflow uses Claude Opus 4.7. For adversarial diversity, the local shepherd loop runs a **second pass with Codex xhigh** against the CI logs themselves — not just the code. A second model catches things the first missed (silent test exclusions, degraded E2E scores on a green checkmark, warnings promoted to errors in a later version).
+The GH `pr-review.yml` workflow uses Claude Opus 4.8 (via `claude-code-action@v1` default). For adversarial diversity, the local shepherd loop runs a **second pass with Codex xhigh** against the CI logs themselves — not just the code. A second model catches things the first missed (silent test exclusions, degraded E2E scores on a green checkmark, warnings promoted to errors in a later version).
 
 ```bash
 # After CI reports pass/fail:

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -249,26 +249,26 @@ When Anthropic provides official plugins or tools that handle something:
 
 Claude Code's **effort level** controls how much thinking the model does before responding. Higher effort = deeper reasoning but more tokens.
 
-> ⚠️ **On Opus 4.7, effort below `xhigh` breaks SDLC compliance in practice.** Unlike 4.6, Opus 4.7 respects effort levels *strictly* — at `high` or below it scopes work tighter (shallow reasoning, skipped TDD, no self-review) rather than going above-and-beyond. Treat the table below accordingly: **`max` is the recommended default, `xhigh` is the floor**, `high` or below is for trivial grep/search subagents only.
+> ⚠️ **On Opus 4.8, effort below `xhigh` breaks SDLC compliance in practice.** Inherited from 4.7, Opus 4.8 respects effort levels *strictly* — at `high` or below it scopes work tighter (shallow reasoning, skipped TDD, no self-review) rather than going above-and-beyond. Treat the table below accordingly: **`max` is the recommended default, `xhigh` is the floor**, `high` or below is for trivial grep/search subagents only.
 
 | Level | When to Use | How to Set |
 |-------|-------------|------------|
-| `high` or below | **Not for SDLC work on Opus 4.7.** Only for trivial grep/search subagents or one-shot questions that don't require planning | `effort: high` in a specific subagent frontmatter only |
-| `xhigh` | **Floor for SDLC work on Opus 4.7.** Long-running tasks, repeated tool calls, deep exploration. Claude Code defaults to this on Opus 4.7 | `/effort xhigh` or set in skill frontmatter |
-| `max` | **Recommended default for Opus 4.7 SDLC work.** Multi-file changes, architecture decisions, debugging, cross-model reviews, any task touching wizard/skill/CI code | `/effort max` (session only — resets next session) |
+| `high` or below | **Not for SDLC work on Opus 4.8.** Only for trivial grep/search subagents or one-shot questions that don't require planning | `effort: high` in a specific subagent frontmatter only |
+| `xhigh` | **Floor for SDLC work on Opus 4.8.** Long-running tasks, repeated tool calls, deep exploration. Claude Code defaults to this on Opus 4.7+ | `/effort xhigh` or set in skill frontmatter |
+| `max` | **Recommended default for Opus 4.8 SDLC work.** Multi-file changes, architecture decisions, debugging, cross-model reviews, any task touching wizard/skill/CI code | `/effort max` (session only — resets next session) |
 
-**Effort level changes in Opus 4.7 (April 2026):**
-- **`xhigh` is new** — sits between `high` and `max`, designed for coding and agentic work (30+ minute tasks with token budgets in the millions)
-- **Claude Code now defaults to `xhigh`** on Opus 4.7 for all plans
-- **Opus 4.7 respects effort levels more strictly** than 4.6 — at lower levels it scopes work tighter instead of going above and beyond. If you see shallow reasoning, raise effort rather than prompting around it
-- **`budget_tokens` is deprecated** on Opus 4.7 — use adaptive thinking with effort instead
+**Strict effort behavior (Opus 4.7+, carried forward to 4.8):**
+- **`xhigh` was introduced in 4.7** — sits between `high` and `max`, designed for coding and agentic work (30+ minute tasks with token budgets in the millions)
+- **Claude Code defaults to `xhigh`** on Opus 4.7+ for all plans
+- **Opus 4.7+ respects effort levels more strictly** than 4.6 — at lower levels it scopes work tighter instead of going above and beyond. If you see shallow reasoning, raise effort rather than prompting around it
+- **`budget_tokens` is deprecated** on Opus 4.7+ — use adaptive thinking with effort instead
 - When running at `xhigh` or `max`, set a large `max_tokens` (64k+) so the model has room to think across subagents and tool calls
 
 **Why `high` was the previous default:** Claude Code uses **adaptive thinking** to dynamically allocate reasoning budget per turn. On Pro and Max plans, the default effort level was **medium (85)**, which causes the model to under-allocate reasoning on complex multi-step tasks — leading to shallow analysis, missed edge cases, and "lazy" outputs. This was [confirmed by Anthropic engineer Boris Cherny](https://github.com/anthropics/claude-code/issues/42796) and is documented at [code.claude.com](https://code.claude.com/docs/en/model-config). API, Team, and Enterprise plans default to high effort and are not affected.
 
 **Don't rely on the CC default — set effort yourself.** Anthropic's [2026-04-23 post-mortem](https://www.anthropic.com/engineering/april-23-postmortem) is independent third-party evidence that CC has flipped reasoning_effort defaults across versions (high → medium → xhigh/high). The default has changed before and will change again. The wizard's `model-effort-check.sh` hook nudges to `xhigh`/`max` at session start specifically because the in-product default is not load-bearing — it can shift release-to-release without notice. Set `/effort max` explicitly every session you do SDLC work, and treat any "I assumed the default was X" reasoning as a bug.
 
-The `/sdlc` skill sets `effort: high` in its frontmatter as a baseline, overriding the medium default on every SDLC invocation. **On Opus 4.7, run `/effort max` at session start** — the frontmatter is a floor, not a ceiling, and `max` is where SDLC-compliant work actually happens on 4.7.
+The `/sdlc` skill sets `effort: high` in its frontmatter as a baseline, overriding the medium default on every SDLC invocation. **On Opus 4.8, run `/effort max` at session start** — the frontmatter is a floor, not a ceiling, and `max` is where SDLC-compliant work actually happens on 4.8.
 
 **Nuclear option — disable adaptive thinking entirely:** Set `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` in your environment or settings.json `env` block. This forces a fixed reasoning budget per turn instead of letting the model dynamically allocate. Use this if you observe persistent quality issues even with `effort: high`. See [Claude Code model config docs](https://code.claude.com/docs/en/model-config) for details.
 
@@ -966,7 +966,7 @@ Override the default auto-compact threshold with environment variables. These ar
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Trigger compaction at this % of context capacity (1-100) | ~95% |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | Override context capacity in tokens (useful for 1M models) | Model default |
 
-**Opt-in (issue #198):** The SDLC Wizard CLI ships `.claude/settings.json` with **no** `model` or `env` pin so Claude Code's auto-mode stays enabled. The setup skill's Step 9.5 asks whether to opt into `"model": "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (tuned for the 1M window — compacts at ~300K). Default answer is **No**. Pinning the model at the top level tells Claude Code you've explicitly chosen a model and turns off per-turn model auto-selection — a real tradeoff, so we ask. Power users who want guaranteed Opus 4.7 + 1M context answer yes.
+**Opt-in (issue #198):** The SDLC Wizard CLI ships `.claude/settings.json` with **no** `model` or `env` pin so Claude Code's auto-mode stays enabled. The setup skill's Step 9.5 asks whether to opt into `"model": "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (tuned for the 1M window — compacts at ~300K). Default answer is **No**. Pinning the model at the top level tells Claude Code you've explicitly chosen a model and turns off per-turn model auto-selection — a real tradeoff, so we ask. Power users who want guaranteed Opus 4.8 + 1M context answer yes.
 
 To opt in by hand, edit `.claude/settings.json`:
 
@@ -1021,13 +1021,13 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 **Why `opus[1m]` is opt-in (issue #198):**
 - **Pinning disables auto-mode.** Max-plan users pay for Claude Code's per-turn model selection (Sonnet for cheap tasks, Opus for hard ones, plus weekly-limit smoothing). A top-level `model` gives that up.
 - **The 1M headroom has to earn it.** If your typical session stays under 150K, you're giving up auto-mode for headroom you're not using.
-- **Power users who want guaranteed Opus 4.7 + 1M** — go ahead, it's a real win for long shepherding sessions. Just make it a conscious choice, not a silent default.
+- **Power users who want guaranteed Opus 4.8 + 1M** — go ahead, it's a real win for long shepherding sessions. Just make it a conscious choice, not a silent default.
 
-**Opt in when:** you routinely cross 100K tokens in a single session (plan → TDD → review → CI shepherd on one feature), you want Opus 4.7 specifically (not Sonnet), and you're OK losing auto-mode.
+**Opt in when:** you routinely cross 100K tokens in a single session (plan → TDD → review → CI shepherd on one feature), you want Opus 4.8 specifically (not Sonnet), and you're OK losing auto-mode.
 
 **Stay on auto-mode (default) when:** you're unsure, your work is mixed short/long, or you want Claude Code to do the model math for you.
 
-**How to opt in:** run `/model opus[1m]` in your session (transient), or set `"model": "opus[1m]"` in `.claude/settings.json` (persistent). Requires Claude Code v2.1.111+ for Opus 4.7. The setup wizard's Step 9.5 also asks once, with default No.
+**How to opt in:** run `/model opus[1m]` in your session (transient), or set `"model": "opus[1m]"` in `.claude/settings.json` (persistent). Requires Claude Code v2.1.154+ for Opus 4.8 (the `opus[1m]` alias auto-resolves to the latest Opus). The setup wizard's Step 9.5 also asks once, with default No.
 
 **How to opt out:** remove the `model` line from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
 
@@ -1037,14 +1037,14 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 
 ### Mixed-Mode Tier (Sonnet coder + Opus reviewer, roadmap #233)
 
-For trivial / blank / config-only / CRUD-style repos, full Opus 4.7 on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
+For trivial / blank / config-only / CRUD-style repos, full Opus 4.8 on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
 
 **The split:**
 
 | Layer | Mixed-mode tier | Flagship tier |
 |-------|----------------|---------------|
 | Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
-| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) | gpt-5.5 xhigh (or Opus 4.7 max via Bash) |
+| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.8 max via Bash) | gpt-5.5 xhigh (or Opus 4.8 max via Bash) |
 | Effort floor (CC session) | xhigh; max preferred | xhigh; max preferred |
 
 The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
@@ -1058,7 +1058,7 @@ The reviewer always stays at flagship — the whole point of mixed-mode is that 
 **When to stay flagship:**
 - Stakes-flagged repo: anywhere `.env` / `secrets/` / `credentials/` exists. Force flagship even if LOC is tiny — leaks are catastrophic
 - Architecture work, debugging non-obvious bugs, security review, anything where the *coder's* judgment matters as much as the reviewer's
-- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.7 fits the window better in a single thread
+- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.8 fits the window better in a single thread
 
 **Auto-detection:** the setup wizard runs `cli/lib/repo-complexity.js` against the target repo and suggests the tier. Stakes flag (`.env` / `secrets/`) forces complex regardless of size. The user always picks the final answer — the heuristic is a hint, not a gate.
 
@@ -2983,7 +2983,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.77.0 -->
+<!-- SDLC Wizard Version: 1.78.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.77.0 -->
+<!-- SDLC Wizard Version: 1.78.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.159 -->
@@ -10,14 +10,14 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.77.0 |
-| Last Updated | 2026-06-01 |
-| Claude Code Minimum | v2.1.111+ (required for Opus 4.7 / `opus[1m]`); v2.1.105+ for `PreCompact` hook |
-| Claude Code Recommended | v2.1.159+ (latest at 2026-06-01) — unlocks Opus 4.8 (v2.1.154 — wizard holds on 4.7 pending #365 A/B), `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
-| Recommended Model | `opus[1m]` (Opus 4.7, 1M context) — run `/model opus[1m]` |
+| Wizard Version | 1.78.0 |
+| Last Updated | 2026-06-02 |
+| Claude Code Minimum | v2.1.154+ (required for Opus 4.8 / `opus[1m]`); v2.1.105+ for `PreCompact` hook |
+| Claude Code Recommended | v2.1.159+ (latest at 2026-06-02) — unlocks Opus 4.8 (v2.1.154), `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
+| Recommended Model | `opus[1m]` (Opus 4.8, 1M context) — run `/model opus[1m]` |
 | Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |
 
-> **Effort warning (Opus 4.7):** `max` is the recommended default, `xhigh` is the absolute floor. Anything below `xhigh` (`high`, `medium`, `low`) causes Opus 4.7 to scope work tighter — shallow reasoning, skipped TDD, dropped self-review, SDLC non-compliance in practice. Use `high` or below only for trivial grep/search subagents, never for real SDLC work.
+> **Effort warning (Opus 4.8):** `max` is the recommended default, `xhigh` is the absolute floor. Anything below `xhigh` (`high`, `medium`, `low`) causes Opus 4.8 to scope work tighter — shallow reasoning, skipped TDD, dropped self-review, SDLC non-compliance in practice. Use `high` or below only for trivial grep/search subagents, never for real SDLC work.
 
 See `CLAUDE_CODE_SDLC_WIZARD.md` → "1M vs 200K Context Window" for the rationale and pricing notes.
 

--- a/cli/lib/repo-complexity.js
+++ b/cli/lib/repo-complexity.js
@@ -1,8 +1,8 @@
 // Roadmap #233: repo complexity heuristic for mixed-mode tier selection.
 //
 // Output: { tier: 'simple' | 'complex', score: <number>, signals: [...] }
-//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.7 reviewer)
-//   - 'complex' → setup wizard suggests full flagship (Opus 4.7 everywhere)
+//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.8 reviewer)
+//   - 'complex' → setup wizard suggests full flagship (Opus 4.8 everywhere)
 // Cross-model review (Codex / external) always stays at the flagship tier
 // regardless of coder selection — see CLAUDE_CODE_SDLC_WIZARD.md.
 //

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -3,9 +3,9 @@
 #
 # Behavior (per ROADMAP #217):
 #   effort=max    -> silent (preferred default, above floor)
-#   effort=xhigh  -> silent (minimum floor on Opus 4.7)
+#   effort=xhigh  -> silent (minimum floor on Opus 4.8)
 #   effort=high|medium|low (or unset) -> LOUD WARNING:
-#     Opus 4.7 needs xhigh floor for SDLC compliance (TDD, self-review, deep reasoning).
+#     Opus 4.8 needs xhigh floor for SDLC compliance (TDD, self-review, deep reasoning).
 #     Recommends `/effort max`. Also reminds about recommended model `opus[1m]`.
 #
 # CC does not expose the current model to hooks, so the model nudge is emitted as
@@ -57,7 +57,7 @@ else
 fi
 
 echo "=============================================================================="
-echo " WARNING: effort '$effort_display' breaks SDLC compliance on Opus 4.7."
+echo " WARNING: effort '$effort_display' breaks SDLC compliance on Opus 4.8."
 echo " Below xhigh = shallow reasoning, skipped TDD, dropped self-review."
 echo ""
 echo " Run: /effort max    (preferred, full SDLC compliance)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -114,7 +114,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 ## Recommended Model
 
-**Opt-in: `opus[1m]` (Opus 4.7 with 1M context).** `/model opus[1m]` at the start of non-trivial sessions — understand the tradeoff (issue #198). A top-level `model` pin in `.claude/settings.json` disables CC's per-turn auto-selection; pin only when you need 1M headroom. Requires CC v2.1.111+.
+**Opt-in: `opus[1m]` (Opus 4.8 with 1M context).** `/model opus[1m]` at the start of non-trivial sessions — understand the tradeoff (issue #198). A top-level `model` pin in `.claude/settings.json` disables CC's per-turn auto-selection; pin only when you need 1M headroom. Requires CC v2.1.154+.
 
 **Pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` when you opt in.** Without it, the default fires at ~76K on 1M. **Pick ONE — do NOT set both `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` AND `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`** — they compound to 30% × 400K = 120K trigger ≈ 12% of 1M, fires almost immediately (#207). See wizard "Autocompact Tuning" for details.
 
@@ -130,7 +130,7 @@ The loop goes back to PLANNING, not TDD RED. Run `/code-review`; issues at confi
 
 ## Cross-Model Review (If Configured)
 
-**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip:** trivial changes, time-sensitive hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.7 max — adversarial diversity is the point.
+**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip:** trivial changes, time-sensitive hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.8 max — adversarial diversity is the point.
 
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -247,8 +247,8 @@ The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the re
 > How do you want to configure the model for this repo?
 >
 > - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
-> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.7 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
-> - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.7 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.111+.
+> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.8 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
+> - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.8 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.154+.
 >
 > `[N/m/f]`
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.77.0
+Latest:    1.78.0
 
 What changed:
+- [1.78.0] Opus 4.7 → 4.8 model recommendation (#365) + min CC v2.1.154+.
 - [1.77.0] release-dry-run.yml + cc-version-drift.yml (#350) + /goal SDLC gates (95% + DLC binding).
 - [1.76.0] /goal /sdlc wrapper (#347) + CC v2.1.150 feature adoption + ROADMAP demand-signal gate (4 excise, 4 kill).
 - [1.75.1] release-workflow fix — Node 22 → 24 (ships npm 11.x), dropped flaky `npm install -g` self-upgrade (hit MODULE_NOT_FOUND on v1.75.0 publish). Explicit npm-version guard.
@@ -104,7 +105,6 @@ What changed:
 - [1.73.0] precompact stale REBASE_HEAD fix + 15 stale artifact deletes (-460 LOC).
 - [1.72.0] #323 closed — customization-aware `check` recommendation + new `--preserve-customized` flag. `init --force --preserve-customized` skips CUSTOMIZED files (action `PRESERVE`), still OVERWRITEs MATCH and CREATEs MISSING. Default `init --force` unchanged. 10 tests.
 - [1.71.0–1.69.0] token-bloat sweep #236 — BASELINE + TDD CHECK fire once per `session_id` (-12K, -0.5-1.5K); sdlc-skill Cross-Model Review trimmed.
-- [1.68.0–1.65.0] roadmap hygiene — five paperwork closes: #97 Anthropic Policy NO-GO + AAR-paper validating parallel; #99 AutoGPT NO-GO; #95 Nous NO-GO; #243 token-history liveness verified; #210 Node-24 false-green; #235 Thoughtworks AI Evals NO-GO. **6/6 external-product audits NO-GO** (continues #76, #77). Research write-ups in `.reviews/research-*.md`.
 - [1.64.0] XDLC ecosystem cross-references — README, wizard doc, and ROADMAP now cross-reference all three sibling packages (`agentic-sdlc-wizard`, `codex-sdlc-wizard`, `claude-gdlc-wizard`). New "Ecosystem (Sibling Projects)" section in README. 3 new doc-consistency tests prevent drift.
 - [1.63.0] cache-cost observability closeout (#204 absorbed by #220) — token-spike test gains explicit cache-miss + negative-control coverage. "Cache-Cost Surprises" docs added (10-20× silent blowups from mid-session CLAUDE.md edits, idle pruning).
 - [1.62.0] roadmap hygiene + #211 backfill — closes paperwork-stale rows. Backfilled 5 corrupted `score-history.jsonl` rows from `max_score:10` → `:11` (UI scenarios). Codex strategic review confirmed scope.
@@ -170,7 +170,7 @@ Check user's `.claude/settings.json`:
 1. **`model: "opus[1m]"` AND `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "30"`** — likely the old wizard-installed pair, not an intentional choice. Ask:
    > Your `.claude/settings.json` pins `model: "opus[1m]"` with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. This pair was the wizard default in 1.31.0–1.33.x, but it disables Claude Code's auto-mode (issue #198).
    > - **Remove the pin** (recommended) — keeps auto-mode enabled
-   > - **Keep the pin** — guaranteed Opus 4.7 + 1M, OK with no auto-selection
+   > - **Keep the pin** — guaranteed Opus 4.8 + 1M, OK with no auto-selection
    > Remove, keep, or decide later? `[r/k/l]`
 
 2. **Only one of the two fields matches** — treat as intentional customization. Do not prompt.

--- a/tests/e2e/local-shepherd.sh
+++ b/tests/e2e/local-shepherd.sh
@@ -218,7 +218,7 @@ echo "PR #$PR_NUMBER → scenario: $SCENARIO_NAME" >&2
 # any of them without a matching CI change creates a silent score-drift risk.
 # The parity-audit test (tests/test-local-shepherd.sh) diffs these against
 # the CI block to catch drift.
-# Model is NOT pinned explicitly — CI relies on action default (Opus 4.7),
+# Model is NOT pinned explicitly — CI relies on action default (Opus 4.8),
 # so shepherd does too. If Anthropic changes the default, both paths shift
 # together.
 PARITY_MAX_TURNS=55

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2669,7 +2669,7 @@ test_model_effort_check_max_is_silent() {
 }
 
 # Test: below-xhigh produces LOUD warning mentioning SDLC compliance + /effort max
-# Per ROADMAP #217: below-xhigh breaks SDLC compliance on Opus 4.7 (shallow reasoning,
+# Per ROADMAP #217: below-xhigh breaks SDLC compliance on Opus 4.8 (shallow reasoning,
 # skipped TDD, dropped self-review). Hook must produce a distinguishable WARNING that
 # recommends /effort max (not just the soft "upgrade available" nudge).
 test_model_effort_check_below_xhigh_loud_warning() {

--- a/tests/test-repo-complexity.sh
+++ b/tests/test-repo-complexity.sh
@@ -4,7 +4,7 @@
 # Sonnet coder + Opus reviewer) or "complex" (full Opus tier recommended).
 #
 # Roadmap #233: introduces repo_complexity signal so setup wizard can suggest
-# mixed-mode for trivial/CRUD repos and reserve flagship Opus 4.7 for
+# mixed-mode for trivial/CRUD repos and reserve flagship Opus 4.8 for
 # fixture-deep, multi-workflow, secrets-touching repos.
 
 set -e


### PR DESCRIPTION
## Summary

- Bump wizard recommended model from **Opus 4.7 → 4.8** across all surface files (closes #365)
- Bump min Claude Code version v2.1.111+ → v2.1.154+ (required for `opus[1m]` alias to resolve to 4.8)
- Bump wizard version v1.77.0 → v1.78.0 across all 6 SDLC checklist locations + new CHANGELOG entry
- `opus[1m]` alias auto-resolves to latest Opus, so **settings.json template is unchanged** — prose-and-version-bump only

## Why now

- Opus 4.8 launched 2026-05-28
- Day 3-5 in-the-wild sentiment settled positive (vs. day-1 mixed reaction)
- Proof-of-life via `claude --print --model claude-opus-4-8` confirmed reachability on current CC v2.1.159

## What changed

| Layer | Files |
|---|---|
| Wizard surface prose | `SDLC.md`, `CLAUDE_CODE_SDLC_WIZARD.md`, `skills/sdlc/SKILL.md`, `skills/setup/SKILL.md`, `skills/update/SKILL.md` |
| Hook + JS | `hooks/model-effort-check.sh`, `cli/lib/repo-complexity.js` |
| Docs | `CI_CD.md`, `tests/e2e/local-shepherd.sh`, `tests/test-hooks.sh`, `tests/test-repo-complexity.sh` (comments) |
| Version | `package.json`, `.claude-plugin/{plugin,marketplace}.json`, `CHANGELOG.md` |

**Effort semantics preserved.** Strict effort behavior introduced in 4.7 carried forward to 4.8 — `max` remains the recommended default, `xhigh` the floor. References to "Opus 4.7+" with the plus sign are intentional historical anchors.

## Un-run gates tracked as post-deploy obligations on #365

| Gate | Status |
|---|---|
| Gate 1: Sentiment | ✅ Day 3-5 positive |
| Gate 2: A/B coder quality vs 4.7 on real PRs | ⏳ Post-deploy |
| Gate 3: 24h dogfood | ⏳ Post-deploy |

**Revert path:** Since `settings.json` template is unchanged (alias does the resolution), revert is prose-only if 4.8 surfaces the system-card-flagged regressions (Gray Swan prompt-injection +60%, file-deletion tendency, eval-awareness affecting wizard output).

## Test plan

- [x] `tests/test-hooks.sh` — 160/160
- [x] `tests/test-self-update.sh` — 153/153
- [x] `tests/test-doc-consistency.sh` — 41/41
- [x] `tests/test-docs-usability.sh` — 29/29 (validates new 1.78.0 anchor in skills/update/SKILL.md)
- [x] `tests/test-audit-session-load.sh` — 10/10 (skills/update/SKILL.md trimmed back under 5K cap after CHANGELOG entry addition)
- [x] `tests/test-repo-complexity.sh` — 11/11
- [ ] CI `validate` green
- [ ] Post-merge: spot-check `/sdlc` session start hook output mentions "Opus 4.8" not "4.7"