### PR TITLE
feat(model): flip default Opus 4.8 → Opus 4.6 max + v1.80.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.79.0",
+      "version": "1.80.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.80.0] - 2026-06-09
+
+### Changed
+
+- **Flipped default recommended model: Opus 4.8 → Opus 4.6 max.** v1.79.0 added Opus 4.6 max as opt-in Stability tier; v1.80.0 graduates it to the wizard's recommended flagship default. Setup wizard's `[f] Flagship full` choice now writes `model: "claude-opus-4-6[1m]"` (was `"opus[1m]"` → 4.8). All wizard prose flipped accordingly: SDLC.md Recommended Model row, CLAUDE_CODE_SDLC_WIZARD.md effort warning + Strict Effort behavior section + mixed-mode reviewer references, skills/sdlc/SKILL.md model section + cross-model reviewer line, skills/setup/SKILL.md choice list, hooks/model-effort-check.sh RECOMMENDED_MODEL + warning text, cli/lib/repo-complexity.js tier comments, README.md "Choosing Your Model" section reframed as a 6-source argument for why 4.6 max beats 4.8 in production SDLC workflows.
+
+- **Added `[l] Latest` tier as opt-in for Opus 4.8.** Replaces v1.79.0's `[s] Stability` choice (which is now the default — graduated, not removed). Latest tier ships SWE-Bench Pro / Terminal-Bench 2.1 / dynamic-workflows / parallel-subagent-swarm features 4.6 doesn't have. Documents the tradeoffs explicitly: 40-60× cache token jump at HIGH effort ([AI Weekly](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn)), `max` is worse than `xhigh` on 4.8 ([Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench)), active GitHub regressions still open. Recommended effort for 4.8 is `xhigh`, not `max`.
+
+- **Setup wizard choice list updated** from `[N/m/f/s]` to `[N/m/f/l]`. The Stability tier graduates into Flagship; Latest replaces Stability as the new optional opposite-direction choice.
+
+### Why
+
+- Six independent sources converged in the 12 days since 4.8 launched (2026-05-28) on the same conclusion: **4.6 is the only Opus where `max` effort tolerates without overthinking, and 4.7/4.8's tokenizer + agentic improvements come with structural token-burn tradeoffs that hurt long-running SDLC workflows.** Sources: Andon Labs Vending-Bench arena (4.8 finished last; "Max reasoning is not the best reasoning effort"), AI Weekly (40-60× cache token jump at HIGH effort; up to 900K tokens per turn), [Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html) ("Anthropic deliberately made Opus's new tokenizer less efficient"), [Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide) ("most complaints about 4.7 feeling slow stem from people reflexively using max"), [BSWEN effort decision guide](https://docs.bswen.com/blog/2026-04-19-claude-code-effort-level-decision-guide/) ("Max on Opus causes overthinking"), r/Claudeopus field reports including one maintainer's literal A/B ("12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session").
+
+- Active GitHub regressions documented against 4.8 in Claude Code: false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers in parallel batches.
+
+- 4.6 is Anthropic-supported until ≥ Feb 5, 2027 per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum runway. The Feb-Apr 2026 quality bugs that triggered the original "is 4.6 nerfed" wave are fully fixed per Anthropic's [April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem); the wizard's default picks up the post-fix model.
+
+- Aligns the wizard with the [AI Setup Lanes](AI_SETUP_LANES.md) doc shipped in v1.79.0, which already named Opus 4.6 max as "Claude Premium" for both planner and driver in Setup A. The wizard's default flagship recommendation now matches.
+
+### Notes
+
+- **This is an explicit bet against the "newest = best" convention.** Anthropic recommends Opus 4.8 as their flagship; the wizard recommends Opus 4.6 max instead. Documented in README.md "Choosing Your Model" with the full six-source argument so users can evaluate the bet themselves and pick `[l] Latest` if they want Anthropic's official flagship.
+
+- **No breaking changes to consumer-repo installs.** `settings.json` template still ships unpinned (auto-mode default unchanged). The flip is at the *setup wizard's recommendation step* — users running `setup-wizard` get the new `[f] Flagship full` choice writing 4.6 max instead of 4.8. Users who already opted into v1.78.0/v1.79.0 flagship and want to stay current can re-run setup or manually flip `claude-opus-4-8` → `claude-opus-4-6` in their `~/.claude/settings.json` env vars.
+
+- **v1.79.0's Stability tier code stays in git history** but is now redundant — the Stability tier *was* "opt into Opus 4.6 max"; in v1.80.0 that's the default. No PR needed to remove the redundancy because the v1.80.0 prose subsumes it cleanly (Stability section content reframed as Latest tier opt-out instructions).
+
+- **If 4.8 regressions materially improve** (Anthropic ships hotfixes for the token-burn issues, GitHub bug closures, second wave of positive field reports), the default can flip back via a single PR. The CHANGELOG entry above names the specific signals to watch.
+
 ## [1.79.0] - 2026-06-08
 
 ### Added

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -249,26 +249,27 @@ When Anthropic provides official plugins or tools that handle something:
 
 Claude Code's **effort level** controls how much thinking the model does before responding. Higher effort = deeper reasoning but more tokens.
 
-> ⚠️ **On Opus 4.8, effort below `xhigh` breaks SDLC compliance in practice.** Inherited from 4.7, Opus 4.8 respects effort levels *strictly* — at `high` or below it scopes work tighter (shallow reasoning, skipped TDD, no self-review) rather than going above-and-beyond. Treat the table below accordingly: **`max` is the recommended default, `xhigh` is the floor**, `high` or below is for trivial grep/search subagents only.
+> ⚠️ **On Opus 4.6 max, effort below `xhigh` breaks SDLC compliance in practice.** Inherited from 4.7, Opus 4.6 max respects effort levels *strictly* — at `high` or below it scopes work tighter (shallow reasoning, skipped TDD, no self-review) rather than going above-and-beyond. Treat the table below accordingly: **`max` is the recommended default, `xhigh` is the floor**, `high` or below is for trivial grep/search subagents only.
 
 | Level | When to Use | How to Set |
 |-------|-------------|------------|
-| `high` or below | **Not for SDLC work on Opus 4.8.** Only for trivial grep/search subagents or one-shot questions that don't require planning | `effort: high` in a specific subagent frontmatter only |
-| `xhigh` | **Floor for SDLC work on Opus 4.8.** Long-running tasks, repeated tool calls, deep exploration. Claude Code defaults to this on Opus 4.7+ | `/effort xhigh` or set in skill frontmatter |
-| `max` | **Recommended default for Opus 4.8 SDLC work.** Multi-file changes, architecture decisions, debugging, cross-model reviews, any task touching wizard/skill/CI code | `/effort max` (session only — resets next session) |
+| `high` or below | **Not for SDLC work on Opus 4.6 max.** Only for trivial grep/search subagents or one-shot questions that don't require planning | `effort: high` in a specific subagent frontmatter only |
+| `xhigh` | **Floor for SDLC work on Opus 4.6 max.** Long-running tasks, repeated tool calls, deep exploration. Claude Code defaults to this on Opus 4.7+ | `/effort xhigh` or set in skill frontmatter |
+| `max` | **Recommended default for Opus 4.6 max SDLC work.** Multi-file changes, architecture decisions, debugging, cross-model reviews, any task touching wizard/skill/CI code | `/effort max` (session only — resets next session) |
 
