### PR TITLE
feat(model): add Opus 4.6 Stability tier + v1.79.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.78.0",
+      "version": "1.79.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.79.0] - 2026-06-08
+
+### Added
+
+- **Opus 4.6 Stability tier** as a fourth setup-wizard model choice ([s] Stability, alongside [N] No pin / [m] Mixed-mode / [f] Flagship). Pins `model: "claude-opus-4-6[1m]"` with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Pairs with `max` effort. Community signal converges on 4.6 being the only Opus version `max` tolerates without overthinking — Andon Labs Vending-Bench arena (4.8 finished last, "Max reasoning is not the best reasoning effort"), Paweł Huryn's 4.7 guide ("most complaints about 4.7 feeling slow stem from people reflexively using max"), BSWEN effort decision guide ("Max on Opus causes overthinking"), r/Claudeopus field reports (one maintainer: "12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session"; another commenter: "4.6 had the best overall balance at max"). New section "Stability tier — Opus 4.6 at max effort" in `CLAUDE_CODE_SDLC_WIZARD.md` documents when to pick it (production 4.7/4.8 regression escape — false-greens GH #63861, 2-3× token burn #64961, dropped constraints #65932, fabricated identifiers; context-heavy work where 4.6 scored 94.7% NYT Connections vs 4.7's 41%; original tokenizer avoids the 4.7+ 12-18% English token tax) and tradeoffs (misses 4.8's SWE-Bench Pro / Terminal-Bench / dynamic-workflows gains). Anthropic-supported until ≥ Feb 5, 2027 (8 months minimum runway per [Anthropic deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations)). Wizard default remains flagship Opus 4.8 — Stability is opt-in, not a recommendation swap. Setup skill updated with `[s] Stability` choice + handler; settings.json snippet provided for both global (env-var sweep across all projects via `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6`) and project-scoped pin patterns.
+
+### Notes
+
+- **4.6's Feb-Apr 2026 quality bugs are fully fixed per [Anthropic's April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem).** The three bugs (effort default high→medium Mar 4-Apr 7; cache-clear-every-turn Mar 26-Apr 10; verbosity-limit prompt Apr 16-Apr 20) are resolved. The Stability tier picks up the post-fix model, not the regression window. Anthropic reset usage limits as compensation Apr 23.
+- **Wizard default unchanged.** v1.78.0's flagship recommendation of Opus 4.8 stays. The Stability tier is an additive sibling for maintainers who've hit 4.7/4.8 regressions in production — surfaced as a choice in the setup wizard, not flipped as the default. If the community-validated A/B of 4.6 max vs 4.7/4.8 max materializes as a sustained pattern across maintainers, a future release may revisit the default.
+- **Validation pending.** This release ships the tier so maintainers can opt in across their own repos and run the comparison. Real-world signal from extended use (token spend deltas, context-fidelity wins, false-green regressions caught) feeds back into a v1.80.0 calibration if warranted.
+
 ## [1.78.0] - 2026-06-02
 
 ### Changed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1076,6 +1076,48 @@ Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different
 - Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
 - Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
 
