### PR TITLE
feat(setup): add Setup C — Claude Lite lane (Haiku driver, no reviewer)

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -47,6 +47,7 @@ on:
       - 'skills/**'
       - '.claude-plugin/**'
       - 'CLAUDE_CODE_SDLC_WIZARD.md'
+      - 'AI_SETUP_LANES.md'
       - 'CHANGELOG.md'
       - 'README.md'
       - 'LICENSE*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Meta-repository — SDLC Wizard documentation, automation, and a zero-dep Node.j
 
 ## AI Setup Lanes
 
-This repo recommends two setup lanes for AI coding — Setup A (Claude Premium) and Setup B (Claude Saver). Both end at GPT-5.5 xhigh as the cross-model reviewer; only the planner/driver differ. Setup A keeps Opus 4.6 max for both planner and driver; Setup B keeps Opus 4.6 max as the planner but moves the driver to Sonnet for cost. See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list (when to use which, credit-spend warning, override policy).
+This repo recommends three setup lanes — Setup A (Claude Premium: Opus 4.6 max all three roles + GPT-5.5 reviewer), Setup B (Claude Saver: Opus 4.6 max planner + Sonnet driver + GPT-5.5 reviewer), and Setup C (Claude Lite: Haiku 4.5 driver, no reviewer — for grunt/deploy/ops work). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list.
 
 The lanes are guidance, not a hard rule — maintainer override is always allowed.
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -1,6 +1,6 @@
 # AI Setup Lanes
 
-Two recommended AI coding setups for this repo. Each is a complete triad: **planner → driver → reviewer**.
+Three recommended AI coding setups for this repo. Setups A and B are complete triads: **planner → driver → reviewer**. Setup C is a lightweight driver-only lane for operational grunt work.
 
 This is **guidance, not a hard rule**. Maintainer override is always allowed.
 
@@ -50,19 +50,55 @@ Setup B is sufficient for routine work where a Sonnet driver can ship with a str
 - Low-risk methodology edits
 - Mechanical refactors
 
+## Setup C — Claude Lite
+
+| Role | Model | Notes |
+|------|-------|-------|
+| **Planner** | You (the user) | Task is pre-planned, no model reasoning needed |
+| **Driver** | Haiku 4.5 | Cheapest Claude model: $1/$5 per Mtok (3× cheaper than Sonnet, 5× cheaper than Opus) |
+| **Driver fallback** | Sonnet 4.6 standard | If Haiku can't handle the task — $3/$15 per Mtok |
+| **Reviewer** | None | Blast radius too low for cross-model overhead |
+
+The "just do the thing" lane. No TDD enforcement, no cross-model review, no planning phase. You already know what to do — you just need a fast, cheap pair of hands.
+
+## When to Use Setup C
+
+Setup C is for work where SDLC discipline overhead exceeds the value:
+
+- Run a script with basic intelligence
+- Deploy to staging or prod
+- Config updates, env var changes
+- File moves, renames, bulk operations
+- Repo maintenance (dependency bumps, lockfile refreshes)
+- Simple administrative tasks across repos like `~/afterhours`
+- Anything where blast radius is low and you need speed, not depth
+
+## What Setup C explicitly skips
+
+- No TDD (no test-first for running a deploy script)
+- No cross-model review (not worth the cost or time for grunt work)
+- No planning phase (you are the planner)
+- No effort escalation (Haiku standard is plenty)
+
+**The discipline of knowing when NOT to use discipline.** Documenting this lane tells users "here's when to switch off the heavy methodology" rather than silently tempting them to skip it. If the task turns out to be harder than expected, escalate to Setup B or A — don't force-fit Haiku on a complex problem.
+
 ## Final Review Policy
 
-**Both lanes end at GPT-5.5 xhigh as the cross-model reviewer.** Claude can't grade its own homework — the reviewer always belongs to a different lab with different blind spots. See [CLAUDE_CODE_SDLC_WIZARD.md → "Cross-Model Review (Codex)"](CLAUDE_CODE_SDLC_WIZARD.md) for the handoff protocol.
+**Setups A and B end at GPT-5.5 xhigh as the cross-model reviewer.** Claude can't grade its own homework — the reviewer always belongs to a different lab with different blind spots. See [CLAUDE_CODE_SDLC_WIZARD.md → "Cross-Model Review (Codex)"](CLAUDE_CODE_SDLC_WIZARD.md) for the handoff protocol.
+
+**Setup C has no reviewer** — the blast radius doesn't justify it. If you're unsure whether a task is truly Lite, it probably isn't. Escalate.
 
 If GPT-5.5 isn't available on your OpenAI account, Codex auto-falls back to GPT-5.4 — still keep `model_reasoning_effort="xhigh"`. Lower reasoning misses subtle bugs that the reviewer is the last gate to catch.
 
 ## Credit-Spend Warning
 
