### PR TITLE
fix(hooks): effort config — env var precedence + max-only floor (#395)

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -249,13 +249,12 @@ When Anthropic provides official plugins or tools that handle something:
 
 Claude Code's **effort level** controls how much thinking the model does before responding. Higher effort = deeper reasoning but more tokens.
 
-> ⚠️ **On Opus 4.6 max, effort below `xhigh` breaks SDLC compliance in practice.** Inherited from 4.7, Opus 4.6 max respects effort levels *strictly* — at `high` or below it scopes work tighter (shallow reasoning, skipped TDD, no self-review) rather than going above-and-beyond. Treat the table below accordingly: **`max` is the recommended default, `xhigh` is the floor**, `high` or below is for trivial grep/search subagents only.
+> ⚠️ **SDLC requires `max` effort on all Claude models.** Below max = degraded reasoning, shallow TDD, weak self-review. Persist via env var: `CLAUDE_CODE_EFFORT_LEVEL=max` (CC docs: `effortLevel: "max"` in settings.json is **session-only and silently ignored** — the env var is the only way to persist it).
 
 | Level | When to Use | How to Set |
 |-------|-------------|------------|
-| `high` or below | **Not for SDLC work on Opus 4.6 max.** Only for trivial grep/search subagents or one-shot questions that don't require planning | `effort: high` in a specific subagent frontmatter only |
-| `xhigh` | **Floor for SDLC work on Opus 4.6 max.** Long-running tasks, repeated tool calls, deep exploration. Claude Code defaults to this on Opus 4.7+ | `/effort xhigh` or set in skill frontmatter |
-| `max` | **Recommended default for Opus 4.6 max SDLC work.** Multi-file changes, architecture decisions, debugging, cross-model reviews, any task touching wizard/skill/CI code | `/effort max` (session only — resets next session) |
+| `max` | **Required for all SDLC work.** Claude: max. OpenAI/Codex: xhigh (their highest). | `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block |
+| `high` or below | **Not for SDLC work.** Only for trivial grep/search subagents | `effort: high` in a specific subagent frontmatter only |
 
 **Strict effort behavior (Opus 4.7+, carried forward in 4.8 — and why 4.6 max is the wizard's pick):**
 - **`xhigh` was introduced in 4.7** — sits between `high` and `max`, designed for coding and agentic work (30+ minute tasks with token budgets in the millions)
@@ -267,7 +266,7 @@ Claude Code's **effort level** controls how much thinking the model does before 
 
 **Why `high` was the previous default:** Claude Code uses **adaptive thinking** to dynamically allocate reasoning budget per turn. On Pro and Max plans, the default effort level was **medium (85)**, which causes the model to under-allocate reasoning on complex multi-step tasks — leading to shallow analysis, missed edge cases, and "lazy" outputs. This was [confirmed by Anthropic engineer Boris Cherny](https://github.com/anthropics/claude-code/issues/42796) and is documented at [code.claude.com](https://code.claude.com/docs/en/model-config). API, Team, and Enterprise plans default to high effort and are not affected.
 
-**Don't rely on the CC default — set effort yourself.** Anthropic's [2026-04-23 post-mortem](https://www.anthropic.com/engineering/april-23-postmortem) is independent third-party evidence that CC has flipped reasoning_effort defaults across versions (high → medium → xhigh/high). The default has changed before and will change again. The wizard's `model-effort-check.sh` hook nudges to `xhigh`/`max` at session start specifically because the in-product default is not load-bearing — it can shift release-to-release without notice. Set `/effort max` explicitly every session you do SDLC work, and treat any "I assumed the default was X" reasoning as a bug.
+**Don't rely on the CC default — set effort yourself.** Anthropic's [2026-04-23 post-mortem](https://www.anthropic.com/engineering/april-23-postmortem) is independent third-party evidence that CC has flipped reasoning_effort defaults across versions (high → medium → xhigh/high). The default has changed before and will change again. The wizard's `model-effort-check.sh` hook warns on anything below `max` at session start. Set `CLAUDE_CODE_EFFORT_LEVEL=max` in your settings env block, and treat any "I assumed the default was X" reasoning as a bug.
 
 The `/sdlc` skill sets `effort: max` in its frontmatter, overriding the medium default on every SDLC invocation. This matches the wizard's v1.80.0 contract: Opus 4.6 max is the recommended flagship, and `max` is where SDLC-compliant work actually happens on 4.6.
 
@@ -481,7 +480,7 @@ When a cached prompt prefix is re-served after idle pruning, downstream thinking
 
 **Workaround**: if you hit suspicious shallow reasoning mid-session — especially after a long idle gap — start a fresh session with `claude --continue` to reset cache state. The wizard's PreCompact hook gates manual `/compact` precisely because compacting at bad seams can also pull thinking blocks out of context.
 
-**Detection signal**: the wizard's `model-effort-check.sh` already loud-warns below `xhigh`. Combine with token-spike anomaly detection (ROADMAP #220) once shipped.
+**Detection signal**: the wizard's `model-effort-check.sh` loud-warns below `max`. Combine with token-spike anomaly detection (ROADMAP #220) once shipped.
 
 ### Prompt brevity caps can compound across turns (post-mortem 2026-04-23)
 
@@ -1046,7 +1045,7 @@ For trivial / blank / config-only / CRUD-style repos, full Opus 4.6 max on every
 |-------|----------------|---------------|
 | Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
 | Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) |
-| Effort floor (CC session) | xhigh; max preferred | xhigh; max preferred |
+| Effort floor (CC session) | max (persist via CLAUDE_CODE_EFFORT_LEVEL env var) | max |
 
 The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
 
@@ -1116,7 +1115,7 @@ The `opus[1m]` alias resolves through the env vars, so this combination pins `cl
 }
 ```
 
-**Effort tuning for 4.8:** field signal recommends `xhigh` instead of `max` on 4.8 — the strict-effort behavior overcorrects at `max`. Keep `max` for 4.6, drop to `xhigh` if running 4.8.
+**Effort tuning for 4.8:** always `max`. Earlier field signal suggested xhigh on 4.8 but the wizard standard is max on all Claude models (#395).
 
 **Escape hatch:** flip the env vars back to `claude-opus-4-6` to return to the wizard's recommended default. Or remove them entirely to fall back to Claude Code auto-mode.
 
@@ -2342,7 +2341,7 @@ Before presenting approach, STATE your confidence:
 |-------|---------|--------|--------|
 | HIGH (90%+) | Know exactly what to do | Present approach, proceed after approval | `max` (default) |
 | MEDIUM (60-89%) | Solid approach, some uncertainty | Present approach, highlight uncertainties | `max` (default) |
-| LOW (<60%) | Not sure | ASK USER before proceeding | **Run `/effort xhigh` now** — don't wait |
+| LOW (<60%) | Not sure | ASK USER before proceeding | **Run `/effort max` now** — don't wait |
 | FAILED 2x | Something's wrong | STOP. ASK USER immediately | **Run `/effort max` now** — you're burning cycles at lower effort |
 | CONFUSED | Can't diagnose why something is failing | STOP. Describe what you tried, ask for help | **Run `/effort max` now** — stop spinning |
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Or pin in `.claude/settings.json`:
 
 Or sweep all your projects from one place by setting `ANTHROPIC_DEFAULT_OPUS_MODEL` in `~/.claude/settings.json` — the `opus[1m]` alias resolves through it, so flipping one env var switches every repo at once.
 
-Effort tuning is independent of model choice. `max` is the wizard's default *paired with 4.6*; `xhigh` is the floor. Adjust per session with `/effort max`. On 4.8, drop effort to `xhigh` per field evidence.
+Effort: **always `max`** on all Claude models. Persist it: set `CLAUDE_CODE_EFFORT_LEVEL=max` in your settings env block (CC docs: `effortLevel: "max"` in settings.json is session-only and silently ignored). OpenAI/Codex: `xhigh` (their highest).
 
 ### Three Setup Lanes
 

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -1,55 +1,53 @@
 #!/bin/bash
 # SessionStart hook — effort/model nudge.
 #
-# Behavior (per ROADMAP #217):
-#   effort=max    -> silent (preferred default, above floor)
-#   effort=xhigh  -> silent (minimum floor on Opus 4.6 max)
-#   effort=high|medium|low (or unset) -> LOUD WARNING:
-#     Opus 4.6 max needs xhigh floor for SDLC compliance (TDD, self-review, deep reasoning).
-#     Recommends `/effort max`. Also reminds about recommended model `claude-opus-4-6[1m]`.
+# Behavior (#395 update):
+#   CLAUDE_CODE_EFFORT_LEVEL env var takes precedence over effortLevel in settings.
+#   CC docs: max is session-only in settings.json — only the env var persists it.
+#   Opus 4.6 supports: low, medium, high, max (NO xhigh — falls back to high).
 #
-# CC does not expose the current model to hooks, so the model nudge is emitted as
-# guidance for Claude to compare against its own system prompt.
+#   effort=max   -> silent (only acceptable level)
+#   anything else -> LOUD WARNING
 #
 # Non-blocking: always exits 0.
 
 RECOMMENDED_MODEL="claude-opus-4-6[1m]"
 
-# Token-bloat fix: when both project + plugin register this hook, plugin yields.
 HOOK_DIR="${BASH_SOURCE[0]%/*}"
 [ "$HOOK_DIR" = "${BASH_SOURCE[0]}" ] && HOOK_DIR="."
 # shellcheck disable=SC1091
 source "$HOOK_DIR/_find-sdlc-root.sh"
 dedupe_plugin_or_project "${BASH_SOURCE[0]}" || { cat > /dev/null; exit 0; }
 
-# Drain stdin (SessionStart sends JSON but model field isn't in it)
 cat > /dev/null
 
 if ! command -v jq > /dev/null 2>&1; then
     exit 0
 fi
 
-effort=""
-project_dir="${CLAUDE_PROJECT_DIR:-.}"
-for f in "$project_dir/.claude/settings.local.json" "$project_dir/.claude/settings.json" "$HOME/.claude/settings.json"; do
-    if [ -f "$f" ]; then
-        val=$(jq -r '.effortLevel // empty' "$f" 2>/dev/null)
-        if [ -n "$val" ]; then
-            effort="$val"
-            break
-        fi
-    fi
-done
+# Env var takes precedence (CC docs: only way to persist max)
+effort="${CLAUDE_CODE_EFFORT_LEVEL:-}"
 
-# At or above floor — silent.
+if [ -z "$effort" ]; then
+    project_dir="${CLAUDE_PROJECT_DIR:-.}"
+    for f in "$project_dir/.claude/settings.local.json" "$project_dir/.claude/settings.json" "$HOME/.claude/settings.json"; do
+        if [ -f "$f" ]; then
+            val=$(jq -r '.effortLevel // empty' "$f" 2>/dev/null)
+            if [ -n "$val" ]; then
+                effort="$val"
+                break
+            fi
+        fi
+    done
+fi
+
+# Only max is acceptable — user preference: always run highest available.
 case "$effort" in
-    max|xhigh)
+    max)
         exit 0
         ;;
 esac
 
-# Below floor OR unset — LOUD warning.
-# Note: test_model_effort_size_cap asserts output < 500 chars. Keep copy terse.
 if [ -z "$effort" ]; then
     effort_display="unset"
 else
@@ -57,11 +55,11 @@ else
 fi
 
 echo "=============================================================================="
-echo " WARNING: effort '$effort_display' breaks SDLC compliance on Opus 4.6 max."
-echo " Below xhigh = shallow reasoning, skipped TDD, dropped self-review."
+echo " WARNING: effort '$effort_display' — SDLC requires max."
+echo " Below max = degraded reasoning, shallow TDD, weak self-review."
 echo ""
-echo " Run: /effort max    (preferred, full SDLC compliance)"
-echo " Or:  /effort xhigh  (minimum floor)"
+echo " Run: /effort max"
+echo " Persist: set CLAUDE_CODE_EFFORT_LEVEL=max in settings env block"
 echo ""
 echo " recommended model: $RECOMMENDED_MODEL (run: /model $RECOMMENDED_MODEL)"
 echo "=============================================================================="

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -98,7 +98,7 @@ State your confidence before presenting an approach:
 |-------|---------|--------|--------|
 | HIGH (90%+) | Know exactly what to do | Present, proceed after approval | `max` (default) |
 | MEDIUM (60-89%) | Solid approach, some uncertainty | Present, highlight uncertainties | `max` (default) |
-| LOW (<60%) | Not sure | Research or try Codex; if still LOW, ASK USER | **`/effort xhigh` now** |
+| LOW (<60%) | Not sure | Research or try Codex; if still LOW, ASK USER | **`/effort max` now** |
 | FAILED 2x | Something's wrong | Codex for fresh perspective; if still stuck, STOP | **`/effort max` now** |
 | CONFUSED | Can't diagnose | Codex; if still confused, STOP and describe | **`/effort max` now** |
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -144,7 +144,7 @@ test_model_effort_size_cap() {
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     local size
-    size=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null | wc -c | tr -d ' ')
+    size=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null | wc -c | tr -d ' ')
     rm -rf "$tmpdir"
     if [ "$size" -lt 500 ]; then
         pass "model-effort-check output is bounded (${size} chars < 500)"
@@ -2597,37 +2597,37 @@ test_model_effort_check_stale_effort() {
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q '/effort' \
-        && echo "$output" | grep -q 'recommended model' \
+        && echo "$output" | grep -q 'WARNING' \
         && echo "$output" | grep -qF 'claude-opus-4-6[1m]'; then
-        pass "model-effort-check.sh nudges effort + recommends claude-opus-4-6[1m] when effort is stale"
+        pass "model-effort-check.sh warns on effort=high (only max acceptable)"
     else
-        fail "model-effort-check.sh should nudge /effort and recommend 'claude-opus-4-6[1m]', got: $output"
+        fail "model-effort-check.sh should warn on effort=high, got: $output"
     fi
 }
 
-# Test: silent when effort is already current
-test_model_effort_check_silent_when_current() {
+# Test: xhigh is NOT silent — only max is acceptable (#395)
+test_model_effort_check_xhigh_warns() {
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"xhigh"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if [ -z "$output" ]; then
-        pass "model-effort-check.sh silent when effort is current"
+    if echo "$output" | grep -q "WARNING"; then
+        pass "#395: model-effort-check.sh warns on xhigh (only max acceptable)"
     else
-        fail "model-effort-check.sh should be silent when current, got: $output"
+        fail "#395: xhigh should warn, got: $output"
     fi
 }
 
 # Test: graceful when no JSON stdin (non-blocking)
 test_model_effort_check_no_stdin() {
     local exit_code
-    echo "" | "$HOOKS_DIR/model-effort-check.sh" > /dev/null 2>&1
+    echo "" | CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" > /dev/null 2>&1
     exit_code=$?
     if [ "$exit_code" -eq 0 ]; then
         pass "model-effort-check.sh exits 0 when stdin is empty"
@@ -2654,7 +2654,7 @@ test_model_effort_check_nested_cwd() {
     mkdir -p "$tmpdir/.claude" "$tmpdir/src/deep"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(cd "$tmpdir/src/deep" && echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(cd "$tmpdir/src/deep" && echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if echo "$output" | grep -q '/effort'; then
         pass "model-effort-check.sh finds project settings via CLAUDE_PROJECT_DIR from nested CWD"
@@ -2669,12 +2669,12 @@ test_model_effort_check_local_overrides_project() {
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
-    echo '{"effortLevel":"xhigh"}' > "$tmpdir/.claude/settings.local.json"
+    echo '{"effortLevel":"max"}' > "$tmpdir/.claude/settings.local.json"
     local output
-    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if [ -z "$output" ]; then
-        pass "model-effort-check.sh respects local settings override (xhigh from local, silent)"
+        pass "model-effort-check.sh respects local settings override (max from local, silent)"
     else
         fail "model-effort-check.sh should respect local settings.json override, got: $output"
     fi
@@ -2689,7 +2689,7 @@ test_model_effort_check_max_is_silent() {
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"max"}' > "$tmpdir/.claude/settings.json"
     local output
-    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
     if [ -z "$output" ]; then
         pass "model-effort-check.sh silent when effort=max (preferred, above floor)"
@@ -2710,7 +2710,7 @@ test_model_effort_check_below_xhigh_loud_warning() {
         mkdir -p "$tmpdir/.claude"
         echo "{\"effortLevel\":\"$bad_effort\"}" > "$tmpdir/.claude/settings.json"
         local output
-        output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+        output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
         # Must contain: WARNING marker, SDLC mention, explicit /effort max recommendation
         if ! echo "$output" | grep -q 'WARNING'; then
             fails=$((fails+1))
@@ -2762,7 +2762,7 @@ test_instructions_loaded_no_duplicate_effort_nudge() {
 
 test_model_effort_check_exists
 test_model_effort_check_stale_effort
-test_model_effort_check_silent_when_current
+test_model_effort_check_xhigh_warns
 test_model_effort_check_max_is_silent
 test_model_effort_check_below_xhigh_loud_warning
 test_model_effort_check_no_stdin
@@ -2770,6 +2770,24 @@ test_settings_has_session_start_hook
 test_model_effort_check_nested_cwd
 test_model_effort_check_local_overrides_project
 test_instructions_loaded_no_duplicate_effort_nudge
+
+# #395: CLAUDE_CODE_EFFORT_LEVEL env var takes precedence over effortLevel in settings
+test_model_effort_env_var_takes_precedence() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude"
+    echo '{"effortLevel":"low"}' > "$tmpdir/.claude/settings.json"
+    local output
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="max" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if [ -z "$output" ]; then
+        pass "#395: CLAUDE_CODE_EFFORT_LEVEL=max overrides effortLevel=low in settings (silent)"
+    else
+        fail "#395: env var should take precedence over settings, got: $output"
+    fi
+}
+
+test_model_effort_env_var_takes_precedence
 
 # ROADMAP token-bloat audit: prevent 2× per-prompt hook print when both
 # project (.claude/settings.json) and plugin (hooks.json) register the same


### PR DESCRIPTION
## Summary

Fixes bugs 1 and 2 from #395 (discovered testing opusplan in tropico repo):

- **Bug 1**: `CLAUDE_CODE_EFFORT_LEVEL` env var now checked first (CC docs: only way to persist max — `effortLevel` in settings.json silently ignores max)
- **Bug 2**: Only `max` is silent. Everything else (including xhigh, high) warns. User preference: "always run highest setting"
- **Verified**: All 4 claims from #395 confirmed against official CC docs (code.claude.com/docs/en/model-config + settings)

Opus 4.6 effort levels: low, medium, high, max (NO xhigh — falls back to high).

## Test plan

- [x] New test: env var takes precedence over settings effortLevel
- [x] New test: xhigh now warns (only max is acceptable)
- [x] Updated: all model-effort tests explicitly unset CLAUDE_CODE_EFFORT_LEVEL to prevent parent inheritance
- [x] hooks: 162/162