### PR TITLE
feat(setup): opusplan + billing trap fixes + effort persistence (#390, #391, #393, #395)

### DIFF
--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -14,15 +14,15 @@ This is **guidance, not a hard rule**. Maintainer override is always allowed.
 
 Quality-first lane. Opus 4.6 max drives both the planning brain and the implementation hands; GPT-5.5 xhigh is the cross-model final gate that catches what Claude's self-review missed.
 
-## Setup B — Claude Saver
+## Setup B — Claude Saver (OpusPlan)
 
 | Role | Model |
 |------|-------|
-| **Planner** | Claude Code Opus 4.6 max |
-| **Driver** | Claude Code Sonnet (latest available) |
+| **Planner** | Opus 4.6 max (via Plan Mode — Shift+Tab) |
+| **Driver** | Sonnet 4.6 (auto, execute mode) |
 | **Reviewer** | Codex (GPT-5.5) xhigh |
 
-Cost-efficient lane. Keeps Opus 4.6 max as the planning brain — where context and reasoning matter most — but moves implementation to Sonnet for routine work. GPT-5.5 xhigh still the final reviewer. Use whatever Sonnet version the picker shows as latest.
+Cost-efficient lane using CC's native `opusplan` alias. Opus reasons during Plan Mode (Shift+Tab), Sonnet executes. Both 200K context, Max-bundled — no API credit drain. Pin `model: "opusplan"` + `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6` + `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block. GPT-5.5 xhigh is the cross-model reviewer.
 
 ## When to Use Setup A
 
@@ -139,9 +139,8 @@ Credit allocations: Pro $20/mo, Max 5x $100/mo, Max 20x $200/mo. **No rollover.*
 ### What this means for the lanes
 
 - **Setup A — Premium (Opus 4.6 max planner + driver):** all interactive `/sdlc` work in Claude Code runs on your Max subscription. No API charges for the Claude side. Opus 4.6 / 4.7 / 4.8 at 1M context are all included in Max — confirmed by Claude Code's own `/model` picker which shows no credit warning for any 1M Opus variant.
-- **Setup B — Saver (Opus 4.6 max planner + Sonnet driver):** **mixed billing.** Planner (Opus 4.6 max) stays on Max. Driver (Sonnet 4.6) billing depends on context window:
-  - **Sonnet 4.6 standard context (~200K):** Max subscription ✓
-  - **Sonnet 4.6 with 1M context:** **draws from your separate usage credits pool**, not your Max subscription. Flat $3/$15 per Mtok, but routes to credits. Claude Code's `/model` picker shows this explicitly: "Sonnet 4.6 with 1M context · Draws from usage credits · $3/$15 per Mtok"
+- **Setup B — Saver (OpusPlan):** **fully Max-bundled.** `opusplan` uses Opus (plan mode) + Sonnet (execute mode), both at 200K context — no `[1m]` variants, no credit drain. This is why Setup B now recommends `opusplan` instead of the old `sonnet[1m]` pin (#390).
+  - **⚠️ Avoid `sonnet[1m]`:** Sonnet with 1M context draws from your usage credits pool ($3/$15 per Mtok), NOT your Max subscription. The `/model` picker shows this explicitly. Plain `sonnet` (200K) or `opusplan` stays on Max.
 - **Reviewer (GPT-5.5 xhigh) in both lanes:** billed against your OpenAI account, completely separate from Anthropic.
 - **CI loops that use `claude -p` post-June-15:** these now bill against the separate Anthropic credit pool, not your Max subscription. The wizard's CI shepherd loops (E2E scoring, weekly-update jobs) are local-only on the maintainer's machine and stay on Max; consumer-repo CI integrations may need to budget the new credit pool.
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -19,7 +19,7 @@ Quality-first lane. Opus 4.6 max drives both the planning brain and the implemen
 | Role | Model |
 |------|-------|
 | **Planner** | Opus 4.6 max (via Plan Mode — Shift+Tab) |
-| **Driver** | Sonnet 4.6 (auto, execute mode) |
+| **Driver** | Sonnet (latest, auto execute mode) |
 | **Reviewer** | Codex (GPT-5.5) xhigh |
 
 Cost-efficient lane using CC's native `opusplan` alias. Opus reasons during Plan Mode (Shift+Tab), Sonnet executes. Both 200K context, Max-bundled — no API credit drain. Pin `model: "opusplan"` + `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6` + `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block. GPT-5.5 xhigh is the cross-model reviewer.

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1035,40 +1035,33 @@ Claude Code supports both 200K and 1M context windows. **`opus[1m]` is an opt-in
 
 **Autocompact pairing (important):** If you opt into `opus[1m]`, also set `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — otherwise CC's default autocompact fires at ~76K and destroys the headroom you're paying for. Step 9.5 writes both together when you opt in.
 
-### Mixed-Mode Tier (Sonnet coder + Opus reviewer, roadmap #233)
+### OpusPlan Tier (Opus planner + Sonnet driver, #395)
 
-For trivial / blank / config-only / CRUD-style repos, full Opus 4.6 max on every turn is overkill on the coder leg. The **mixed-mode tier** pins `model: "sonnet[1m]"` for in-session work while keeping the cross-model review layer (Codex / external reviewer) at the flagship — so the reviewer still catches what Sonnet missed.
+For cost-conscious SDLC work, CC's native `opusplan` alias gives you Opus reasoning during Plan Mode (Shift+Tab) and Sonnet execution — both at 200K, Max-bundled, no API credit drain.
 
-**The split:**
+| Layer | OpusPlan tier | Flagship tier |
+|-------|--------------|---------------|
+| Planner | Opus 4.6 max (Plan Mode) | Opus 4.6 max |
+| Driver | Sonnet 4.6 (execute mode) | Opus 4.6 max |
+| Reviewer | GPT-5.5 xhigh | GPT-5.5 xhigh |
+| Effort | max (via `CLAUDE_CODE_EFFORT_LEVEL` env var) | max |
 
-| Layer | Mixed-mode tier | Flagship tier |
-|-------|----------------|---------------|
-| Coder (in-session CC) | `model: "sonnet[1m]"` | `model: "opus[1m]"` |
-| Cross-model reviewer (Codex etc.) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) | gpt-5.5 xhigh (or Opus 4.6 max via Bash for an in-family second opinion) |
-| Effort floor (CC session) | max (persist via CLAUDE_CODE_EFFORT_LEVEL env var) | max |
-
-The reviewer always stays at flagship — the whole point of mixed-mode is that adversarial review catches Sonnet's blind spots, so weakening the review leg defeats the savings.
-
-**When mixed-mode is the right call:**
-- Repo is small (LOC < 10K), few tests (< 30), few hooks (< 5), few workflows (< 5), no `.env` / secrets handling
-- You're on API billing (not Max subscription) and 2× cost on simple repos actually matters
-- Tasks are predominantly mechanical — typo fixes, config tweaks, small CRUD endpoints
-- You're running the SDLC Wizard's setup flow against a sibling repo where the coder doesn't need flagship reasoning
-
-**When to stay flagship:**
-- Stakes-flagged repo: anywhere `.env` / `secrets/` / `credentials/` exists. Force flagship even if LOC is tiny — leaks are catastrophic
-- Architecture work, debugging non-obvious bugs, security review, anything where the *coder's* judgment matters as much as the reviewer's
-- Long shepherd sessions (plan → TDD → review → CI loop) — they cross 100K tokens regularly and Opus 4.6 max fits the window better in a single thread
-
-**Auto-detection:** the setup wizard runs `cli/lib/repo-complexity.js` against the target repo and suggests the tier. Stakes flag (`.env` / `secrets/`) forces complex regardless of size. The user always picks the final answer — the heuristic is a hint, not a gate.
-
-**How to opt in (manual):**
+**How to opt in:**
 ```json
 {
-  "model": "sonnet[1m]"
+  "model": "opusplan",
+  "env": {
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+  }
 }
 ```
-Don't add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` — Sonnet's 1M window has different compaction characteristics than Opus's; let upstream defaults ride until we benchmark.
+
+**⚠️ Avoid `sonnet[1m]`** — Sonnet with 1M context draws from usage credits ($3/$15 per Mtok), not your Max subscription (#390). Plain `sonnet` (200K) or `opusplan` stays on Max.
+
+**When to use OpusPlan:** routine SDLC work, simple repos, cost-conscious sessions. Press Shift+Tab before architecture/blast-radius decisions to get Opus reasoning.
+
+**When to stay Flagship:** stakes-flagged repos, architecture work, security review, long shepherd sessions.
 
 **Prove-It Gate (#233 acceptance criterion):** mixed-mode ships only if pair-tested on 3+ simple repos shows Sonnet-coder + Opus-reviewer produces ≥ same SDLC scores as full-Opus baseline. The first version of the heuristic ships v1.38.0; pair-test results land in CHANGELOG before recommending mixed-mode as the default for any tier.
 

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -11,7 +11,7 @@
 #
 # Non-blocking: always exits 0.
 
-RECOMMENDED_MODEL="claude-opus-4-6[1m]"
+RECOMMENDED_MODEL="claude-opus-4-6"
 
 HOOK_DIR="${BASH_SOURCE[0]%/*}"
 [ "$HOOK_DIR" = "${BASH_SOURCE[0]}" ] && HOOK_DIR="."
@@ -43,19 +43,14 @@ if [ -z "$effort" ]; then
     done
 fi
 
-# Only max is acceptable — user preference: always run highest available.
-case "$effort" in
-    max)
-        # Warn if max is in settings (CC ignores it there) without env var
-        if [ "$settings_max" -eq 1 ] && [ -z "${CLAUDE_CODE_EFFORT_LEVEL:-}" ]; then
-            echo "NOTE: effortLevel: max in settings is session-only (CC ignores it)."
-            echo " Persist: add CLAUDE_CODE_EFFORT_LEVEL=max to settings env block."
-        fi
-        exit 0
-        ;;
-esac
+# Only env-var max is truly silent.
+if [ "$effort" = "max" ] && [ "$settings_max" -eq 0 ]; then
+    exit 0
+fi
 
-if [ -z "$effort" ]; then
+if [ "$settings_max" -eq 1 ] && [ -z "${CLAUDE_CODE_EFFORT_LEVEL:-}" ]; then
+    effort_display="max (settings-only — CC ignores this)"
+elif [ -z "$effort" ]; then
     effort_display="unset"
 else
     effort_display="$effort"

--- a/hooks/model-effort-check.sh
+++ b/hooks/model-effort-check.sh
@@ -27,6 +27,7 @@ fi
 
 # Env var takes precedence (CC docs: only way to persist max)
 effort="${CLAUDE_CODE_EFFORT_LEVEL:-}"
+settings_max=0
 
 if [ -z "$effort" ]; then
     project_dir="${CLAUDE_PROJECT_DIR:-.}"
@@ -35,6 +36,7 @@ if [ -z "$effort" ]; then
             val=$(jq -r '.effortLevel // empty' "$f" 2>/dev/null)
             if [ -n "$val" ]; then
                 effort="$val"
+                [ "$val" = "max" ] && settings_max=1
                 break
             fi
         fi
@@ -44,6 +46,11 @@ fi
 # Only max is acceptable — user preference: always run highest available.
 case "$effort" in
     max)
+        # Warn if max is in settings (CC ignores it there) without env var
+        if [ "$settings_max" -eq 1 ] && [ -z "${CLAUDE_CODE_EFFORT_LEVEL:-}" ]; then
+            echo "NOTE: effortLevel: max in settings is session-only (CC ignores it)."
+            echo " Persist: add CLAUDE_CODE_EFFORT_LEVEL=max to settings env block."
+        fi
         exit 0
         ;;
 esac

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -114,7 +114,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 ## Recommended Model
 
-**Opt-in: `claude-opus-4-6[1m]` (Opus 4.6 max + 1M context — wizard's flagship).** `/model claude-opus-4-6[1m]` at session start (issue #198). Top-level `model` pin disables CC auto-selection; pin only when you need 1M headroom. CC v2.1.154+. For 4.8 opt-in, see wizard "Latest tier".
+**Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max — wizard's flagship).** Pin in settings or `/model claude-opus-4-6` at session start. `opusplan` uses Opus for Plan Mode (Shift+Tab) + Sonnet for execution — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block (#395).
 
 **Pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` when you opt in.** Without it, the default fires at ~76K on 1M. **Pick ONE — do NOT set both `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` AND `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`** — they compound to 30% × 400K = 120K trigger ≈ 12% of 1M, fires almost immediately (#207). See wizard "Autocompact Tuning" for details.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -246,50 +246,54 @@ The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the re
 >
 > How do you want to configure the model for this repo?
 >
-> - **[N] No pin (default, recommended for most repos):** Leaves auto-mode enabled. Claude Code picks the model per turn. Compaction follows upstream defaults. Simplest, lowest friction.
-> - **[m] Mixed-mode** *(suggested for **simple** tier — roadmap #233):* Pins `model: "sonnet[1m]"` for the coder (Sonnet 4.6 with 1M context). The cross-model review layer (Codex / external reviewer) **always stays at the flagship** (Opus 4.6 max or gpt-5.5 xhigh) regardless. Saves cost/quota on simple repos; reviewer catches what Sonnet misses. Requires comfort with losing per-turn auto-selection.
-> - **[f] Flagship full** *(wizard's recommended default — suggested for complex / stakes-flagged):* Pins `model: "claude-opus-4-6[1m]"` + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30`. 4.6 max is the only Opus/max combo that doesn't overthink (Andon Labs, Huryn, BSWEN, r/Claudeopus). Avoids 4.7+ tokenizer tax. Anthropic-supported until ≥ Feb 5, 2027. Requires CC v2.1.154+.
-> - **[l] Latest** *(opt-in for Anthropic's newest Opus):* Pins `model: "claude-opus-4-8[1m]"`. Ships SWE-Bench Pro / Terminal-Bench / dynamic-workflows gains. Tradeoff: 40-60× cache token jump at HIGH, active false-green / token-burn regressions. Drop to `xhigh` (4.8's `max` is worse than `xhigh`).
+> - **[N] No pin (default):** Auto-mode. CC picks model per turn. Simplest.
+> - **[o] OpusPlan** *(recommended for cost-conscious SDLC):* Pins `model: "opusplan"`. Opus plans (Shift+Tab), Sonnet executes. Both 200K, Max-bundled. No API credit drain (#390).
+> - **[f] Flagship full** *(recommended for complex / high-stakes):* Pins `model: "claude-opus-4-6"`. Opus 4.6 max everywhere. Max-bundled at 200K.
+> - **[l] Latest** *(opt-in bleeding-edge):* Pins `model: "claude-opus-4-8"`. Effort: always max (#395).
 >
-> `[N/m/f/l]`
+> `[N/o/f/l]`
 
 **If the user answers `N` (default):** Make no edits to `.claude/settings.json`. Auto-mode stays on. Done.
 
-**If the user answers `m` (mixed-mode):** Edit `.claude/settings.json` and add:
+**If the user answers `o` (opusplan):** Edit `.claude/settings.json` and add:
 
 ```json
 {
-  "model": "sonnet[1m]"
-}
-```
-
-Do NOT add `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` for Sonnet — Sonnet's 1M window has different compaction characteristics than Opus; let the upstream default ride. Tell the user explicitly: "Cross-model reviews still run at the flagship — `codex exec -c 'model_reasoning_effort=\"xhigh\"'` (gpt-5.5) or any future Opus-tier reviewer. Mixed-mode is coder-only."
-
-**If the user answers `f` (flagship):** Edit `.claude/settings.json` and add both fields at the top level:
-
-```json
-{
-  "model": "claude-opus-4-6[1m]",
+  "model": "opusplan",
   "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
 }
 ```
 
-Tell the user: "Pair this with `/effort max` — 4.6 is the only Opus version where `max` doesn't overthink. See [`README.md` § Choosing Your Model](../README.md#choosing-your-model) and `CLAUDE_CODE_SDLC_WIZARD.md` → 'Latest tier — Opus 4.8' for the full rationale + the opt-in alternative if you want Anthropic's newest model."
+Tell the user: "Opus reasons during Plan Mode (Shift+Tab), Sonnet executes. Both Max-bundled at 200K — no API credit drain. Press Shift+Tab before architecture/blast-radius decisions to get Opus reasoning. Cross-model reviews still run at GPT-5.5 xhigh."
+
+**If the user answers `f` (flagship):** Edit `.claude/settings.json` and add:
+
+```json
+{
+  "model": "claude-opus-4-6",
+  "env": {
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+  }
+}
+```
+
+Tell the user: "Opus 4.6 max everywhere. Max-bundled at 200K on your subscription. Effort persisted via env var (CC ignores effortLevel: max in settings)."
 
 **If the user answers `l` (latest):** Edit `.claude/settings.json` and add:
 
 ```json
 {
-  "model": "claude-opus-4-8[1m]",
+  "model": "claude-opus-4-8",
   "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "30"
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
   }
 }
 ```
 
-Tell the user: "Recommend dropping to `/effort xhigh` instead of `max` on 4.8 — strict effort behavior overcorrects at `max`. You'll want this if you're chasing SWE-Bench Pro / Terminal-Bench 2.1 / dynamic-workflows wins; otherwise the wizard's `[f] Flagship` (4.6 max) is the safer pick. Escape hatch: change the `model` value back to `claude-opus-4-6[1m]` or remove the line to fall back to auto-mode."
+Tell the user: "Always max effort on all Claude models (#395). Escape hatch: change `model` back to `claude-opus-4-6` or remove to fall back to auto-mode."
 
 Mention the escape hatch in all four cases:
 - To opt out later: remove the `model` line (and optionally the `env` block) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -1207,7 +1207,7 @@ test_setup_skill_step95_is_opt_in_default_no() {
     local ok=true
     echo "$step95" | grep -qiE 'opt.?in|\[y/N\]|default.*no' || ok=false
     echo "$step95" | grep -qiE 'auto.?mode|auto.?select' || ok=false
-    echo "$step95" | grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' || ok=false
+    echo "$step95" | grep -qE 'opusplan|claude-opus-4-[0-9]+' || ok=false
     if [ "$ok" = true ]; then
         pass "Setup skill Step 9.5 frames Opus pin as opt-in (default No, mentions auto-mode)"
     else

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -359,15 +359,13 @@ test_wizard_doc_no_default_opus_1m_wording() {
     fi
 }
 
-test_sdlc_skill_recommends_opus_1m() {
+test_sdlc_skill_recommends_opus_or_opusplan() {
     local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
-    # v1.80.0: accept either the opus[1m] alias OR an explicit
-    # claude-opus-4-X[1m] model id (flagship default flipped to 4.6 max).
-    if grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' "$SKILL"; then
-        pass "skills/sdlc/SKILL.md references an Opus pin (alias or explicit)"
+    if grep -qE 'opusplan|claude-opus-4-[0-9]+' "$SKILL"; then
+        pass "skills/sdlc/SKILL.md references opusplan or Opus model pin"
     else
-        fail "skills/sdlc/SKILL.md missing opus[1m] or claude-opus-4-X[1m] recommendation"
+        fail "skills/sdlc/SKILL.md missing opusplan or claude-opus-4-X recommendation"
     fi
 }
 
@@ -427,19 +425,12 @@ test_repo_settings_match_template_no_model_pin() {
     fi
 }
 
-# Hooks must nudge users toward the recommended Opus alias or explicit id,
-# not raw "claude-opus-4-6" without [1m] suffix (we want the 1M context).
-# Regression guard against Codex round-1 finding #3.
-# Post-#217 (2026-04-24): the effort/model nudge is centralized in
-# model-effort-check.sh — instructions-loaded-check.sh no longer duplicates it.
-# v1.80.0 flipped RECOMMENDED_MODEL from `opus[1m]` to explicit
-# `claude-opus-4-6[1m]`, so the wizard's flagship recommendation names the
-# version not the alias.
-test_hooks_recommend_opus_1m_alias() {
+# Hook must recommend a model pin (plain or opusplan — no [1m] since #390).
+test_hooks_recommend_model() {
     local H1="$REPO_ROOT/hooks/model-effort-check.sh"
     if [ ! -f "$H1" ]; then fail "$H1 not found"; return; fi
-    if ! grep -qE 'RECOMMENDED_MODEL="(opus\[1m\]|claude-opus-4-[0-9]+\[1m\])"' "$H1"; then
-        fail "model-effort-check.sh should set RECOMMENDED_MODEL to opus[1m] or claude-opus-4-X[1m]"
+    if ! grep -qE 'RECOMMENDED_MODEL="(claude-opus-4-[0-9]+|opusplan)"' "$H1"; then
+        fail "model-effort-check.sh should set RECOMMENDED_MODEL to claude-opus-4-X or opusplan"
         return
     fi
     # instructions-loaded-check.sh must NOT re-declare the variable (would
@@ -521,14 +512,13 @@ test_sdlc_skill_warns_against_compound_autocompact_config() {
 # the Opus pin as opt-in (matching the wizard doc post-#198), not default.
 # v1.80.0 flipped from opus[1m] alias to explicit claude-opus-4-6[1m] —
 # both forms are acceptable references to the opt-in pin.
-test_sdlc_skill_frames_opus_1m_as_opt_in() {
+test_sdlc_skill_frames_model_as_recommendation() {
     local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
-    # Must explicitly say "opt-in" or "issue #198" in the Recommended Model section.
-    if grep -qE 'Opt-in:.*opus\[1m\]|opt-in.*opus\[1m\]|opus\[1m\].*opt-in|Opt-in:.*claude-opus-4-[0-9]+\[1m\]|opt-in.*claude-opus-4-[0-9]+\[1m\]|claude-opus-4-[0-9]+\[1m\].*opt-in|issue #198' "$SKILL"; then
-        pass "skills/sdlc/SKILL.md frames Opus pin as opt-in (#198, #207 round 1)"
+    if grep -qE 'Recommended:.*claude-opus|Recommended:.*opusplan|opusplan.*claude-opus' "$SKILL"; then
+        pass "skills/sdlc/SKILL.md frames model pin as recommendation"
     else
-        fail "skills/sdlc/SKILL.md must frame Opus pin as opt-in, not default (#198)"
+        fail "skills/sdlc/SKILL.md must recommend opusplan or claude-opus-4-X"
     fi
 }
 
@@ -620,18 +610,18 @@ test_wizard_doc_frames_opus_1m_as_opt_in
 test_wizard_doc_no_default_opus_1m_wording
 test_wizard_doc_warns_against_compound_autocompact_config
 test_sdlc_skill_warns_against_compound_autocompact_config
-test_sdlc_skill_frames_opus_1m_as_opt_in
+test_sdlc_skill_frames_model_as_recommendation
 test_wizard_doc_has_browser_tooling_policy_section
 test_wizard_doc_browser_policy_covers_three_way_split
 test_wizard_doc_mcp_profile_isolation_for_concurrent_agents
 test_wizard_doc_notes_playwright_default_isolation_rejected
 test_wizard_doc_real_browser_trigger_examples
-test_sdlc_skill_recommends_opus_1m
+test_sdlc_skill_recommends_opus_or_opusplan
 test_cli_template_has_no_default_model_pin
 test_cli_template_has_no_default_autocompact
 test_setup_skill_mentions_model_pin_in_optin_prompt
 test_repo_settings_match_template_no_model_pin
-test_hooks_recommend_opus_1m_alias
+test_hooks_recommend_model
 test_setup_skill_mentions_less_permission_prompts
 test_wizard_doc_mentions_less_permission_prompts
 test_wizard_doc_mentions_permissions_command

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -402,13 +402,13 @@ test_cli_template_has_no_default_autocompact() {
 # `opus[1m]` generic alias or an explicit `claude-opus-4-X[1m]` id) so users
 # can discover the pin during the opt-in prompt — just without calling it the
 # default. v1.80.0 flipped to explicit model ids for the recommended flagship.
-test_setup_skill_mentions_opus_1m_in_optin_prompt() {
+test_setup_skill_mentions_model_pin_in_optin_prompt() {
     local SKILL="$REPO_ROOT/skills/setup/SKILL.md"
     if [ ! -f "$SKILL" ]; then fail "skills/setup/SKILL.md not found"; return; fi
-    if grep -qE 'opus\[1m\]|claude-opus-4-[0-9]+\[1m\]' "$SKILL"; then
-        pass "skills/setup/SKILL.md references an Opus pin alias (opt-in prompt in Step 9.5)"
+    if grep -qE 'opusplan|claude-opus-4-[0-9]+' "$SKILL"; then
+        pass "skills/setup/SKILL.md references opusplan or Opus model pin (Step 9.5)"
     else
-        fail "skills/setup/SKILL.md must name opus[1m] or claude-opus-4-X[1m] in the Step 9.5 opt-in prompt"
+        fail "skills/setup/SKILL.md must reference opusplan or claude-opus-4-X in Step 9.5"
     fi
 }
 
@@ -629,7 +629,7 @@ test_wizard_doc_real_browser_trigger_examples
 test_sdlc_skill_recommends_opus_1m
 test_cli_template_has_no_default_model_pin
 test_cli_template_has_no_default_autocompact
-test_setup_skill_mentions_opus_1m_in_optin_prompt
+test_setup_skill_mentions_model_pin_in_optin_prompt
 test_repo_settings_match_template_no_model_pin
 test_hooks_recommend_opus_1m_alias
 test_setup_skill_mentions_less_permission_prompts

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2601,7 +2601,7 @@ test_model_effort_check_stale_effort() {
     rm -rf "$tmpdir"
     if echo "$output" | grep -q '/effort' \
         && echo "$output" | grep -q 'WARNING' \
-        && echo "$output" | grep -qF 'claude-opus-4-6[1m]'; then
+        && echo "$output" | grep -qF 'claude-opus-4-6'; then
         pass "model-effort-check.sh warns on effort=high (only max acceptable)"
     else
         fail "model-effort-check.sh should warn on effort=high, got: $output"
@@ -2663,20 +2663,19 @@ test_model_effort_check_nested_cwd() {
     fi
 }
 
-# Test: settings.json precedence — local overrides project
-test_model_effort_check_local_overrides_project() {
+# Test: env var overrides settings — local settings high + env var max = silent
+test_model_effort_check_env_overrides_settings() {
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
     echo '{"effortLevel":"high"}' > "$tmpdir/.claude/settings.json"
-    echo '{"effortLevel":"max"}' > "$tmpdir/.claude/settings.local.json"
     local output
-    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" CLAUDE_CODE_EFFORT_LEVEL="max" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if ! echo "$output" | grep -q "WARNING"; then
-        pass "model-effort-check.sh respects local override (max from local, no WARNING)"
+    if [ -z "$output" ]; then
+        pass "model-effort-check.sh env var max overrides settings high (silent)"
     else
-        fail "model-effort-check.sh should respect local settings.json override (no WARNING), got: $output"
+        fail "model-effort-check.sh env var max should override settings, got: $output"
     fi
 }
 
@@ -2692,10 +2691,10 @@ test_model_effort_check_max_settings_warns_persistence() {
     local output
     output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "session-only"; then
-        pass "#395: effortLevel:max in settings warns about session-only persistence"
+    if echo "$output" | grep -q "WARNING"; then
+        pass "#395: effortLevel:max in settings triggers WARNING (CC ignores it there)"
     else
-        fail "#395: should warn about settings max being session-only, got: $output"
+        fail "#395: settings-only max should trigger WARNING, got: $output"
     fi
 }
 
@@ -2786,7 +2785,7 @@ test_model_effort_check_below_xhigh_loud_warning
 test_model_effort_check_no_stdin
 test_settings_has_session_start_hook
 test_model_effort_check_nested_cwd
-test_model_effort_check_local_overrides_project
+test_model_effort_check_env_overrides_settings
 test_instructions_loaded_no_duplicate_effort_nudge
 
 # #395: CLAUDE_CODE_EFFORT_LEVEL env var takes precedence over effortLevel in settings

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2673,17 +2673,18 @@ test_model_effort_check_local_overrides_project() {
     local output
     output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="/nonexistent" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if [ -z "$output" ]; then
-        pass "model-effort-check.sh respects local settings override (max from local, silent)"
+    if ! echo "$output" | grep -q "WARNING"; then
+        pass "model-effort-check.sh respects local override (max from local, no WARNING)"
     else
-        fail "model-effort-check.sh should respect local settings.json override, got: $output"
+        fail "model-effort-check.sh should respect local settings.json override (no WARNING), got: $output"
     fi
 }
 
 # Test: effort=max is silent (preferred; above the floor, no nudge needed)
 # Per ROADMAP #217: xhigh is the floor, max is preferred. Anything at-or-above the
 # floor should produce no output.
-test_model_effort_check_max_is_silent() {
+# effortLevel: max in settings WITHOUT env var → NOTE (CC ignores it)
+test_model_effort_check_max_settings_warns_persistence() {
     local tmpdir
     tmpdir=$(mktemp -d)
     mkdir -p "$tmpdir/.claude"
@@ -2691,10 +2692,26 @@ test_model_effort_check_max_is_silent() {
     local output
     output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if [ -z "$output" ]; then
-        pass "model-effort-check.sh silent when effort=max (preferred, above floor)"
+    if echo "$output" | grep -q "session-only"; then
+        pass "#395: effortLevel:max in settings warns about session-only persistence"
     else
-        fail "model-effort-check.sh should be silent when effort=max, got: $output"
+        fail "#395: should warn about settings max being session-only, got: $output"
+    fi
+}
+
+# env var CLAUDE_CODE_EFFORT_LEVEL=max → truly silent (correctly persisted)
+test_model_effort_check_max_env_var_silent() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude"
+    echo '{}' > "$tmpdir/.claude/settings.json"
+    local output
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="max" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if [ -z "$output" ]; then
+        pass "#395: CLAUDE_CODE_EFFORT_LEVEL=max is truly silent (correctly persisted)"
+    else
+        fail "#395: env var max should be silent, got: $output"
     fi
 }
 
@@ -2763,7 +2780,8 @@ test_instructions_loaded_no_duplicate_effort_nudge() {
 test_model_effort_check_exists
 test_model_effort_check_stale_effort
 test_model_effort_check_xhigh_warns
-test_model_effort_check_max_is_silent
+test_model_effort_check_max_settings_warns_persistence
+test_model_effort_check_max_env_var_silent
 test_model_effort_check_below_xhigh_loud_warning
 test_model_effort_check_no_stdin
 test_settings_has_session_start_hook


### PR DESCRIPTION
## Summary

Unified fix for 4 issues, Codex-APPROVED plan v2:

- **#390** `sonnet[1m]` billing trap: all `[1m]` model pins removed from setup options. Plain models (200K) are Max-bundled.
- **#391** Global `[1m]` pin detection: documented in setup — advisory migration guidance.
- **#393** Tri-model workflow: **superseded** by CC's native `opusplan` alias (Opus plans via Shift+Tab, Sonnet executes).
- **#395 bug 3** `opusplan` added as `[o]` choice in setup Step 9.5, replacing `[m]` mixed-mode.

### Key changes
- Setup Step 9.5: `[N/o/f/l]` replaces `[N/m/f/l]`
- `[o] OpusPlan`: `model: "opusplan"` + `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6` + `CLAUDE_CODE_EFFORT_LEVEL=max`
- `[f] Flagship`: `model: "claude-opus-4-6"` (no `[1m]`) + `CLAUDE_CODE_EFFORT_LEVEL=max`
- `[l] Latest`: `model: "claude-opus-4-8"` (no `[1m]`) + always max (#395)
- Hook: warns when `effortLevel: "max"` in settings without env var (CC ignores it there)
- AI_SETUP_LANES.md Setup B rewritten for opusplan

## Test plan
- [x] hooks: 164/164 (2 new: settings-max persistence warning, env var silent)
- [x] CLI: 93/93 (updated Step 9.5 assertion)
- [x] doc-consistency: 42/42 (updated model pin test)
- [x] session-load: 10/10