### PR TITLE
fix(review): address Codex round-2 stale opt-in refs (#372 follow-up)

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2271,7 +2271,7 @@ TodoWrite([
   { content: "DRY check: Is logic duplicated elsewhere?", status: "pending", activeForm: "Checking for duplication" },
   { content: "Self-review: run /code-review", status: "pending", activeForm: "Running code review" },
   { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
-  { content: "Cross-model review (if configured — see below)", status: "pending", activeForm: "Running cross-model review" },
+  { content: "Cross-model review (REQUIRED for high-stakes)", status: "pending", activeForm: "Running cross-model review" },
   // CI FEEDBACK LOOP (After local tests pass)
   { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
   { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
@@ -4164,7 +4164,7 @@ Every wizard step has a unique ID for tracking:
 | `step-9` | SDLC/TESTING/ARCH docs | 1.0.0 |
 | `question-git-workflow` | Git workflow preference | 1.2.0 |
 | `step-update-notify` | Optional: CI update notification | 1.13.0 |
-| `step-cross-model-review` | Optional: Cross-model review loop | 1.16.0 |
+| `step-cross-model-review` | Cross-model review (REQUIRED for high-stakes) | 1.16.0 |
 | `step-update-wizard` | /update-wizard smart update skill | 1.18.0 |
 
 When checking for updates, Claude compares user's completed steps against this registry.

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -47,7 +47,7 @@ TodoWrite([
   { content: "Visual consistency check (if UI change)", status: "pending" },
   { content: "Self-review: run /code-review", status: "pending" },
   { content: "Security review (if warranted)", status: "pending" },
-  { content: "Cross-model review (if configured)", status: "pending" },
+  { content: "Cross-model review (high-stakes)", status: "pending" },
   { content: "Scope guard: only changes related to task? No legacy/fallback code left?", status: "pending" },
   // CI SHEPHERD
   { content: "Commit and push to remote", status: "pending" },


### PR DESCRIPTION
## Summary

Follow-up to PR #394. Codex round 2 found 3 more stale "if configured"/"Optional" references that the initial PR missed:

- **P1** TodoWrite checklist in skill + wizard doc still said "if configured" (lowercase)
- **P2** Step registry still said "Optional: Cross-model review loop"

## Test plan

- [x] doc-consistency: 42/42
- [x] self-update: 153/153
- [x] session-load: 10/10