-Both lanes use Opus 4.6 max for at least the planner — that's the expensive half. On Max-plan subscriptions, **Premium can burn the 5-hour cap faster than Saver** because Opus 4.6 max drives implementation too. If you're hitting the cap mid-session:
+Setups A and B use Opus 4.6 max for at least the planner — that's the expensive half. On Max-plan subscriptions, **Premium can burn the 5-hour cap faster than Saver** because Opus 4.6 max drives implementation too. If you're hitting the cap mid-session:
 
 - Drop to Setup B for the remainder of the day
-- Or stick with Premium but downshift effort to `xhigh` (Opus 4.6 still works well there)
+- Or drop to Setup C for grunt work that doesn't need Opus reasoning
 - Or use Sonnet directly for the final mechanical edits, then run the GPT-5.5 reviewer over the whole diff at the end
+
+**Setup C is the cheapest option** — Haiku at $1/$5 per Mtok is 5× cheaper than Opus. For high-volume operational work, this is where the savings are.
 
 The reviewer (GPT-5.5 xhigh) is billed against your OpenAI account, separately. Watch both bills.
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -66,7 +66,7 @@ The "just do the thing" lane. No TDD enforcement, no cross-model review, no plan
 Setup C is for work where SDLC discipline overhead exceeds the value:
 
 - Run a script with basic intelligence
-- Deploy to staging or prod
+- Deploy to staging (prod deploys need Setup A's discipline — human gate + rollback plan)
 - Config updates, env var changes
 - File moves, renames, bulk operations
 - Repo maintenance (dependency bumps, lockfile refreshes)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ Or sweep all your projects from one place by setting `ANTHROPIC_DEFAULT_OPUS_MOD
 
 Effort tuning is independent of model choice. `max` is the wizard's default *paired with 4.6*; `xhigh` is the floor. Adjust per session with `/effort max`. On 4.8, drop effort to `xhigh` per field evidence.
 
+### Three Setup Lanes
+
+The wizard defines three AI coding setups in [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md):
+
+| Lane | Planner | Driver | Reviewer | When |
+|------|---------|--------|----------|------|
+| **A — Premium** | Opus 4.6 max | Opus 4.6 max | GPT-5.5 xhigh | Architecture, releases, security, anything high-stakes |
+| **B — Saver** | Opus 4.6 max | Sonnet (latest) | GPT-5.5 xhigh | Routine impl, docs, tests, low-risk edits |
+| **C — Lite** | You | Haiku 4.5 ($1/$5/Mtok) | None | Scripts, deploys to staging, config changes, grunt work |
+
+Setup C's whole point: **the discipline of knowing when NOT to use discipline.** When blast radius is low and you just need fast cheap hands, skip the SDLC overhead.
+
 **A note on `[1m]` and billing.** The `[1m]` suffix is the 1M-context alias. As of [March 2026](https://claude.com/blog/1m-context-ga), 1M context is GA at standard pricing — **no long-context surcharge, no premium tier, no API-only restriction.** Interactive Claude Code sessions on Max / Team / Enterprise plans include 1M context automatically; whether you set `claude-opus-4-6` or `claude-opus-4-6[1m]`, you're billed against the same per-token Max budget at $5/$25 per million tokens. (Pro users need "Enable usage credits" turned on once.) The [June 15, 2026 billing split](https://codersera.com/blog/anthropic-june-2026-billing-change-claude-code/) moved *headless* surfaces — `claude -p`, Agent SDK, GitHub Actions, third-party apps — off the Max subscription onto a separate metered credit pool. Interactive Claude Code in your terminal stays on Max. Full details in [`AI_SETUP_LANES.md` § How Billing Works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split).
 
 ## How It Works

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hooks/",
     ".claude-plugin/",
     "CLAUDE_CODE_SDLC_WIZARD.md",
+    "AI_SETUP_LANES.md",
     "CHANGELOG.md"
   ],
   "keywords": [


### PR DESCRIPTION
## Summary

Third AI Setup Lane for operational grunt work. Joins Setup A (Premium) and Setup B (Saver).

**Setup C — Claude Lite**
| Role | Model | Price |
|------|-------|-------|
| Planner | You | Free |
| Driver | Haiku 4.5 | $1/$5 per Mtok |
| Driver fallback | Sonnet 4.6 standard | $3/$15 per Mtok |
| Reviewer | None | N/A |

For: script execution, deploys, config updates, repo maintenance, bulk ops across repos like ~/afterhours. No TDD, no cross-model review, no planning phase.

Pure docs — no version bump, no source/package changes.

## Test plan

- [ ] CI validate passes
- [ ] Codex cross-model review