### PR TITLE
feat(sdlc): cross-model review REQUIRED for high-stakes (closes #372)

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2486,7 +2486,7 @@ Self-review passes → handoff.json (round 1, PENDING_REVIEW)
 
 **Tool-agnostic:** The value is adversarial diversity (different model, different blind spots), not the specific tool. Any competing AI reviewer works.
 
-**Full protocol:** See the "Cross-Model Review Loop (Optional)" section below for key flags and reasoning effort guidance.
+**Full protocol:** See the "Cross-Model Review Loop" section below for key flags and reasoning effort guidance.
 
 ### Release Review Focus
 
@@ -3787,7 +3787,7 @@ Claude: [fetches via gh api, discusses with you interactively]
 
 This is optional - skip if you prefer fresh reviews only.
 
-### Cross-Model Review Loop (Optional)
+### Cross-Model Review Loop (REQUIRED for High-Stakes)
 
 Use an independent AI model from a different company as a code reviewer. The author can't grade their own homework — a model with different training data and different biases catches blind spots the authoring model misses.
 

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2372,10 +2372,10 @@ PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Self-Review
 4. Issues below 80 are likely false positives — skip unless obviously valid
 5. Address issues by going back through the proper SDLC loop
 
-## Cross-Model Review (If Configured)
+## Cross-Model Review (REQUIRED for High-Stakes)
 
 **When to run:** High-stakes changes (auth, payments, data handling), releases/publishes (version bumps, CHANGELOG, npm publish), complex refactors, research-heavy work.
-**When to skip:** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
+**When to skip (log justification):** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
 
 **Prerequisites:** Codex CLI installed (`npm i -g @openai/codex`), OpenAI API key set.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Layer 1: PHILOSOPHY
 | **Pre-tool TDD hooks** | Before source edits, a hook reminds Claude to write tests first. CI scoring checks whether it actually followed TDD |
 | **Self-evolving loop** | Weekly/monthly external research + local CI shepherd loop — you approve, the system gets better |
 
-## Optional: Cross-Model Review (Codex)
+## Cross-Model Review (Codex) — REQUIRED for High-Stakes
 
 Claude can't grade its own homework. Have a **different AI from a different company** review Claude's work — different training, different blind spots, different biases. We use OpenAI's Codex CLI, and it's **three commands to set up**:
 
@@ -136,7 +136,7 @@ codex exec -c 'model_reasoning_effort="xhigh"' -s danger-full-access \
 
 **Always append `< /dev/null`** when running `codex exec` from a non-interactive parent (background, hooks, CI, Claude Code Bash tool). Without it, codex blocks on stdin reads even when the prompt is an argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file. Validated on codex-cli 0.130.0 / macOS 14, 2026-05-15.
 
-`xhigh` reasoning is **non-negotiable** — lower settings miss subtle bugs. See [CLAUDE_CODE_SDLC_WIZARD.md](CLAUDE_CODE_SDLC_WIZARD.md#cross-model-review-loop-optional) for the full protocol (handoff format, round-2 dialogue loop, preflight docs). Real-world: this catches P0/P1 issues in 2-3 out of 10 reviews that Claude's self-review rated as clean.
+`xhigh` reasoning is **non-negotiable** — lower settings miss subtle bugs. See [CLAUDE_CODE_SDLC_WIZARD.md](CLAUDE_CODE_SDLC_WIZARD.md#cross-model-review-loop-required-for-high-stakes) for the full protocol (handoff format, round-2 dialogue loop, preflight docs). Real-world: this catches P0/P1 issues in 2-3 out of 10 reviews that Claude's self-review rated as clean.
 
 ## Choosing Your Model
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -128,9 +128,9 @@ PLANNING → DOCS → TDD RED → GREEN → Tests Pass → Self-Review
 
 The loop goes back to PLANNING, not TDD RED. Run `/code-review`; issues at confidence ≥ 80 are real, < 80 are likely false positives. Found issues → ask "Want a plan to fix?" → new plan → docs → TDD → review.
 
-## Cross-Model Review (If Configured)
+## Cross-Model Review (REQUIRED for High-Stakes)
 
-**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip:** trivial changes, time-sensitive hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.6 max — adversarial diversity is the point.
+**When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **When to skip (log justification):** trivial, hotfixes, risk < review cost. **Prerequisites:** Codex CLI (`npm i -g @openai/codex`) + OpenAI API key. **Reviewer at flagship tier (#233):** even when project pins `sonnet[1m]`, reviewer runs `gpt-5.5` / Opus 4.6 max — adversarial diversity is the point.
 
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -874,10 +874,16 @@ test_codex_review_guidance_teaches_background_mode
 # #372: Cross-model review is REQUIRED for high-stakes, not opt-in
 test_cross_model_review_required_not_optional() {
     local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
-    if grep -q 'REQUIRED' "$SKILL" && ! grep -q 'If Configured' "$SKILL"; then
-        pass "#372: Cross-model review is REQUIRED (not opt-in 'If Configured')"
+    local WIZARD="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    local ok=true
+    grep -q '## Cross-Model Review (REQUIRED' "$SKILL" || ok=false
+    grep -q 'REQUIRED' "$WIZARD" || ok=false
+    grep -q 'If Configured' "$SKILL" && ok=false
+    grep -q 'log justification' "$SKILL" || ok=false
+    if [ "$ok" = true ]; then
+        pass "#372: Cross-model review REQUIRED in skill + wizard, skip requires justification"
     else
-        fail "#372: skills/sdlc/SKILL.md should say REQUIRED, not 'If Configured'"
+        fail "#372: Cross-model review heading must say REQUIRED, not 'If Configured', with log justification"
     fi
 }
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -871,6 +871,18 @@ test_codex_exec_blocks_redirect_stdin
 test_sdlc_skill_has_goal_wrapper
 test_codex_review_guidance_teaches_background_mode
 
+# #372: Cross-model review is REQUIRED for high-stakes, not opt-in
+test_cross_model_review_required_not_optional() {
+    local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
+    if grep -q 'REQUIRED' "$SKILL" && ! grep -q 'If Configured' "$SKILL"; then
+        pass "#372: Cross-model review is REQUIRED (not opt-in 'If Configured')"
+    else
+        fail "#372: skills/sdlc/SKILL.md should say REQUIRED, not 'If Configured'"
+    fi
+}
+
+test_cross_model_review_required_not_optional
+
 # ────────────────────────────────────────────
 # Summary
 # ────────────────────────────────────────────

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -241,10 +241,10 @@ test_version_consistency() {
 
 # Test 16: Wizard contains Cross-Model Review section
 test_cross_model_review_section() {
-    if grep -q "### Cross-Model Review Loop (Optional)" "$WIZARD"; then
-        pass "Wizard contains Cross-Model Review section"
+    if grep -q "### Cross-Model Review Loop (REQUIRED" "$WIZARD"; then
+        pass "Wizard contains Cross-Model Review section (REQUIRED)"
     else
-        fail "Wizard should contain '### Cross-Model Review Loop (Optional)' section"
+        fail "Wizard should contain '### Cross-Model Review Loop (REQUIRED for High-Stakes)' section"
     fi
 }
 
@@ -388,7 +388,7 @@ test_step_registry_update_wizard
 # Helper: extract wizard cross-model blocks (embedded SKILL + deep-dive)
 wizard_cross_model_blocks() {
     # Embedded SKILL section: ## Cross-Model Review ... ## Test Review
-    sed -n '/^## Cross-Model Review (If Configured)/,/^## Test Review/p' "$WIZARD"
+    sed -n '/^## Cross-Model Review (REQUIRED/,/^## Test Review/p' "$WIZARD"
     # Deep-dive section: ### Cross-Model Review Loop ... next ### or EOF
     sed -n '/^### Cross-Model Review Loop/,/^### [^C]/p' "$WIZARD"
 }


### PR DESCRIPTION
## Summary

- Changed "Cross-Model Review (If Configured)" → "Cross-Model Review (REQUIRED for High-Stakes)" in both skill and wizard doc
- Added "(log justification)" to the "When to skip" text — skipping is allowed but must be explicit
- Incident-driven: 32 commits shipped single-model on kajillionaire because the opt-in framing was too easy to silently skip; Codex caught 2 P1s that all single-model gates missed

## Test plan

- [x] New test: `test_cross_model_review_required_not_optional` — verifies REQUIRED in skill, no "If Configured"
- [x] doc-consistency: 42/42
- [x] session-load audit: 10/10 (skill stays under 20K chars)