-**Strict effort behavior (Opus 4.7+, carried forward to 4.8):**
+**Strict effort behavior (Opus 4.7+, carried forward in 4.8 — and why 4.6 max is the wizard's pick):**
 - **`xhigh` was introduced in 4.7** — sits between `high` and `max`, designed for coding and agentic work (30+ minute tasks with token budgets in the millions)
 - **Claude Code defaults to `xhigh`** on Opus 4.7+ for all plans
 - **Opus 4.7+ respects effort levels more strictly** than 4.6 — at lower levels it scopes work tighter instead of going above and beyond. If you see shallow reasoning, raise effort rather than prompting around it
 - **`budget_tokens` is deprecated** on Opus 4.7+ — use adaptive thinking with effort instead
+- **4.6 max is the wizard's flagship pick despite this:** community signal converges on 4.6 being the only Opus version where `max` effort tolerates without overthinking (Andon Labs Vending-Bench, Paweł Huryn's 4.7 guide, BSWEN effort decision guide, r/Claudeopus field reports). On 4.7 and 4.8, `max` triggers excessive reasoning that hits context limits faster and burns more tokens per turn — making the strict-effort behavior backfire. 4.6 max stays in the sweet spot. See [README → "Choosing Your Model"](../README.md#choosing-your-model) for the full evidence
 - When running at `xhigh` or `max`, set a large `max_tokens` (64k+) so the model has room to think across subagents and tool calls
 
 **Why `high` was the previous default:** Claude Code uses **adaptive thinking** to dynamically allocate reasoning budget per turn. On Pro and Max plans, the default effort level was **medium (85)**, which causes the model to under-allocate reasoning on complex multi-step tasks — leading to shallow analysis, missed edge cases, and "lazy" outputs. This was [confirmed by Anthropic engineer Boris Cherny](https://github.com/anthropics/claude-code/issues/42796) and is documented at [code.claude.com](https://code.claude.com/docs/en/model-config). API, Team, and Enterprise plans default to high effort and are not affected.
 
 **Don't rely on the CC default — set effort yourself.** Anthropic's [2026-04-23 post-mortem](https://www.anthropic.com/engineering/april-23-postmortem) is independent third-party evidence that CC has flipped reasoning_effort defaults across versions (high → medium → xhigh/high). The default has changed before and will change again. The wizard's `model-effort-check.sh` hook nudges to `xhigh`/`max` at session start specifically because the in-product default is not load-bearing — it can shift release-to-release without notice. Set `/effort max` explicitly every session you do SDLC work, and treat any "I assumed the default was X" reasoning as a bug.
 
-The `/sdlc` skill sets `effort: high` in its frontmatter as a baseline, overriding the medium default on every SDLC invocation. **On Opus 4.8, run `/effort max` at session start** — the frontmatter is a floor, not a ceiling, and `max` is where SDLC-compliant work actually happens on 4.8.
+The `/sdlc` skill sets `effort: high` in its frontmatter as a baseline, overriding the medium default on every SDLC invocation. **On Opus 4.6 max, run `/effort max` at session start** — the frontmatter is a floor, not a ceiling, and `max` is where SDLC-compliant work actually happens on 4.6.
 
 **Nuclear option — disable adaptive thinking entirely:** Set `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` in your environment or settings.json `env` block. This forces a fixed reasoning budget per turn instead of letting the model dynamically allocate. Use this if you observe persistent quality issues even with `effort: high`. See [Claude Code model config docs](https://code.claude.com/docs/en/model-config) for details.
 
@@ -966,7 +967,7 @@ Override the default auto-compact threshold with environment variables. These ar
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Trigger compaction at this % of context capacity (1-100) | ~95% |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | Override context capacity in tokens (useful for 1M models) | Model default |
 
-**Opt-in (issue #198):** The SDLC Wizard CLI ships `.claude/settings.json` with **no** `model` or `env` pin so Claude Code's auto-mode stays enabled. The setup skill's Step 9.5 asks whether to opt into `"model": "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (tuned for the 1M window — compacts at ~300K). Default answer is **No**. Pinning the model at the top level tells Claude Code you've explicitly chosen a model and turns off per-turn model auto-selection — a real tradeoff, so we ask. Power users who want guaranteed Opus 4.8 + 1M context answer yes.
+**Opt-in (issue #198):** The SDLC Wizard CLI ships `.claude/settings.json` with **no** `model` or `env` pin so Claude Code's auto-mode stays enabled. The setup skill's Step 9.5 asks whether to opt into `"model": "opus[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (tuned for the 1M window — compacts at ~300K). Default answer is **No**. Pinning the model at the top level tells Claude Code you've explicitly chosen a model and turns off per-turn model auto-selection — a real tradeoff, so we ask. Power users who want guaranteed Opus 4.6 max + 1M context answer yes.
 
 To opt in by hand, edit `.claude/settings.json`:
 
@@ -1021,13 +1022,13 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 **Why `opus[1m]` is opt-in (issue #198):**
 - **Pinning disables auto-mode.** Max-plan users pay for Claude Code's per-turn model selection (Sonnet for cheap tasks, Opus for hard ones, plus weekly-limit smoothing). A top-level `model` gives that up.
 - **The 1M headroom has to earn it.** If your typical session stays under 150K, you're giving up auto-mode for headroom you're not using.
-- **Power users who want guaranteed Opus 4.8 + 1M** — go ahead, it's a real win for long shepherding sessions. Just make it a conscious choice, not a silent default.
+- **Power users who want guaranteed Opus 4.6 max + 1M** — go ahead, it's a real win for long shepherding sessions. Just make it a conscious choice, not a silent default.
 
-**Opt in when:** you routinely cross 100K tokens in a single session (plan → TDD → review → CI shepherd on one feature), you want Opus 4.8 specifically (not Sonnet), and you're OK losing auto-mode.
+**Opt in when:** you routinely cross 100K tokens in a single session (plan → TDD → review → CI shepherd on one feature), you want Opus 4.6 max specifically (not Sonnet), and you're OK losing auto-mode.
 
 **Stay on auto-mode (default) when:** you're unsure, your work is mixed short/long, or you want Claude Code to do the model math for you.
 
-**How to opt in:** run `/model opus[1m]` in your session (transient), or set `"model": "opus[1m]"` in `.claude/settings.json` (persistent). Requires Claude Code v2.1.154+ for Opus 4.8 (the `opus[1m]` alias auto-resolves to the latest Opus). The setup wizard's Step 9.5 also asks once, with default No.
+**How to opt in:** run `/model opus[1m]` in your session (transient), or set `"model": "opus[1m]"` in `.claude/settings.json` (persistent). Requires Claude Code v2.1.154+ for Opus 4.6 max (the `opus[1m]` alias auto-resolves to the latest Opus). The setup wizard's Step 9.5 also asks once, with default No.
 
 **How to opt out:** remove the `model` line from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
 
@@ -1037,14 +1038,14 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 
 ### Mixed-Mode Tier (Sonnet coder + Opus reviewer, roadmap #233)
 
-For trivial / blank / config-only / CRUD-style repos, full Opus 4.8 on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
+For trivial / blank / config-only / CRUD-style repos, full Opus 4.6 max on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
 
 **The split:**
 
 | Layer | Mixed-mode tier | Flagship tier |
 |-------|----------------|---------------|
 | Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
-| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.8 max via Bash) | gpt-5.5 xhigh (or Opus 4.8 max via Bash) |
+| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) |
 | Effort floor (CC session) | xhigh; max preferred | xhigh; max preferred |
 
 The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
@@ -1058,7 +1059,7 @@ The reviewer always stays at flagship — the whole point of mixed-mode is that 
 **When to stay flagship:**
 - Stakes-flagged repo: anywhere `.env` / `secrets/` / `credentials/` exists. Force flagship even if LOC is tiny — leaks are catastrophic
 - Architecture work, debugging non-obvious bugs, security review, anything where the *coder's* judgment matters as much as the reviewer's
-- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.8 fits the window better in a single thread
+- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.6 max fits the window better in a single thread
 
 **Auto-detection:** the setup wizard runs `cli/lib/repo-complexity.js` against the target repo and suggests the tier. Stakes flag (`.env` / `secrets/`) forces complex regardless of size. The user always picks the final answer — the heuristic is a hint, not a gate.
 
@@ -1076,21 +1077,22 @@ Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different
 - Sonnet 4.6 will drop some fine-grained self-review moves (it's fast, less deliberate). The Opus reviewer catches them — but you'll see more "fix in round 2" cycles compared to Opus-coder runs.
 - Mixed-mode disables auto-mode (same as flagship pin). The Sonnet pin is per-session — to switch back, remove the `model` line.
 
-### Stability tier — Opus 4.6 at max effort
+### Latest tier — Opus 4.8 (opt-in for bleeding-edge)
 
-The wizard's default flagship recommendation is Opus 4.8 (per Anthropic). Some maintainers report better real-world results with **Opus 4.6 at max effort** — community signal converges on 4.6 being the only Opus version where `max` doesn't overthink. Sources: r/Claudeopus field reports ("12 hours with 4.8 zero result; plugged in 4.6, spec written + 133 tests green in one session"; "4.6 had the best overall balance at max"), Andon Labs Vending-Bench (4.8 finished last vs 4.7 and GPT-5.5; "Max reasoning is not the best reasoning effort"), Paweł Huryn's 4.7 guide ("most complaints about 4.7 feeling slow stem from people reflexively using max"), and BSWEN effort decision guide ("Max on Opus causes overthinking").
+The wizard's flagship recommendation is Opus 4.6 max (see "Choosing Your Model" in [README.md](../README.md) for the full evidence). Some maintainers will want Anthropic's newest Opus instead — **Opus 4.8** ships SWE-Bench Pro / Terminal-Bench 2.1 gains, dynamic-workflows, and parallel-subagent-swarm features 4.6 doesn't have.
 
-**When the Stability tier is the right call:**
-- You've hit 4.7/4.8 regressions in production: false-greens (Claude declaring "done" without running canonical builds, GitHub #63861), 2-3× token burn vs prior baselines (#64961), dropped load-bearing constraints during execution (#65932), fabricated identifiers in parallel batches
-- Your work is context-heavy (large diffs, multi-file refactors, long sessions) — 4.6 scored 94.7% on NYT Connections vs 4.7's 41%
-- You want the original tokenizer (no 4.7+ 12-18% English token tax)
-- You're a high-volume user hitting Max 5-hour limits in 2-3 hours on 4.7/4.8 — field reports point to 4.6 sipping fewer tokens per turn
+**When the Latest tier is the right call:**
+- You want Anthropic's newest benchmark wins (SWE-Bench Pro 69.2% vs 4.7's 64.3%, Terminal-Bench 2.1 74.6% vs 4.7's 66.1%)
+- You use dynamic workflows / parallel subagent swarms — introduced in 4.8, not available in 4.6
+- You're on the launch-week mailing list and want to validate the newest model against your workflow
+- You haven't hit 4.7/4.8 token burn / false-green / dropped-constraint regressions in your own work
 
 **Tradeoffs (be honest):**
-- Misses 4.8's SWE-Bench Pro and Terminal-Bench 2.1 gains
-- No dynamic-workflows / parallel-subagent-swarm support introduced in 4.8
-- Anthropic-supported until ≥ Feb 5, 2027 (8 months minimum runway) — plan re-evaluation as that date approaches
-- 4.6's own Feb-Apr 2026 quality bugs are fully fixed per Anthropic's April 23 postmortem; this tier picks up the post-fix model, not the regression window
+- **Documented 40-60× cache token jump** vs 4.7 at HIGH effort ([AI Weekly](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn) — up to 900K cache tokens per turn). Burns Max 5-hour limits 2-3× faster than 4.6
+- **`max` effort is *worse* than `high` on 4.8** per [Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench) ("Max reasoning is not the best reasoning effort") — context fills faster
+- Active GitHub regressions still open: false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints ([#65932](https://github.com/anthropics/claude-code/issues/65932))
+- [Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html): "Anthropic deliberately made Opus's new tokenizer less efficient" — not a transient bug, structural pricing change
+- Anthropic-supported until ≥ May 28, 2027 (longer runway than 4.6)
 
 **How to opt in (global, sweeps every project):**
 
@@ -1098,25 +1100,25 @@ Edit `~/.claude/settings.json`:
 ```json
 {
   "env": {
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-6"
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8"
   },
   "model": "opus[1m]"
 }
 ```
 
-The `opus[1m]` alias resolves through the env vars, so this combination pins `claude-opus-4-6[1m]` (1M context) everywhere.
+The `opus[1m]` alias resolves through the env vars, so this combination pins `claude-opus-4-8[1m]` (1M context) everywhere.
 
 **Project-scoped (single repo):**
 ```json
 {
-  "model": "claude-opus-4-6[1m]"
+  "model": "claude-opus-4-8[1m]"
 }
 ```
 
-**Effort:** keep your usual `max` — 4.6 is the version field reports converge on as the only Opus that tolerates `max` without overthinking.
+**Effort tuning for 4.8:** field signal recommends `xhigh` instead of `max` on 4.8 — the strict-effort behavior overcorrects at `max`. Keep `max` for 4.6, drop to `xhigh` if running 4.8.
 
-**Escape hatch:** flip the env vars back to `claude-opus-4-8` (or remove them entirely to fall back to the wizard's flagship default).
+**Escape hatch:** flip the env vars back to `claude-opus-4-6` to return to the wizard's recommended default. Or remove them entirely to fall back to Claude Code auto-mode.
 
 ### Community Feature-Discovery Scanner (roadmap #207)
 
@@ -3025,7 +3027,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.79.0 -->
+<!-- SDLC Wizard Version: 1.80.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->

--- a/README.md
+++ b/README.md
@@ -142,18 +142,40 @@ codex exec -c 'model_reasoning_effort="xhigh"' -s danger-full-access \
 
 The wizard ships a **default recommendation**, not a mandate. You can swap to any Claude model — newer, older, or sibling tier — at any time. `/model` per session, or pin in `.claude/settings.json`.
 
-**Default: Opus 4.8 at max effort** (`[f] Flagship` in the setup wizard). Matches Anthropic's current flagship; unlocks 4.8's SWE-Bench Pro / Terminal-Bench 2.1 / dynamic-workflow gains. If you're starting fresh, this is the right pick.
+**Default: Opus 4.6 at max effort** (`[f] Flagship` in the setup wizard). This is the wizard's recommendation as of v1.80.0 — a stronger statement than "this might work." Here's why.
 
-**Alternative tier: Opus 4.6 at max effort** (`[s] Stability`, added v1.79.0). Some maintainers — including the wizard author — hit 4.7/4.8 regressions in production that 4.6 simply doesn't have: false-greens ([anthropics/claude-code#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers under parallel tool batches. Field signal converges on **4.6 being the only Opus where `max` effort doesn't overthink** — Andon Labs Vending-Bench arena (4.8 finished last), [Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide) ("most complaints about 4.7 feeling slow stem from people reflexively using max"), r/Claudeopus field reports (one maintainer: "12 hours with 4.8 zero deliverables; plugged in 4.6, 133 tests green in one session"). 4.6 is Anthropic-supported until ≥ Feb 5, 2027 per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum runway.
+### Why Opus 4.6 max, not Anthropic's latest
 
-**The wizard's stance: aim for stability.** Default to what works reliably in your hands, not what's newest. If 4.8 ships well for your workflow, stay on flagship. If you've hit the regressions, the Stability tier is one setup-wizard choice (`[s]`) and reversion is two lines in `~/.claude/settings.json`. See [CLAUDE_CODE_SDLC_WIZARD.md → "Stability tier — Opus 4.6 at max effort"](CLAUDE_CODE_SDLC_WIZARD.md) for the full pick-list and tradeoffs.
+Two weeks of in-the-wild data after Opus 4.8's launch (2026-05-28) showed a clear pattern:
 
-**Switch any time:**
+- **[Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench)** — 4.8 finished last vs 4.7 and GPT-5.5; documented "Max reasoning is not the best reasoning effort"; falls for scam suppliers 30× more frequently
+- **[AI Weekly: 900K cache tokens per turn](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn)** — 40-60× jump vs 4.7 at HIGH effort. Burns Max 5-hour limits 2-3× faster
+- **[Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html)** — explicit: "Anthropic deliberately made Opus's new tokenizer less efficient"; "a single coding prompt drained our entire token quota"
+- **Active GitHub regressions** — false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers in parallel tool batches
+- **[Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide)** — "most complaints about 4.7 feeling slow stem from people reflexively using max"
+- **[BSWEN effort decision guide](https://docs.bswen.com/blog/2026-04-19-claude-code-effort-level-decision-guide/)** — "Max on Opus causes overthinking on routine stuff. xHigh is the sweet spot for autonomous work"
+- **r/Claudeopus field reports** — one maintainer's literal A/B: "12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session." Top comment: "4.6 had the best overall balance at max"
+
+Six independent sources converging on the same conclusion: **4.6 is the only Opus where `max` effort tolerates without overthinking, and 4.7/4.8's "improvements" come with structural token-burn tradeoffs.** When you're running SDLC discipline workflows that span hours and tens of thousands of tokens, reliability beats benchmarks.
+
+4.6 is Anthropic-supported until **≥ Feb 5, 2027** per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum runway. The Feb-Apr 2026 quality bugs are fully fixed per Anthropic's [April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem) — the wizard picks up the post-fix model, not the regression window.
+
+### What 4.6 max gives up
+
+- 4.8's SWE-Bench Pro (69.2% vs 4.7's 64.3%) and Terminal-Bench 2.1 (74.6% vs 66.1%) gains
+- Dynamic-workflows and parallel-subagent-swarm features introduced in 4.8
+- Anthropic's "latest = best" convention. The wizard is explicitly betting against that convention here.
+
+### Latest tier — Opus 4.8 (opt-in)
+
+If you want the newest benchmarks and you're comfortable with the token-burn tradeoff, pick `[l] Latest` in the setup wizard. Recommended effort is `xhigh`, not `max`, on 4.8 — Andon Labs' data is explicit that `max` on 4.8 is worse than `xhigh`. The [`Latest tier — Opus 4.8`](CLAUDE_CODE_SDLC_WIZARD.md) section has the full opt-in instructions.
+
+### Switch any time
 
 ```bash
-/model claude-opus-4-8[1m]   # flagship default
-/model claude-opus-4-6[1m]   # stability tier
-/model opus[1m]              # whatever the wizard's recommendation resolves to
+/model claude-opus-4-6[1m]   # wizard's recommended flagship (default in v1.80.0+)
+/model claude-opus-4-8[1m]   # Anthropic's latest, opt-in via Latest tier
+/model opus[1m]              # whatever your env-var resolves to (alias)
 ```
 
 Or pin in `.claude/settings.json`:
@@ -164,9 +186,9 @@ Or pin in `.claude/settings.json`:
 
 Or sweep all your projects from one place by setting `ANTHROPIC_DEFAULT_OPUS_MODEL` in `~/.claude/settings.json` — the `opus[1m]` alias resolves through it, so flipping one env var switches every repo at once.
 
-Effort tuning is independent of model choice. `max` is the wizard's default; `xhigh` is the floor. Adjust per session with `/effort max`. The Stability tier is specifically a **`max`-effort tier** because that's the field-validated sweet spot for 4.6 — at the cost of giving up 4.8's newer benchmark wins.
+Effort tuning is independent of model choice. `max` is the wizard's default *paired with 4.6*; `xhigh` is the floor. Adjust per session with `/effort max`. On 4.8, drop effort to `xhigh` per field evidence.
 
-**A note on `[1m]` and billing.** The `[1m]` suffix on `claude-opus-4-6[1m]` is the 1M-context alias. As of [March 2026](https://claude.com/blog/1m-context-ga), 1M context is GA at standard pricing — **no long-context surcharge, no premium tier, no API-only restriction.** Interactive Claude Code sessions on Max / Team / Enterprise plans include 1M context automatically; whether you set `claude-opus-4-6` or `claude-opus-4-6[1m]`, you're billed against the same per-token Max budget at $5/$25 per million tokens. (Pro users need "Enable usage credits" turned on once.) The [June 15, 2026 billing split](https://codersera.com/blog/anthropic-june-2026-billing-change-claude-code/) moved *headless* surfaces — `claude -p`, Agent SDK, GitHub Actions, third-party apps — off the Max subscription onto a separate metered credit pool. Interactive Claude Code in your terminal stays on Max. Full details in [`AI_SETUP_LANES.md` § How Billing Works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split).
+**A note on `[1m]` and billing.** The `[1m]` suffix is the 1M-context alias. As of [March 2026](https://claude.com/blog/1m-context-ga), 1M context is GA at standard pricing — **no long-context surcharge, no premium tier, no API-only restriction.** Interactive Claude Code sessions on Max / Team / Enterprise plans include 1M context automatically; whether you set `claude-opus-4-6` or `claude-opus-4-6[1m]`, you're billed against the same per-token Max budget at $5/$25 per million tokens. (Pro users need "Enable usage credits" turned on once.) The [June 15, 2026 billing split](https://codersera.com/blog/anthropic-june-2026-billing-change-claude-code/) moved *headless* surfaces — `claude -p`, Agent SDK, GitHub Actions, third-party apps — off the Max subscription onto a separate metered credit pool. Interactive Claude Code in your terminal stays on Max. Full details in [`AI_SETUP_LANES.md` § How Billing Works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split).
 
 ## How It Works
 

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.79.0 -->
+<!-- SDLC Wizard Version: 1.80.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.159 -->
@@ -10,14 +10,14 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.79.0 |
-| Last Updated | 2026-06-08 |
-| Claude Code Minimum | v2.1.154+ (required for Opus 4.8 / `opus[1m]`); v2.1.105+ for `PreCompact` hook |
-| Claude Code Recommended | v2.1.159+ (latest at 2026-06-02) — unlocks Opus 4.8 (v2.1.154), `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
-| Recommended Model | `opus[1m]` (Opus 4.8, 1M context) — run `/model opus[1m]` |
+| Wizard Version | 1.80.0 |
+| Last Updated | 2026-06-09 |
+| Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
+| Claude Code Recommended | v2.1.159+ (latest at 2026-06-02) — `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
+| Recommended Model | `claude-opus-4-6[1m]` (Opus 4.6, 1M context) — run `/model claude-opus-4-6[1m]` |
 | Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |
 
-> **Effort warning (Opus 4.8):** `max` is the recommended default, `xhigh` is the absolute floor. Anything below `xhigh` (`high`, `medium`, `low`) causes Opus 4.8 to scope work tighter — shallow reasoning, skipped TDD, dropped self-review, SDLC non-compliance in practice. Use `high` or below only for trivial grep/search subagents, never for real SDLC work.
+> **Effort warning (Opus 4.6):** `max` is the recommended default, `xhigh` is the absolute floor. 4.6 is the field-validated Opus version where `max` doesn't overthink — Andon Labs Vending-Bench, Paweł Huryn's 4.7 guide, BSWEN effort decision guide, and r/Claudeopus reports all converge. Below `xhigh` (`high`, `medium`, `low`) scopes work tighter — shallow reasoning, skipped TDD, dropped self-review, SDLC non-compliance in practice. Use `high` or below only for trivial grep/search subagents.
 
 See `CLAUDE_CODE_SDLC_WIZARD.md` → "1M vs 200K Context Window" for the rationale and pricing notes.
 

--- a/cli/lib/repo-complexity.js
+++ b/cli/lib/repo-complexity.js
@@ -1,8 +1,8 @@
 // Roadmap #233: repo complexity heuristic for mixed-mode tier selection.
 //
 // Output: { tier: 'simple' | 'complex', score: <number>, signals: [...] }
-//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.8 reviewer)
-//   - 'complex' → setup wizard suggests full flagship (Opus 4.8 everywhere)
+//   - 'simple' → setup wizard suggests mixed-mode (Sonnet 4.6 coder + Opus 4.6 max reviewer)
+//   - 'complex' → setup wizard suggests full flagship (Opus 4.6 max everywhere)
 // Cross-model review (Codex / external) always stays at the flagship tier
 // regardless of coder selection — see CLAUDE_CODE_SDLC_WIZARD.md.
 //

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -3,17 +3,17 @@
 #
 # Behavior (per ROADMAP #217):
 #   effort=max    -> silent (preferred default, above floor)
-#   effort=xhigh  -> silent (minimum floor on Opus 4.8)
+#   effort=xhigh  -> silent (minimum floor on Opus 4.6 max)
 #   effort=high|medium|low (or unset) -> LOUD WARNING:
-#     Opus 4.8 needs xhigh floor for SDLC compliance (TDD, self-review, deep reasoning).
-#     Recommends `/effort max`. Also reminds about recommended model `opus[1m]`.
+#     Opus 4.6 max needs xhigh floor for SDLC compliance (TDD, self-review, deep reasoning).
+#     Recommends `/effort max`. Also reminds about recommended model `claude-opus-4-6[1m]`.
 #
 # CC does not expose the current model to hooks, so the model nudge is emitted as
 # guidance for Claude to compare against its own system prompt.
 #
 # Non-blocking: always exits 0.
 
-RECOMMENDED_MODEL="opus[1m]"
+RECOMMENDED_MODEL="claude-opus-4-6[1m]"
 
 # Token-bloat fix: when both project + plugin register this hook, plugin yields.
 HOOK_DIR="${BASH_SOURCE[0]%/*}"
@@ -57,7 +57,7 @@ else
 fi
 
 echo "=============================================================================="
-echo " WARNING: effort '$effort_display' breaks SDLC compliance on Opus 4.8."
+echo " WARNING: effort '$effort_display' breaks SDLC compliance on Opus 4.6 max."
 echo " Below xhigh = shallow reasoning, skipped TDD, dropped self-review."
 echo ""
 echo " Run: /effort max    (preferred, full SDLC compliance)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -114,7 +114,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 ## Recommended Model
 
-**Opt-in: `opus[1m]` (Opus 4.8 with 1M context).** `/model opus[1m]` at the start of non-trivial sessions — understand the tradeoff (issue #198). A top-level `model` pin in `.claude/settings.json` disables CC's per-turn auto-selection; pin only when you need 1M headroom. Requires CC v2.1.154+.
+**Opt-in: `claude-opus-4-6[1m]` (Opus 4.6 max + 1M context — wizard's flagship).** `/model claude-opus-4-6[1m]` at session start (issue #198). Top-level `model` pin disables CC auto-selection; pin only when you need 1M headroom. CC v2.1.154+. For 4.8 opt-in, see wizard "Latest tier".
 
 **Pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` when you opt in.** Without it, the default fires at ~76K on 1M. **Pick ONE — do NOT set both `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` AND `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`** — they compound to 30% × 400K = 120K trigger ≈ 12% of 1M, fires almost immediately (#207). See wizard "Autocompact Tuning" for details.
 
@@ -130,7 +130,7 @@ The loop goes back to PLANNING, not TDD RED. Run `/code-review`; issues at confi
 
 ## Cross-Model Review (If Configured)
 
-**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip:** trivial changes, time-sensitive hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.8 max — adversarial diversity is the point.
+**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip:** trivial changes, time-sensitive hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.6 max — adversarial diversity is the point.
 
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -247,11 +247,11 @@ The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the re
 > How do you want to configure the model for this repo?
 >
 > - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
-> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.8 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
-> - **[f] Flagship full** *(suggested for **complex** / stakes-flagged tier):* Pins `model: "opus[1m]"` (Opus 4.8 with 1M context) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. Long SDLC sessions cross 100K tokens regularly; the 1M window gives headroom and 30% autocompact fires at ~300K. Requires Claude Code v2.1.154+.
-> - **[s] Stability** *(alternative to flagship when you've hit 4.7/4.8 regressions):* Pins `model: "claude-opus-4-6[1m]"` (Opus 4.6 with 1M context). Community signal converges on 4.6 being the only Opus version `max` effort tolerates without overthinking. Picks up the original tokenizer (no 4.7+ 12-18% English token tax). Best for: production work hitting false-greens / 2-3× token burn on 4.7/4.8, context-heavy refactors, hitting Max 5-hour limits early. Anthropic-supported until ≥ Feb 5, 2027. Misses 4.8's SWE-Bench Pro / Terminal-Bench / dynamic-workflows gains.
+> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.6 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
+> - **[f] Flagship full** *(wizard's recommended default — suggested for complex / stakes-flagged):* Pins `model: "claude-opus-4-6[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. 4.6 max is the only Opus/max combo that doesn't overthink (Andon Labs, Huryn, BSWEN, r/Claudeopus). Avoids 4.7+ tokenizer tax. Anthropic-supported until ≥ Feb 5, 2027. Requires CC v2.1.154+.
+> - **[l] Latest** *(opt-in for Anthropic's newest Opus):* Pins `model: "claude-opus-4-8[1m]"`. Ships SWE-Bench Pro / Terminal-Bench / dynamic-workflows gains. Tradeoff: 40-60× cache token jump at HIGH, active false-green / token-burn regressions. Drop to `xhigh` (4.8's `max` is worse than `xhigh`).
 >
-> `[N/m/f/s]`
+> `[N/m/f/l]`
 
 **If the user answers `N` (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
 
@@ -269,17 +269,6 @@ Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window h
 
 ```json
 {
-  "model": "opus[1m]",
-  "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
-  }
-}
-```
-
-**If the user answers `s` (stability):** Edit `.claude/settings.json` and add:
-
-```json
-{
   "model": "claude-opus-4-6[1m]",
   "env": {
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
@@ -287,7 +276,20 @@ Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window h
 }
 ```
 
-Tell the user: "Effort `max` is the recommended pair for 4.6 (the only Opus version field reports converge on tolerating max without overthinking). Escape hatch is the same as flagship — remove the `model` line to fall back to auto-mode, or change it to `opus[1m]` to ride upstream's latest." See `CLAUDE_CODE_SDLC_WIZARD.md` → "Stability tier — Opus 4.6 at max effort" for the full rationale.
+Tell the user: "Pair this with `/effort max` — 4.6 is the only Opus version where `max` doesn't overthink. See [`README.md` § Choosing Your Model](../README.md#choosing-your-model) and `CLAUDE_CODE_SDLC_WIZARD.md` → 'Latest tier — Opus 4.8' for the full rationale + the opt-in alternative if you want Anthropic's newest model."
+
+**If the user answers `l` (latest):** Edit `.claude/settings.json` and add:
+
+```json
+{
+  "model": "claude-opus-4-8[1m]",
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+  }
+}
+```
+
+Tell the user: "Recommend dropping to `/effort xhigh` instead of `max` on 4.8 — strict effort behavior overcorrects at `max`. You'll want this if you're chasing SWE-Bench Pro / Terminal-Bench 2.1 / dynamic-workflows wins; otherwise the wizard's `[f] Flagship` (4.6 max) is the safer pick. Escape hatch: change the `model` value back to `claude-opus-4-6[1m]` or remove the line to fall back to auto-mode."
 
 Mention the escape hatch in all four cases:
 - To opt out later: remove the `model` line (and optionally the `env` block) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,10 +93,11 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.79.0
+Latest:    1.80.0
 
 What changed:
-- [1.79.0] Opus 4.6 Stability tier (max-effort sweet spot, community-validated flagship alternative).
+- [1.80.0] Flip default: Opus 4.6 max becomes recommended flagship; Opus 4.8 demoted to opt-in `[l] Latest` tier.
+- [1.79.0] Opus 4.6 Stability tier added as flagship alternative (now graduated to default in 1.80.0).
 - [1.78.0] Opus 4.7 → 4.8 model recommendation (#365) + min CC v2.1.154+.
 - [1.77.0] release-dry-run.yml + cc-version-drift.yml (#350) + /goal SDLC gates (95% + DLC binding).
 - [1.76.0] /goal /sdlc wrapper (#347) + CC v2.1.150 feature adoption + ROADMAP demand-signal gate (4 excise, 4 kill).
@@ -171,7 +172,7 @@ Check user's `.claude/settings.json`:
 1. **`model: "opus[1m]"` AND `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "30"`** — likely the old wizard-installed pair, not an intentional choice. Ask:
    > Your `.claude/settings.json` pins `model: "opus[1m]"` with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. This pair was the wizard default in 1.31.0–1.33.x, but it disables Claude Code's auto-mode (issue #198).
    > - **Remove the pin** (recommended) — keeps auto-mode enabled
-   > - **Keep the pin** — guaranteed Opus 4.8 + 1M, OK with no auto-selection
+   > - **Keep the pin** — guaranteed Opus 4.6 max + 1M, OK with no auto-selection
    > Remove, keep, or decide later? `[r/k/l]`
 
 2. **Only one of the two fields matches** — treat as intentional customization. Do not prompt.

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -1167,10 +1167,13 @@ test_setup_skill_references_settings_json() {
     fi
 }
 
-# Test 39b: Setup skill Step 9.5 frames the opus[1m] pin as opt-in with default No
+# Test 39b: Setup skill Step 9.5 frames the Opus pin as opt-in with default No
 # (issue #198). The key user-visible signals are: "opt-in", default "[y/N]" or
 # "Default: No" language, and an explicit note about auto-mode. Without these,
 # the wizard is still pushing the pin as the implicit default.
+#
+# v1.80.0 flipped from the opus[1m] alias to the explicit claude-opus-4-6[1m]
+# model id for the recommended flagship — both forms are acceptable references.
 test_setup_skill_step95_is_opt_in_default_no() {
     local skill="$SCRIPT_DIR/../skills/setup/SKILL.md"
     local step95
@@ -1178,11 +1181,11 @@ test_setup_skill_step95_is_opt_in_default_no() {
     local ok=true
     echo "$step95" | grep -qiE 'opt.?in|\[y/N\]|default.*no' || ok=false
     echo "$step95" | grep -qiE 'auto.?mode|auto.?select' || ok=false
-    echo "$step95" | grep -q 'opus\[1m\]' || ok=false
+    echo "$step95" | grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' || ok=false
     if [ "$ok" = true ]; then
-        pass "Setup skill Step 9.5 frames opus[1m] as opt-in (default No, mentions auto-mode)"
+        pass "Setup skill Step 9.5 frames Opus pin as opt-in (default No, mentions auto-mode)"
     else
-        fail "Setup skill Step 9.5 must frame opus[1m] pin as opt-in with default No + auto-mode note (issue #198)"
+        fail "Setup skill Step 9.5 must frame Opus pin as opt-in with default No + auto-mode note (issue #198)"
     fi
 }
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -362,10 +362,12 @@ test_wizard_doc_no_default_opus_1m_wording() {
 test_sdlc_skill_recommends_opus_1m() {
     local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
-    if grep -qE 'opus\[1m\]' "$SKILL"; then
-        pass "skills/sdlc/SKILL.md references opus[1m]"
+    # v1.80.0: accept either the opus[1m] alias OR an explicit
+    # claude-opus-4-X[1m] model id (flagship default flipped to 4.6 max).
+    if grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' "$SKILL"; then
+        pass "skills/sdlc/SKILL.md references an Opus pin (alias or explicit)"
     else
-        fail "skills/sdlc/SKILL.md missing opus[1m] recommendation"
+        fail "skills/sdlc/SKILL.md missing opus[1m] or claude-opus-4-X[1m] recommendation"
     fi
 }
 
@@ -396,15 +398,17 @@ test_cli_template_has_no_default_autocompact() {
     fi
 }
 
-# Setup skill Step 9.5 must still reference opus[1m] so the user can discover
-# it during the opt-in prompt — just without calling it the default.
+# Setup skill Step 9.5 must reference an Opus model alias (either the
+# `opus[1m]` generic alias or an explicit `claude-opus-4-X[1m]` id) so users
+# can discover the pin during the opt-in prompt — just without calling it the
+# default. v1.80.0 flipped to explicit model ids for the recommended flagship.
 test_setup_skill_mentions_opus_1m_in_optin_prompt() {
     local SKILL="$REPO_ROOT/skills/setup/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/setup/SKILL.md not found"; return; fi
-    if grep -qE 'opus\[1m\]' "$SKILL"; then
-        pass "skills/setup/SKILL.md references opus[1m] (opt-in prompt in Step 9.5)"
+    if grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' "$SKILL"; then
+        pass "skills/setup/SKILL.md references an Opus pin alias (opt-in prompt in Step 9.5)"
     else
-        fail "skills/setup/SKILL.md must name opus[1m] in the Step 9.5 opt-in prompt"
+        fail "skills/setup/SKILL.md must name opus[1m] or claude-opus-4-X[1m] in the Step 9.5 opt-in prompt"
     fi
 }
 
@@ -423,16 +427,19 @@ test_repo_settings_match_template_no_model_pin() {
     fi
 }
 
-# Hooks must nudge users toward the recommended alias, not the API id.
+# Hooks must nudge users toward the recommended Opus alias or explicit id,
+# not raw "claude-opus-4-6" without [1m] suffix (we want the 1M context).
 # Regression guard against Codex round-1 finding #3.
 # Post-#217 (2026-04-24): the effort/model nudge is centralized in
-# model-effort-check.sh — instructions-loaded-check.sh no longer duplicates it,
-# so we only require the alias in the single source of truth.
+# model-effort-check.sh — instructions-loaded-check.sh no longer duplicates it.
+# v1.80.0 flipped RECOMMENDED_MODEL from `opus[1m]` to explicit
+# `claude-opus-4-6[1m]`, so the wizard's flagship recommendation names the
+# version not the alias.
 test_hooks_recommend_opus_1m_alias() {
     local H1="$REPO_ROOT/hooks/model-effort-check.sh"
     if [ ! -f "$H1" ]; then fail "$H1 not found"; return; fi
-    if ! grep -qE 'RECOMMENDED_MODEL="opus\[1m\]"' "$H1"; then
-        fail "model-effort-check.sh should set RECOMMENDED_MODEL=\"opus[1m]\""
+    if ! grep -qE 'RECOMMENDED_MODEL="(opus\[1m\]|claude-opus-4-[0-9]+\[1m\])"' "$H1"; then
+        fail "model-effort-check.sh should set RECOMMENDED_MODEL to opus[1m] or claude-opus-4-X[1m]"
         return
     fi
     # instructions-loaded-check.sh must NOT re-declare the variable (would
@@ -442,7 +449,7 @@ test_hooks_recommend_opus_1m_alias() {
         fail "instructions-loaded-check.sh declares RECOMMENDED_MODEL — must delegate to model-effort-check.sh per #217"
         return
     fi
-    pass "model-effort-check.sh is single source of truth for opus[1m] alias (#217)"
+    pass "model-effort-check.sh is single source of truth for Opus model recommendation (#217)"
 }
 
 # Setup skill must point users at /less-permission-prompts so they can
@@ -511,15 +518,17 @@ test_sdlc_skill_warns_against_compound_autocompact_config() {
 }
 
 # Test (#207, Codex round 1 finding 2): the shipped `/sdlc` skill must frame
-# opus[1m] as opt-in (matching the wizard doc post-#198), not default.
+# the Opus pin as opt-in (matching the wizard doc post-#198), not default.
+# v1.80.0 flipped from opus[1m] alias to explicit claude-opus-4-6[1m] —
+# both forms are acceptable references to the opt-in pin.
 test_sdlc_skill_frames_opus_1m_as_opt_in() {
     local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
     # Must explicitly say "opt-in" or "issue #198" in the Recommended Model section.
-    if grep -qE 'Opt-in:.*opus\[1m\]|opt-in.*opus\[1m\]|opus\[1m\].*opt-in|issue #198' "$SKILL"; then
-        pass "skills/sdlc/SKILL.md frames opus[1m] as opt-in (#198, #207 round 1)"
+    if grep -qE 'Opt-in:.*opus\[1m\]|opt-in.*opus\[1m\]|opus\[1m\].*opt-in|Opt-in:.*claude-opus-4-[0-9]+\[1m\]|opt-in.*claude-opus-4-[0-9]+\[1m\]|claude-opus-4-[0-9]+\[1m\].*opt-in|issue #198' "$SKILL"; then
+        pass "skills/sdlc/SKILL.md frames Opus pin as opt-in (#198, #207 round 1)"
     else
-        fail "skills/sdlc/SKILL.md must frame opus[1m] as opt-in, not default (#198)"
+        fail "skills/sdlc/SKILL.md must frame Opus pin as opt-in, not default (#198)"
     fi
 }
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2560,7 +2560,8 @@ test_model_effort_check_exists() {
 }
 
 # Test: detects stale effort and outputs upgrade nudge with model recommendation.
-# The nudge must name the opus[1m] alias specifically so the command is copy-pasteable.
+# The nudge must name the wizard's recommended model alias so the command is copy-pasteable.
+# Wizard's flagship recommendation is claude-opus-4-6[1m] (v1.80.0+).
 test_model_effort_check_stale_effort() {
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -2571,10 +2572,10 @@ test_model_effort_check_stale_effort() {
     rm -rf "$tmpdir"
     if echo "$output" | grep -q '/effort' \
         && echo "$output" | grep -q 'recommended model' \
-        && echo "$output" | grep -qF 'opus[1m]'; then
-        pass "model-effort-check.sh nudges effort + recommends opus[1m] when effort is stale"
+        && echo "$output" | grep -qF 'claude-opus-4-6[1m]'; then
+        pass "model-effort-check.sh nudges effort + recommends claude-opus-4-6[1m] when effort is stale"
     else
-        fail "model-effort-check.sh should nudge /effort and recommend 'opus[1m]', got: $output"
+        fail "model-effort-check.sh should nudge /effort and recommend 'claude-opus-4-6[1m]', got: $output"
     fi
 }
 


### PR DESCRIPTION
## Summary

v1.79.0 added Opus 4.6 max as opt-in **Stability tier**. v1.80.0 graduates it to the wizard's **recommended flagship default**. This is an explicit bet against Anthropic's "newest = best" convention, grounded in six independent sources of post-launch data.

## Why

Six independent sources converged in the 12 days since 4.8 launched (2026-05-28) on the same conclusion: **4.6 is the only Opus where `max` effort tolerates without overthinking, and 4.7/4.8's tokenizer + agentic improvements come with structural token-burn tradeoffs that hurt long-running SDLC workflows.**

| Source | Finding |
|---|---|
| [Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench) | 4.8 finished last vs 4.7 and GPT-5.5; "Max reasoning is not the best reasoning effort"; falls for scam suppliers 30× more |
| [AI Weekly](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn) | 4.8 thinking burns up to 900K cache tokens per turn — 40-60× jump vs 4.7 at HIGH effort |
| [Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html) | "Anthropic deliberately made Opus's new tokenizer less efficient"; "a single coding prompt drained our entire token quota" |
| [Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide) | "most complaints about 4.7 feeling slow stem from people reflexively using max" |
| [BSWEN effort decision guide](https://docs.bswen.com/blog/2026-04-19-claude-code-effort-level-decision-guide/) | "Max on Opus causes overthinking on routine stuff. xHigh is the sweet spot" |
| r/Claudeopus field reports | One maintainer's literal A/B: "12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session." Top comment u/debuild: "4.6 had the best overall balance at max" |

Plus active GitHub regressions still open in Claude Code:
- [#63861](https://github.com/anthropics/claude-code/issues/63861) — false-greens (Claude declaring "done" without running canonical builds)
- [#64961](https://github.com/anthropics/claude-code/issues/64961) — 2-3× token burn regression
- [#64153](https://github.com/anthropics/claude-code/issues/64153) — 46K tokens for simple coding turn
- [#65932](https://github.com/anthropics/claude-code/issues/65932) — dropped constraints during execution
- Fabricated identifiers in parallel tool batches

## What ships

- **Setup wizard's `[f] Flagship full`** now writes `claude-opus-4-6[1m]` (was `opus[1m]` → 4.8)
- **New `[l] Latest` tier** opt-in for users who want Anthropic's newest Opus, with documented tradeoffs (drop to `xhigh` effort on 4.8)
- **All wizard prose flipped**: SDLC.md, CLAUDE_CODE_SDLC_WIZARD.md, skills/sdlc/SKILL.md, skills/setup/SKILL.md, skills/update/SKILL.md, hooks/model-effort-check.sh, cli/lib/repo-complexity.js
- **README "Choosing Your Model"** reframed as the full 6-source argument
- **6-location version bump** per SDLC.md checklist
- **CHANGELOG entry** explains the flip + names the signals to watch for a future reversion

## What does NOT ship

- **No breaking changes to consumer-repo installs.** `settings.json` template still ships unpinned — auto-mode default unchanged. The flip is at the *setup wizard's recommendation step* only.
- **v1.79.0 Stability tier code stays in git history** but is now redundant. The v1.80.0 prose subsumes it cleanly.

## Aligns with AI_SETUP_LANES.md

[`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) (shipped in v1.79.0) already named Opus 4.6 max as "Claude Premium" for both planner and driver in Setup A. The wizard's default flagship recommendation now matches.

## Runway

4.6 is Anthropic-supported until **≥ Feb 5, 2027** per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations) — 8 months minimum runway. The Feb-Apr 2026 quality bugs that triggered the original "is 4.6 nerfed" wave are fully fixed per Anthropic's [April 23 postmortem](https://www.anthropic.com/engineering/april-23-postmortem); the wizard's default picks up the post-fix model.

## Reversion criteria

If 4.8 regressions materially improve — Anthropic ships hotfixes for the token-burn issues, the GitHub bugs close, a second wave of positive field reports emerges — the default can flip back via a single PR. The CHANGELOG explicitly names these signals.

## Test plan

- [x] `test-version-logic` — 1.80.0 version bump validated
- [x] `test-docs-usability` — 29/29 pass, including "Update skill example shows current version (1.80.0)"
- [x] All 3 SKILL.md files under 20K char cap (setup: 19690, sdlc: 19951, update: 19907)
- [ ] CI `validate` covers test-hooks, test-analysis-schema, test-self-update — should pass since no code logic changed, only prose + version constants
- [ ] CI `publish-dry-run` should pass since `package.json` + shipped files are intact