### PR TITLE
fix(hooks,cli): banner misfire host-gate + structural settings check (#375, #383)

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -544,8 +544,13 @@ function settingsHooksMatch(srcPath, destPath) {
         if (!th.command) continue;
         const marker = WIZARD_HOOK_MARKERS.find((m) => th.command.includes(m));
         if (!marker) continue;
+        // Verify marker present AND type matches. We intentionally skip matcher/if
+        // comparison — those are customizable per-project (the wizard's own settings
+        // use different if guards than the consumer template).
         const found = dest.hooks[event].some(
-          (de) => de.hooks && de.hooks.some((h) => h.command && h.command.includes(marker))
+          (de) => de.hooks && de.hooks.some(
+            (h) => h.command && h.command.includes(marker) && h.type === (th.type || 'command')
+          )
         );
         if (!found) return false;
       }

--- a/cli/init.js
+++ b/cli/init.js
@@ -532,16 +532,45 @@ function buildUpdateRecommendation(updateInfo, customizedCount) {
   return lines;
 }
 
+function settingsHooksMatch(srcPath, destPath) {
+  try {
+    const src = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
+    const dest = JSON.parse(fs.readFileSync(destPath, 'utf8'));
+    for (const [event, entries] of Object.entries(src.hooks || {})) {
+      if (!dest.hooks || !dest.hooks[event]) return false;
+      const templateEntry = entries[0];
+      if (!templateEntry || !templateEntry.hooks) continue;
+      for (const th of templateEntry.hooks) {
+        if (!th.command) continue;
+        const marker = WIZARD_HOOK_MARKERS.find((m) => th.command.includes(m));
+        if (!marker) continue;
+        const found = dest.hooks[event].some(
+          (de) => de.hooks && de.hooks.some((h) => h.command && h.command.includes(marker))
+        );
+        if (!found) return false;
+      }
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function checkFile(srcPath, destPath, relativeDest, shouldBeExecutable) {
   if (!fs.existsSync(destPath)) {
     return { file: relativeDest, status: 'MISSING' };
   }
   const srcHash = crypto.createHash('sha256').update(fs.readFileSync(srcPath)).digest('hex');
   const destHash = crypto.createHash('sha256').update(fs.readFileSync(destPath)).digest('hex');
-  const result = {
-    file: relativeDest,
-    status: srcHash === destHash ? 'MATCH' : 'CUSTOMIZED',
-  };
+  let fileStatus;
+  if (srcHash === destHash) {
+    fileStatus = 'MATCH';
+  } else if (relativeDest === '.claude/settings.json' && settingsHooksMatch(srcPath, destPath)) {
+    fileStatus = 'MATCH';
+  } else {
+    fileStatus = 'CUSTOMIZED';
+  }
+  const result = { file: relativeDest, status: fileStatus };
 
   if (shouldBeExecutable) {
     try {

--- a/hooks/instructions-loaded-check.sh
+++ b/hooks/instructions-loaded-check.sh
@@ -256,7 +256,9 @@ if [ -f "$PROJECT_DIR/.github/workflows/weekly-update.yml" ] && \
 fi
 
 # Claude Code version check (non-blocking, best-effort)
-if command -v claude > /dev/null 2>&1 && command -v npm > /dev/null 2>&1; then
+# Gate on CLAUDE_PROJECT_DIR — only Claude Code sets this. Without it, we're
+# running under Codex/OpenCode where a CC update nudge is misleading (#375).
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && command -v claude > /dev/null 2>&1 && command -v npm > /dev/null 2>&1; then
     CC_LOCAL=$(claude --version 2>/dev/null | grep -o '[0-9][0-9.]*' | head -1) || true
     if [ -n "$CC_LOCAL" ]; then
         CC_LATEST=$(npm view @anthropic-ai/claude-code version 2>/dev/null) || true

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -415,6 +415,30 @@ test_check_customized() {
     rm -rf "$d"
 }
 
+# #383: consumer settings.json with extra hooks should still show MATCH for
+# settings.json — the wizard hooks are all present, extras are intentional.
+test_check_settings_match_with_extras() {
+    local d
+    d=$(make_temp)
+    (cd "$d" && node "$CLI" init > /dev/null 2>&1)
+    # Add extra consumer hooks (simulating PDLC or custom project hooks)
+    node -e "
+      const fs = require('fs');
+      const s = JSON.parse(fs.readFileSync('$d/.claude/settings.json','utf8'));
+      s.permissions = {allow:['Bash(npm test)']};
+      s.hooks.SessionStart[0].hooks.push({type:'command',command:'echo custom-hook'});
+      fs.writeFileSync('$d/.claude/settings.json', JSON.stringify(s,null,2)+'\n');
+    "
+    local output
+    output=$(cd "$d" && node "$CLI" check 2>&1)
+    if echo "$output" | grep "settings.json" | grep -q "MATCH"; then
+        pass "#383: settings.json with extra hooks shows MATCH (wizard hooks present)"
+    else
+        fail "#383: settings.json with extra hooks should show MATCH, got: $(echo "$output" | grep settings)"
+    fi
+    rm -rf "$d"
+}
+
 # Test 19: check on empty dir shows all MISSING
 test_check_all_missing() {
     local d
@@ -945,6 +969,7 @@ test_tdd_hook_generic
 test_no_allowed_tools
 test_check_all_match
 test_check_customized
+test_check_settings_match_with_extras
 test_check_all_missing
 test_check_json
 test_check_drift_permissions

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2305,6 +2305,33 @@ test_update_notification_rejects_non_numeric_minor
 test_update_notification_silent_when_installed_newer_than_cache
 test_update_notification_surfaces_npm_failure
 
+# #375: CC version check must NOT fire under non-Claude hosts (Codex, OpenCode).
+# The bug: `command -v claude` is true even under Codex/OpenCode when the user
+# has Claude Code installed. Gate on CLAUDE_PROJECT_DIR instead of CLI presence.
+test_cc_version_check_silent_under_non_claude_host() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo '<!-- SDLC Wizard Version: 1.20.0 -->' > "$tmpdir/SDLC.md"
+    touch "$tmpdir/TESTING.md"
+    mkdir -p "$tmpdir/bin"
+    # Fake claude CLI that reports an old version
+    printf '#!/bin/bash\necho "2.1.90 (Claude Code)"\n' > "$tmpdir/bin/claude"
+    # Fake npm that reports a newer version
+    printf '#!/bin/bash\nif echo "$@" | grep -q "claude-code"; then echo "2.1.168"; else echo "1.20.0"; fi\n' > "$tmpdir/bin/npm"
+    chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm"
+    local output
+    # Key: do NOT set CLAUDE_PROJECT_DIR — simulates running under Codex/OpenCode
+    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" SDLC_WIZARD_CACHE_DIR="$tmpdir/cache" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if echo "$output" | grep -q "Claude Code update"; then
+        fail "#375: CC version check should NOT fire when CLAUDE_PROJECT_DIR is unset (non-Claude host)"
+    else
+        pass "#375: CC version check silent under non-Claude host (CLAUDE_PROJECT_DIR unset)"
+    fi
+}
+
+test_cc_version_check_silent_under_non_claude_host
+
 echo ""
 echo "--- Hook if-conditional tests (#68) ---"
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2320,8 +2320,9 @@ test_cc_version_check_silent_under_non_claude_host() {
     printf '#!/bin/bash\nif echo "$@" | grep -q "claude-code"; then echo "2.1.168"; else echo "1.20.0"; fi\n' > "$tmpdir/bin/npm"
     chmod +x "$tmpdir/bin/claude" "$tmpdir/bin/npm"
     local output
-    # Key: do NOT set CLAUDE_PROJECT_DIR — simulates running under Codex/OpenCode
-    output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" SDLC_WIZARD_CACHE_DIR="$tmpdir/cache" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
+    # Key: explicitly unset CLAUDE_PROJECT_DIR — simulates running under Codex/OpenCode.
+    # Must use env -u to prevent inheriting from the parent shell (e.g., when run from Claude Code).
+    output=$(cd "$tmpdir" && env -u CLAUDE_PROJECT_DIR PATH="$tmpdir/bin:$PATH" SDLC_WIZARD_CACHE_DIR="$tmpdir/cache" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q "Claude Code update"; then
         fail "#375: CC version check should NOT fire when CLAUDE_PROJECT_DIR is unset (non-Claude host)"


### PR DESCRIPTION
## Summary

- **#375** CC version check nudge fired under Codex/OpenCode because it gated on `command -v claude` (CLI presence), not on the actual host. Fixed by gating on `CLAUDE_PROJECT_DIR` — only Claude Code sets this env var.
- **#383** Drift checker flagged consumer settings.json as CUSTOMIZED when the only difference was extra hooks/permissions the consumer added. Fixed by falling back to structural comparison: if every wizard hook marker is registered in the consumer's settings, the file is MATCH regardless of extras.

## Test plan

- [x] **#375 TDD**: new test `test_cc_version_check_silent_under_non_claude_host` — verified red before fix, green after
- [x] **#383 TDD**: new test `test_check_settings_match_with_extras` — verified red before fix, green after
- [x] hooks: 161/161 (was 160, +1 new)
- [x] CLI: 93/93 (was 92, +1 new)
- [x] doc-consistency: 41/41
- [x] release-dry-run: 25/25