### PR TITLE
fix(review): address Codex round-1 Lite lane findings — 2 P1s, 2 P2s

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          for path in cli/ skills/ hooks/ .claude-plugin/ CLAUDE_CODE_SDLC_WIZARD.md CHANGELOG.md; do
+          for path in cli/ skills/ hooks/ .claude-plugin/ CLAUDE_CODE_SDLC_WIZARD.md AI_SETUP_LANES.md CHANGELOG.md; do
             # `npm publish --dry-run --json` includes a `files[]` array
             # listing every shipped file path. Match the path prefix to
             # detect at least one file from each entry.
@@ -132,4 +132,4 @@ jobs:
             echo "If package.json.files was edited intentionally, update tests/test-release-dry-run-workflow.sh too."
             exit 1
           fi
-          echo "All 6 shipped paths present in dry-run output."
+          echo "All 7 shipped paths present in dry-run output."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Meta-repository — SDLC Wizard documentation, automation, and a zero-dep Node.j
 
 ## AI Setup Lanes
 
-This repo recommends three setup lanes — Setup A (Claude Premium: Opus 4.6 max all three roles + GPT-5.5 reviewer), Setup B (Claude Saver: Opus 4.6 max planner + Sonnet driver + GPT-5.5 reviewer), and Setup C (Claude Lite: Haiku 4.5 driver, no reviewer — for grunt/deploy/ops work). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list.
+This repo recommends three setup lanes — Setup A (Claude Premium: Opus 4.6 max planner + driver, GPT-5.5 xhigh reviewer), Setup B (Claude Saver: Opus 4.6 max planner + Sonnet driver + GPT-5.5 reviewer), and Setup C (Claude Lite: Haiku 4.5 driver, no reviewer — for grunt/deploy/ops work). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list.
 
 The lanes are guidance, not a hard rule — maintainer override is always allowed.
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -73,6 +73,10 @@ Setup C is for work where SDLC discipline overhead exceeds the value:
 - Simple administrative tasks across repos like `~/afterhours`
 - Anything where blast radius is low and you need speed, not depth
 
+**Not Lite — escalate to A or B:** env vars that touch secrets or credentials, dependency bumps with security advisories, destructive bulk ops (rm -rf, drop table), migrations, prod-like shared staging, anything security-sensitive. If you're unsure, it's not Lite.
+
+**Haiku's context limit is 200K** (vs 1M for Opus/Sonnet). If the task needs to load a large diff, multi-file refactor, or cross-repo audit, Haiku will hit the ceiling — escalate to Setup B.
+
 ## What Setup C explicitly skips
 
 - No TDD (no test-first for running a deploy script)

--- a/tests/test-release-dry-run-workflow.sh
+++ b/tests/test-release-dry-run-workflow.sh
@@ -227,13 +227,13 @@ test_asserts_shipped_paths() {
     # dry-run output — otherwise a regression where package.json.files
     # silently drops a path would not be caught.
     local missing=""
-    for path in 'cli/' 'skills/' 'hooks/' '.claude-plugin/' 'CLAUDE_CODE_SDLC_WIZARD.md' 'CHANGELOG.md'; do
+    for path in 'cli/' 'skills/' 'hooks/' '.claude-plugin/' 'CLAUDE_CODE_SDLC_WIZARD.md' 'AI_SETUP_LANES.md' 'CHANGELOG.md'; do
         if ! grep -qF "$path" "$WF"; then
             missing="$missing $path"
         fi
     done
     if [ -z "$missing" ]; then
-        pass "workflow references all 6 shipped paths from package.json.files for assertion"
+        pass "workflow references all 7 shipped paths from package.json.files for assertion"
     else
         fail "workflow missing shipped-path assertions for:$missing"
     fi


### PR DESCRIPTION
## Summary

Codex xhigh cross-model review of PR #387 (Setup C — Lite lane) returned FINDINGS. All 4 fixed:

- **P1** Dry-run assertion loop + test hardcoded 6 shipped paths — now 7 (added `AI_SETUP_LANES.md`)
- **P1** Setup C task list lacked explicit exclusions for high-blast-radius items (secrets, prod staging, migrations, destructive bulk ops) and Haiku's 200K context ceiling
- **P2** AGENTS.md said "all three roles" but Opus only fills 2 (planner + driver); GPT-5.5 is the third
- **P2** Haiku 4.5 has 200K context (not 1M like Opus/Sonnet) — added escalation guidance for large diffs

## Test plan

- [x] release-dry-run tests: 25/25 (new path count assertion verified)
- [x] doc-consistency tests: 41/41
- [x] hooks tests: 160/160
- [x] CLI tests: 92/92
- [x] session-load audit: 10/10