### PR TITLE
fix(docs): Fable round-1 findings — 4 P1s (stale [1m], effort contradictions)

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1081,7 +1081,7 @@ The wizard's flagship recommendation is Opus 4.6 max (see "Choosing Your Model" 
 
 **Tradeoffs (be honest):**
 - **Documented 40-60× cache token jump** vs 4.7 at HIGH effort ([AI Weekly](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn) — up to 900K cache tokens per turn). Burns Max 5-hour limits 2-3× faster than 4.6
-- **`max` effort is *worse* than `high` on 4.8** per [Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench) ("Max reasoning is not the best reasoning effort") — context fills faster
+- **Earlier field signal suggested xhigh over max on 4.8** per [Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench), but wizard standard is now `max` on all Claude models (#395)
 - Active GitHub regressions still open: false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints ([#65932](https://github.com/anthropics/claude-code/issues/65932))
 - [Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html): "Anthropic deliberately made Opus's new tokenizer less efficient" — not a transient bug, structural pricing change
 - Anthropic-supported until ≥ May 28, 2027 (longer runway than 4.6)

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -284,7 +284,7 @@ The `/sdlc` skill sets `effort: max` in its frontmatter, overriding the medium d
 - `effort: max` in SKILL.md frontmatter persists — every `/sdlc` invocation uses `max`
 - You can also type `ultrathink` in any prompt for a single high-effort turn
 
-**Cost note:** `max` uses more tokens than `xhigh`. On Opus 4.6 (the wizard's recommended flagship), this is the validated sweet spot — 4.6 is the only Opus where `max` doesn't overthink. On Opus 4.7/4.8, consider `xhigh` instead.
+**Cost note:** `max` uses more tokens than lower efforts. Always `max` on all Claude models (#395). Token burn is higher on 4.7/4.8 than 4.6 — that's why 4.6 is the wizard's flagship.
 
 > See also: the **Effort** column in the [Confidence Check table](#confidence-check-required) below for per-confidence-level guidance on when to escalate to `max`.
 
@@ -1091,22 +1091,14 @@ The wizard's flagship recommendation is Opus 4.6 max (see "Choosing Your Model" 
 Edit `~/.claude/settings.json`:
 ```json
 {
+  "model": "claude-opus-4-8",
   "env": {
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8"
-  },
-  "model": "opus[1m]"
+    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+  }
 }
 ```
 
-The `opus[1m]` alias resolves through the env vars, so this combination pins `claude-opus-4-8[1m]` (1M context) everywhere.
-
-**Project-scoped (single repo):**
-```json
-{
-  "model": "claude-opus-4-8[1m]"
-}
-```
+On Max plans, Opus auto-upgrades to 1M context. No `[1m]` suffix needed.
 
 **Effort tuning for 4.8:** always `max`. Earlier field signal suggested xhigh on 4.8 but the wizard standard is max on all Claude models (#395).
 

--- a/README.md
+++ b/README.md
@@ -168,23 +168,23 @@ Six independent sources converging on the same conclusion: **4.6 is the only Opu
 
 ### Latest tier — Opus 4.8 (opt-in)
 
-If you want the newest benchmarks and you're comfortable with the token-burn tradeoff, pick `[l] Latest` in the setup wizard. Recommended effort is `xhigh`, not `max`, on 4.8 — Andon Labs' data is explicit that `max` on 4.8 is worse than `xhigh`. The [`Latest tier — Opus 4.8`](CLAUDE_CODE_SDLC_WIZARD.md) section has the full opt-in instructions.
+If you want the newest benchmarks and you're comfortable with the token-burn tradeoff, pick `[l] Latest` in the setup wizard. Always `max` effort on all Claude models (#395). The [`Latest tier — Opus 4.8`](CLAUDE_CODE_SDLC_WIZARD.md) section has the full opt-in instructions.
 
 ### Switch any time
 
 ```bash
-/model claude-opus-4-6[1m]   # wizard's recommended flagship (default in v1.80.0+)
-/model claude-opus-4-8[1m]   # Anthropic's latest, opt-in via Latest tier
-/model opus[1m]              # whatever your env-var resolves to (alias)
+/model claude-opus-4-6   # wizard's recommended flagship (default in v1.80.0+)
+/model opusplan          # Opus plans (Shift+Tab), Sonnet executes — both Max-bundled
+/model claude-opus-4-8   # Anthropic's latest, opt-in via Latest tier
 ```
 
 Or pin in `.claude/settings.json`:
 
 ```json
-{ "model": "claude-opus-4-6[1m]" }
+{ "model": "claude-opus-4-6", "env": { "CLAUDE_CODE_EFFORT_LEVEL": "max" } }
 ```
 
-Or sweep all your projects from one place by setting `ANTHROPIC_DEFAULT_OPUS_MODEL` in `~/.claude/settings.json` — the `opus[1m]` alias resolves through it, so flipping one env var switches every repo at once.
+Or sweep all your projects by setting `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6` in `~/.claude/settings.json`.
 
 Effort: **always `max`** on all Claude models. Persist it: set `CLAUDE_CODE_EFFORT_LEVEL=max` in your settings env block (CC docs: `effortLevel: "max"` in settings.json is session-only and silently ignored). OpenAI/Codex: `xhigh` (their highest).
 

--- a/SDLC.md
+++ b/SDLC.md
@@ -14,10 +14,10 @@
 | Last Updated | 2026-06-09 |
 | Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.159+ (latest at 2026-06-02) — `.claude/skills` plugin auto-load (v2.1.157), enriched `tool_decision` telemetry via `OTEL_LOG_TOOL_DETAILS=1` (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147), per-category `/usage` (v2.1.149), `$CLAUDE_EFFORT` env var for hooks (v2.1.133) |
-| Recommended Model | `claude-opus-4-6[1m]` (Opus 4.6, 1M context) — run `/model claude-opus-4-6[1m]` |
-| Recommended Effort | `max` (preferred) / `xhigh` (floor) — run `/effort max` |
+| Recommended Model | `claude-opus-4-6` or `opusplan` — run `/model claude-opus-4-6` or `/model opusplan` |
+| Recommended Effort | `max` — persist via `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block |
 
-> **Effort warning (Opus 4.6):** `max` is the recommended default, `xhigh` is the absolute floor. 4.6 is the field-validated Opus version where `max` doesn't overthink — Andon Labs Vending-Bench, Paweł Huryn's 4.7 guide, BSWEN effort decision guide, and r/Claudeopus reports all converge. Below `xhigh` (`high`, `medium`, `low`) scopes work tighter — shallow reasoning, skipped TDD, dropped self-review, SDLC non-compliance in practice. Use `high` or below only for trivial grep/search subagents.
+> **Effort warning:** `max` is required on all Claude models (#395). CC docs: `effortLevel: "max"` in settings.json is session-only — use the env var to persist. Below max = degraded reasoning, shallow TDD, weak self-review.
 
 See `CLAUDE_CODE_SDLC_WIZARD.md` → "1M vs 200K Context Window" for the rationale and pricing notes.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -248,7 +248,7 @@ The output is JSON: `{ tier: "simple" | "complex", score, signals }`. Use the re
 >
 > - **[N] No pin (default):** Auto-mode. CC picks model per turn. Simplest.
 > - **[o] OpusPlan** *(recommended for cost-conscious SDLC):* Pins `model: "opusplan"`. Opus plans (Shift+Tab), Sonnet executes. Both 200K, Max-bundled. No API credit drain (#390).
-> - **[f] Flagship full** *(recommended for complex / high-stakes):* Pins `model: "claude-opus-4-6"`. Opus 4.6 max everywhere. Max-bundled at 200K.
+> - **[f] Flagship full** *(recommended for complex / high-stakes):* Pins `model: "claude-opus-4-6"`. Opus 4.6 max everywhere. Max-bundled (auto-upgrades to 1M on Max plans).
 > - **[l] Latest** *(opt-in bleeding-edge):* Pins `model: "claude-opus-4-8"`. Effort: always max (#395).
 >
 > `[N/o/f/l]`

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -176,8 +176,8 @@ Check user's `.claude/settings.json`:
    > Remove, keep, or decide later? `[r/k/l]`
 
 2. **Only one of the two fields matches** — treat as intentional customization. Do not prompt.
-3. **`model: "sonnet[1m]"`** (mixed-mode tier, #233, v1.38.0+) — explicit user choice. Mention in summary: "Detected mixed-mode tier (Sonnet coder + flagship reviewer). Cross-model review still uses Opus / gpt-5.5."
-4. **Other `model` value** (`sonnet`, `opus`) — explicit user choice. Do not touch.
+3. **`model: "sonnet[1m]"`** — ⚠️ warn: "sonnet[1m] draws from usage credits, not Max subscription (#390). Consider switching to `opusplan` (Opus plans, Sonnet executes, both Max-bundled) or plain `sonnet` (200K, Max-bundled)."
+4. **`model: "opusplan"`** or other value (`sonnet`, `opus`) — explicit user choice. Do not touch.
 5. **Neither field set** — already on new default.
 
 When removing: drop `model` (and `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` if `env` becomes empty). Never touch other keys.


### PR DESCRIPTION
## Summary

Fixes 4 P1s found by Fable 5 during cross-model review of #398 (all verified by Codex GPT-5.5 xhigh):

- **P1-1** Update skill now warns `sonnet[1m]` users about credit drain + offers `opusplan` migration
- **P1-2** SDLC.md + README purged of stale `[1m]` pins — updated to `claude-opus-4-6` / `opusplan`
- **P1-3** 4.8 effort contradiction resolved — always max per #395, old field signal noted as historical
- **P1-4** Flagship "200K" text corrected to "auto-upgrades to 1M on Max plans"

## Test plan

- [x] doc-consistency: 42/42
- [x] hooks: 163/163
- [x] session-load: 10/10

## Reviewer comparison data point

This PR will be reviewed by BOTH Fable 5 and Codex GPT-5.5 xhigh to collect comparison data for #385.