+### Stability tier — Opus 4.6 at max effort
+
+The wizard's default flagship recommendation is Opus 4.8 (per Anthropic). Some maintainers report better real-world results with **Opus 4.6 at max effort** — community signal converges on 4.6 being the only Opus version where `max` doesn't overthink. Sources: r/Claudeopus field reports ("12 hours with 4.8 zero result; plugged in 4.6, spec written + 133 tests green in one session"; "4.6 had the best overall balance at max"), Andon Labs Vending-Bench (4.8 finished last vs 4.7 and GPT-5.5; "Max reasoning is not the best reasoning effort"), Paweł Huryn's 4.7 guide ("most complaints about 4.7 feeling slow stem from people reflexively using max"), and BSWEN effort decision guide ("Max on Opus causes overthinking").
+
+**When the Stability tier is the right call:**
+- You've hit 4.7/4.8 regressions in production: false-greens (Claude declaring "done" without running canonical builds, GitHub #63861), 2-3× token burn vs prior baselines (#64961), dropped load-bearing constraints during execution (#65932), fabricated identifiers in parallel batches
+- Your work is context-heavy (large diffs, multi-file refactors, long sessions) — 4.6 scored 94.7% on NYT Connections vs 4.7's 41%
+- You want the original tokenizer (no 4.7+ 12-18% English token tax)
+- You're a high-volume user hitting Max 5-hour limits in 2-3 hours on 4.7/4.8 — field reports point to 4.6 sipping fewer tokens per turn
+
+**Tradeoffs (be honest):**
+- Misses 4.8's SWE-Bench Pro and Terminal-Bench 2.1 gains
+- No dynamic-workflows / parallel-subagent-swarm support introduced in 4.8
+- Anthropic-supported until ≥ Feb 5, 2027 (8 months minimum runway) — plan re-evaluation as that date approaches
+- 4.6's own Feb-Apr 2026 quality bugs are fully fixed per Anthropic's April 23 postmortem; this tier picks up the post-fix model, not the regression window
+
+**How to opt in (global, sweeps every project):**
+
+Edit `~/.claude/settings.json`:
+```json
+{
+  "env": {
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-6"
+  },
+  "model": "opus[1m]"
+}
+```
+
+The `opus[1m]` alias resolves through the env vars, so this combination pins `claude-opus-4-6[1m]` (1M context) everywhere.
+
+**Project-scoped (single repo):**
+```json
+{
+  "model": "claude-opus-4-6[1m]"
+}
+```
+
+**Effort:** keep your usual `max` — 4.6 is the version field reports converge on as the only Opus that tolerates `max` without overthinking.
+
+**Escape hatch:** flip the env vars back to `claude-opus-4-8` (or remove them entirely to fall back to the wizard's flagship default).
+
 ### Community Feature-Discovery Scanner (roadmap #207)
 
 The weekly-update workflow watches Anthropic's official changelog + GitHub releases, but new CC slash-commands (e.g. a hypothetical `/insights`) often surface FIRST on Reddit, HN, or Discord weeks before they hit the changelog. `tests/e2e/scan-community.sh` ports the community-scan job out of CI (deleted per ROADMAP #231) into a maintainer-runnable script: pull transcripts manually, pipe through the scanner, triage the digest.
@@ -2983,7 +3025,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.78.0 -->
+<!-- SDLC Wizard Version: 1.79.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->

--- a/README.md
+++ b/README.md
@@ -138,6 +138,34 @@ codex exec -c 'model_reasoning_effort="xhigh"' -s danger-full-access \
 
 `xhigh` reasoning is **non-negotiable** — lower settings miss subtle bugs. See [CLAUDE_CODE_SDLC_WIZARD.md](CLAUDE_CODE_SDLC_WIZARD.md#cross-model-review-loop-optional) for the full protocol (handoff format, round-2 dialogue loop, preflight docs). Real-world: this catches P0/P1 issues in 2-3 out of 10 reviews that Claude's self-review rated as clean.
 
+## Choosing Your Model
+
+The wizard ships a **default recommendation**, not a mandate. You can swap to any Claude model — newer, older, or sibling tier — at any time. `/model` per session, or pin in `.claude/settings.json`.
+
+**Default: Opus 4.8 at max effort** (`[f] Flagship` in the setup wizard). Matches Anthropic's current flagship; unlocks 4.8's SWE-Bench Pro / Terminal-Bench 2.1 / dynamic-workflow gains. If you're starting fresh, this is the right pick.
+
+**Alternative tier: Opus 4.6 at max effort** (`[s] Stability`, added v1.79.0). Some maintainers — including the wizard author — hit 4.7/4.8 regressions in production that 4.6 simply doesn't have: false-greens ([anthropics/claude-code#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers under parallel tool batches. Field signal converges on **4.6 being the only Opus where `max` effort doesn't overthink** — Andon Labs Vending-Bench arena (4.8 finished last), [Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide) ("most complaints about 4.7 feeling slow stem from people reflexively using max"), r/Claudeopus field reports (one maintainer: "12 hours with 4.8 zero deliverables; plugged in 4.6, 133 tests green in one session"). 4.6 is Anthropic-supported until ≥ Feb 5, 2027 per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum runway.
+
+**The wizard's stance: aim for stability.** Default to what works reliably in your hands, not what's newest. If 4.8 ships well for your workflow, stay on flagship. If you've hit the regressions, the Stability tier is one setup-wizard choice (`[s]`) and reversion is two lines in `~/.claude/settings.json`. See [CLAUDE_CODE_SDLC_WIZARD.md → "Stability tier — Opus 4.6 at max effort"](CLAUDE_CODE_SDLC_WIZARD.md) for the full pick-list and tradeoffs.
+
+**Switch any time:**
+
+```bash
+/model claude-opus-4-8[1m]   # flagship default
+/model claude-opus-4-6[1m]   # stability tier
+/model opus[1m]              # whatever the wizard's recommendation resolves to
+```
+
+Or pin in `.claude/settings.json`:
+
+```json
+{ "model": "claude-opus-4-6[1m]" }
+```
+
+Or sweep all your projects from one place by setting `ANTHROPIC_DEFAULT_OPUS_MODEL` in `~/.claude/settings.json` — the `opus[1m]` alias resolves through it, so flipping one env var switches every repo at once.
+
+Effort tuning is independent of model choice. `max` is the wizard's default; `xhigh` is the floor. Adjust per session with `/effort max`. The Stability tier is specifically a **`max`-effort tier** because that's the field-validated sweet spot for 4.6 — at the cost of giving up 4.8's newer benchmark wins.
+
 ## How It Works
 
 **Think Iron Man:** Jarvis is nothing without Tony Stark. Tony Stark is still Tony Stark. But together? They make Iron Man. This SDLC is your suit - you build it over time, improve it for your needs, and it makes you both better.

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.78.0 -->
+<!-- SDLC Wizard Version: 1.79.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.159 -->
@@ -10,8 +10,8 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.78.0 |
-| Last Updated | 2026-06-02 |
+| Wizard Version | 1.79.0 |
+| Last Updated | 2026-06-08 |
 | Claude Code Minimum | v2.1.154+ (required for Opus 4.8 / `opus[1m]`); v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.159+ (latest at 2026-06-02) — unlocks Opus 4.8 (v2.1.154), `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
 | Recommended Model | `opus[1m]` (Opus 4.8, 1M context) — run `/model opus[1m]` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -249,8 +249,9 @@ The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the re
 > - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
 > - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.8 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
 > - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.8 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.154+.
+> - **[s] Stability** *(alternative to flagship when you've hit 4.7/4.8 regressions):* Pins `model: "claude-opus-4-6[1m]"` (Opus 4.6 with 1M context). Community signal converges on 4.6 being the only Opus version `max` effort tolerates without overthinking. Picks up the original tokenizer (no 4.7+ 12-18% English token tax). Best for: production work hitting false-greens / 2-3× token burn on 4.7/4.8, context-heavy refactors, hitting Max 5-hour limits early. Anthropic-supported until ≥ Feb 5, 2027. Misses 4.8's SWE-Bench Pro / Terminal-Bench / dynamic-workflows gains.
 >
-> `[N/m/f]`
+> `[N/m/f/s]`
 
 **If the user answers `N` (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
 
@@ -275,7 +276,20 @@ Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window h
 }
 ```
 
-Mention the escape hatch in all three cases:
+**If the user answers `s` (stability):** Edit `.claude/settings.json` and add:
+
+```json
+{
+  "model": "claude-opus-4-6[1m]",
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+  }
+}
+```
+
+Tell the user: "Effort `max` is the recommended pair for 4.6 (the only Opus version field reports converge on tolerating max without overthinking). Escape hatch is the same as flagship — remove the `model` line to fall back to auto-mode, or change it to `opus[1m]` to ride upstream's latest." See `CLAUDE_CODE_SDLC_WIZARD.md` → "Stability tier — Opus 4.6 at max effort" for the full rationale.
+
+Mention the escape hatch in all four cases:
 - To opt out later: remove the `model` line (and optionally the `env` block) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
 - To switch tiers later: edit `.claude/settings.json` and replace the `model` value, or re-run `/setup-wizard` Step 9.5.
 - For CI pipelines with short tasks (flagship only), consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.78.0
+Latest:    1.79.0
 
 What changed:
+- [1.79.0] Opus 4.6 Stability tier (max-effort sweet spot, community-validated flagship alternative).
 - [1.78.0] Opus 4.7 → 4.8 model recommendation (#365) + min CC v2.1.154+.
 - [1.77.0] release-dry-run.yml + cc-version-drift.yml (#350) + /goal SDLC gates (95% + DLC binding).
 - [1.76.0] /goal /sdlc wrapper (#347) + CC v2.1.150 feature adoption + ROADMAP demand-signal gate (4 excise, 4 kill).


### PR DESCRIPTION
## Summary

New **[s] Stability tier** in setup wizard pins `claude-opus-4-6[1m]` at max effort for maintainers who've hit 4.7/4.8 regressions in production. Default flagship recommendation (Opus 4.8) **unchanged** — Stability is an additive opt-in.

## Why now

Community signal converges on **4.6 being the only Opus version `max` tolerates without overthinking**. Four independent sources:

1. **Andon Labs Vending-Bench arena** — 4.8 finished last vs 4.7 and GPT-5.5. Explicit: "Max reasoning is not the best reasoning effort"
2. **Paweł Huryn's 4.7 guide** — "most complaints about 4.7 feeling slow stem from people reflexively using max"
3. **BSWEN effort decision guide** — "Max on Opus causes overthinking"
4. **r/Claudeopus field reports** — one maintainer ran a literal A/B: "12 hours with 4.8 zero deliverables; plugged in 4.6 on same project, spec written + 133 tests green in one session." Top comment from u/debuild: "4.6 had the best overall balance at max"

Plus 4.7/4.8 regressions actively being filed against Claude Code:
- `anthropics/claude-code#63861` — false-greens (4.8 declaring "done" without canonical builds)
- `anthropics/claude-code#64961` — 2-3× token burn regression
- `anthropics/claude-code#65932` — dropped constraints during execution

## What ships

- **New setup wizard choice `[s] Stability`** in `skills/setup/SKILL.md` alongside [N]/[m]/[f]
- **New section "Stability tier — Opus 4.6 at max effort"** in `CLAUDE_CODE_SDLC_WIZARD.md` — when to choose, tradeoffs, opt-in snippets (global env-var sweep + project-scoped)
- **v1.79.0 version bump** across 6 locations per `SDLC.md` checklist
- **CHANGELOG entry** with full triangulation + tradeoff disclosure

## What does NOT ship

- Default recommendation stays at **Opus 4.8** (Anthropic's official rec). This is an additive sibling tier, not a default swap.
- No code changes to hooks or repo-complexity logic — the heuristic still suggests `simple` → mixed-mode and `complex` → flagship. Stability is a manual maintainer choice.

## Anthropic deprecation runway

`claude-opus-4-6` is **Active** with retirement "not sooner than February 5, 2027" per [Anthropic deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum. The 4.6 Feb-Apr 2026 quality bugs are fully fixed per [Anthropic's April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem); this tier picks up the post-fix model.

## Test plan

- [ ] CI `validate` passes (test-version-logic.sh, test-analysis-schema.sh, test-hooks.sh `test_sdlc_version_matches_wizard`, test-docs-usability.sh including skills/update/SKILL.md token cap)
- [ ] After merge, run `/setup-wizard` in another local repo and confirm `[s] Stability` choice writes the expected `.claude/settings.json` block
- [ ] Maintainer A/B over the coming week: 4.6 max vs 4.7/4.8 max — token-spend deltas, context-fidelity wins, false-green regressions caught. Results feed v1.80.0 calibration if warranted.