### PR TITLE
feat(docs): usage diagnostics + advisor fallback + Fable effort — v1.82.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.81.0",
+      "version": "1.82.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.81.0",
+  "version": "1.82.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Run doc consistency tests
         run: ./tests/test-doc-consistency.sh
 
+      - name: Run usage diagnostics tests (v1.82.0)
+        run: ./tests/test-usage-diagnostics.sh
+
       - name: Run API feature detection tests
         run: ./tests/test-api-feature-detection.sh
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -15,6 +15,8 @@ This is **guidance, not a hard rule**. Maintainer override is always allowed.
 
 Quality-first lane. Fable 5 advises automatically at key decision points (architecture, complexity, blast-radius) via native `advisorModel` (v2.1.170+), Opus 4.6 max implements (stable, Max-bundled), GPT-5.5 xhigh reviews (cross-family, free on ChatGPT sub, catches blind spots Fable can't see in its own work). Escalate to Fable review for the ~5% of PRs where stakes justify it.
 
+**Effort levels:** Opus driver at `max` (standing default). Fable advisor runs at its own effort level server-side. If switching driver to Fable temporarily (fallback), use `/effort high` — Fable `high` already exceeds prior models at `max`. Unset `CLAUDE_CODE_EFFORT_LEVEL` env var if it forces `max`.
+
 ## Setup B — Claude Saver (OpusPlan)
 
 | Role | Model |
@@ -105,6 +107,25 @@ The `!` prefix runs shell commands inside your CC session — no need to exit an
 
 Fable 5 as advisor also requires Fable 5 access for your organization/plan (free on Max through June 22, 2026).
 
+## When the Advisor Is Unavailable
+
+If the advisor returns "Advisor unavailable," the server-side harness failed to initialize. No in-session action (`/model`, `/clear`) can recover it.
+
+**Step 1 — restart the session.** Exit and run `claude` (not `--resume`). A fresh process re-initializes the server handshake. This resolves most advisor failures.
+
+**Step 2 — if the API incident persists:**
+
+- `/model fable` + `/effort high` for the planning phase, then `/model claude-opus-4-6` for implementation. Interactive — stays on your Max subscription.
+- Or proceed with Opus only and let the Codex xhigh PR gate catch issues.
+
+**Last resort (scripted/CI only):**
+
+- `claude --model fable --effort high -p "$(cat <file>)"` — headless mode bills API credits, not your Max subscription.
+
+Check [status.claude.com](https://status.claude.com) if the advisor fails across multiple fresh sessions.
+
+Whichever path you use, the cross-model PR review gate still applies.
+
 ## Credit-Spend Warning
 
 Setups A and B use Opus 4.6 max for at least the planner — that's the expensive half. On Max-plan subscriptions, **Premium can burn the 5-hour cap faster than Saver** because Opus 4.6 max drives implementation too. If you're hitting the cap mid-session:
@@ -116,6 +137,10 @@ Setups A and B use Opus 4.6 max for at least the planner — that's the expensiv
 **Setup C uses Sonnet** — same model as Setup B's driver, Max-bundled. One less model to manage.
 
 The reviewer (GPT-5.5 xhigh) is billed against your OpenAI account, separately. Watch both bills.
+
+## Autocompact Thresholds
+
+For recommended `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` values per context window and task shape, see [CLAUDE_CODE_SDLC_WIZARD.md → Autocompact Tuning](CLAUDE_CODE_SDLC_WIZARD.md#autocompact-tuning).
 
 ## How Billing Works — 1M Context, Max Plan, and the June 15 Split
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.82.0] - 2026-06-11
+
+### Added
+
+- **"Reading Usage Signals" subsection** in Token Efficiency section. Maps community-observed session signals (subagent-heavy, >150K context, 8+ hour sessions) to SDLC actions per setup lane. Marked as community-observed, not official CC docs.
+
+- **Advisor fallback procedure** in AI_SETUP_LANES.md. Escalation ladder: restart session → Fable driver fallback → `-p` last resort (with billing caveat). Documented after advisor was unavailable for a full session during API incident (2026-06-11).
+
+- **Fable effort guidance** in Setup A description. Opus stays at `max`; Fable at `high` (exceeds prior models at `max`). Unset `CLAUDE_CODE_EFFORT_LEVEL` env var if switching driver to Fable temporarily.
+
+- **Autocompact Thresholds cross-reference** in AI_SETUP_LANES.md. Numbers-free pointer to wizard doc to prevent dual-source drift.
+
+### Fixed
+
+- **Stale `/usage` row** in Monitor Costs table. Was "Session total: USD, API time, code changes" — now accurately describes plan usage limits and per-category breakdown (skill, subagent, plugin, MCP server). Added `/status` row (settings panel) to prevent future confusion.
+
+- **`/usage` mention in SKILL.md** Context Management section. Folded into existing auto-compact bullet within 20K char budget.
+
+### Why
+
+- Token-burn spike (1.36M costly tokens vs ~86K median) in session 98d6c7b0 surfaced that the wizard's usage guidance was stale and didn't help diagnose the cause. The Monitor Costs table described `/usage` incorrectly, and no wizard prose mapped usage signals to SDLC actions. The advisor fallback procedure is a direct lesson from the same session where the Fable advisor was unavailable for the entire duration.
+
 ## [1.81.0] - 2026-06-10
 
 ### Changed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -3041,7 +3041,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.81.0 -->
+<!-- SDLC Wizard Version: 1.82.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -3691,9 +3691,20 @@ Practical techniques to reduce token consumption without sacrificing quality.
 
 | Tool | What It Shows | When to Use |
 |------|---------------|-------------|
-| `/usage` | Session total: USD, API time, code changes (aliases: `/cost`, `/stats`) | After a session to review spend |
+| `/usage` | Session cost, plan usage limits, and per-category breakdown (skill, subagent, plugin, MCP server). Aliases: `/cost`, `/stats` | After heavy subagent work, before/after workflow runs, when approaching rate limits |
+| `/status` | Settings panel — version, model, account, connectivity | Confirm setup before starting work |
 | `/context` | What's consuming context window space | When hitting context limits |
 | Status line | Real-time `cost.total_cost_usd` + token counts | Continuous monitoring |
+
+### Reading Usage Signals
+
+These signals are community-observed behavior on paid plans (Max/Team) — not in official CC docs. They are independent dimensions, not a single breakdown. A single session can contribute to all three. Run `/usage` to see the per-category breakdown.
+
+| Signal | What It Means | SDLC Action |
+|--------|---------------|-------------|
+| **Subagent-heavy** | Each subagent runs its own context. The advisor is a separate server-side consultation (full transcript forwarded, different token profile). Explore agents, full Agent delegates, and workflow agents each spawn separate contexts. | Expected in Setup A (Fable advisor fires per-decision). If unexpectedly high: use `subagent_type: "Explore"` for search (lighter), reserve full agents for implementation. |
+| **>150K context** | Sessions staying large between compactions. | **Context-window dependent.** On 1M (Setup A): >150K is expected at 30% compact threshold — the real question is whether the task needed 1M headroom. On 200K (Setup B/C): lower `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` toward 75%. `/compact` between planning and implementation. |
+| **8+ hour sessions** | Long-running sessions accumulate stale context. | `/clear` between unrelated tasks. Split multi-feature work into separate sessions. After committing a PR, start fresh. Background `/loop` sessions count toward this — audit which are still needed. |
 
 ### Reduce Consumption
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-firmware-fixture.sh && \
    ./tests/test-degradation-detection.sh && \
    ./tests/test-doc-consistency.sh && \
+   ./tests/test-usage-diagnostics.sh && \
    ./tests/test-api-feature-detection.sh && \
    ./tests/test-memory-audit-protocol.sh && \
    ./tests/test-community-paths.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -10,8 +10,8 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.81.0 |
-| Last Updated | 2026-06-10 |
+| Wizard Version | 1.82.0 |
+| Last Updated | 2026-06-11 |
 | Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.170+ — native `advisorModel` support (v2.1.170), `.claude/skills` plugin auto-load (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147) |
 | Recommended Model | `claude-opus-4-6` or `opusplan` — run `/model claude-opus-4-6` or `/model opusplan` |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.81.0 -->
+<!-- SDLC Wizard Version: 1.82.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.170 -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.81.0",
+  "version": "1.82.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -267,7 +267,7 @@ Don't fix only the symptom. Add a gate so it can't happen again. Example: PR #14
 
 - `/compact` between planning and implementation (plan preserved in summary)
 - `/clear` between unrelated tasks; after 2+ failed corrections (context polluted)
-- Auto-compact fires at ~95% capacity
+- Auto-compact fires at ~95%; `/usage` shows what's driving token spend
 - After committing a PR, `/clear` before next feature
 - `--bare` mode (v2.1.81+) skips ALL hooks/skills/LSP/plugins. Scripted headless only — never normal development.
 - Custom subagents (`.claude/agents/`) run autonomously and return results. Skills guide behavior; agents do work. Use for parallel tasks or fresh context. Examples: `sdlc-reviewer`, `ci-debug`, `test-writer`.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -93,9 +93,10 @@ Parse CHANGELOG entries between the user's installed version and latest. Present
 
 ```
 Installed: 1.42.0
-Latest:    1.81.0
+Latest:    1.82.0
 
 What changed:
+- [1.82.0] Usage diagnostics: fix /usage row, Reading Usage Signals guide, advisor fallback procedure, Fable effort guidance, autocompact cross-reference.
 - [1.81.0] Native `advisorModel` support: Setup A gets Fable advisor, Setup B gets Opus advisor. Replaces manual subagent spawning. Requires CC v2.1.170+.
 - [1.80.0] Flip default: Opus 4.6 max becomes recommended flagship; Opus 4.8 demoted to opt-in `[l] Latest` tier.
 - [1.79.0] Opus 4.6 Stability tier added as flagship alternative (now graduated to default in 1.80.0).

--- a/tests/test-usage-diagnostics.sh
+++ b/tests/test-usage-diagnostics.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Test usage diagnostics deliverables (v1.82.0)
+# Verification checks from plan v3 (Opus + Fable reviewed)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAILED=$((FAILED + 1))
+}
+
+WIZARD="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+LANES="$REPO_ROOT/AI_SETUP_LANES.md"
+SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
+SDLC="$REPO_ROOT/SDLC.md"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+echo "=== Usage Diagnostics Tests (v1.82.0) ==="
+echo ""
+
+# ────────────────────────────────────────────
+# Deliverable 1: /usage row is not stale
+# ────────────────────────────────────────────
+
+echo "--- Deliverable 1: /usage row accuracy ---"
+
+test_usage_row_mentions_per_category_breakdown() {
+    if grep -q "per-category breakdown" "$WIZARD"; then
+        pass "/usage row mentions per-category breakdown"
+    else
+        fail "/usage row missing per-category breakdown description"
+    fi
+}
+
+test_usage_row_mentions_plan_limits() {
+    if grep -q "plan.*limit\|limit.*usage" "$WIZARD"; then
+        pass "/usage row mentions plan/limits"
+    else
+        fail "/usage row missing plan limits description"
+    fi
+}
+
+test_usage_row_not_stale() {
+    # The stale description was "Session total: USD, API time, code changes"
+    if grep -q "Session total: USD, API time, code changes" "$WIZARD"; then
+        fail "/usage row still has stale description"
+    else
+        pass "/usage row no longer has stale description"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 2: Reading Usage Signals subsection
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 2: Reading Usage Signals ---"
+
+test_signals_subsection_exists() {
+    if grep -q "### Reading Usage Signals" "$WIZARD"; then
+        pass "Reading Usage Signals subsection exists"
+    else
+        fail "Reading Usage Signals subsection missing"
+    fi
+}
+
+test_signals_community_observed_caveat() {
+    if grep -q "community-observed" "$WIZARD"; then
+        pass "Signals section marked as community-observed"
+    else
+        fail "Signals section missing community-observed caveat"
+    fi
+}
+
+test_signals_advisor_not_subagent() {
+    # Fable P2 #6: advisor must be described as server-side consultation, NOT subagent
+    # Check for patterns that equate the two (not just proximity on a table row)
+    local signals_section
+    signals_section=$(sed -n '/### Reading Usage Signals/,/### /p' "$WIZARD" | head -30)
+    if echo "$signals_section" | grep -qiE "advisor (is a subagent|as a subagent|subagent)"; then
+        fail "Signals section calls advisor a subagent (must be server-side consultation)"
+    else
+        pass "Advisor correctly NOT called a subagent in signals section"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 3: Autocompact cross-reference in lanes doc
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 3: Autocompact cross-reference ---"
+
+test_lanes_autocompact_crossref_exists() {
+    if grep -q "Autocompact Thresholds" "$LANES"; then
+        pass "Autocompact Thresholds section exists in lanes doc"
+    else
+        fail "Autocompact Thresholds section missing from lanes doc"
+    fi
+}
+
+test_lanes_autocompact_no_inline_numbers() {
+    # Numbers-free: should NOT contain specific % values in the crossref section
+    local crossref_section
+    crossref_section=$(sed -n '/## Autocompact Thresholds/,/^## /p' "$LANES")
+    if echo "$crossref_section" | grep -qE '[0-9]+%'; then
+        fail "Autocompact cross-reference contains inline percentage numbers (should be numbers-free)"
+    else
+        pass "Autocompact cross-reference is numbers-free"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 4: SKILL.md /usage fold + char budget
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 4: SKILL.md /usage + char budget ---"
+
+test_skill_usage_mention() {
+    if grep -q '/usage' "$SKILL"; then
+        pass "SKILL.md mentions /usage"
+    else
+        fail "SKILL.md missing /usage mention"
+    fi
+}
+
+test_skill_char_budget() {
+    local char_count
+    char_count=$(wc -c < "$SKILL")
+    if [ "$char_count" -le 20000 ]; then
+        pass "SKILL.md is under 20K chars ($char_count)"
+    else
+        fail "SKILL.md exceeds 20K chars ($char_count)"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 5: REJECTED (no test)
+# ────────────────────────────────────────────
+
+# ────────────────────────────────────────────
+# Deliverable 6: Advisor fallback in lanes doc
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 6: Advisor fallback procedure ---"
+
+test_advisor_fallback_exists() {
+    if grep -q "When the Advisor Is Unavailable" "$LANES"; then
+        pass "Advisor fallback procedure exists in lanes doc"
+    else
+        fail "Advisor fallback procedure missing from lanes doc"
+    fi
+}
+
+test_advisor_fallback_escalation_ladder() {
+    # Must have restart as step 1, not a flat menu
+    local fallback_section
+    fallback_section=$(sed -n '/## When the Advisor Is Unavailable/,/^## /p' "$LANES")
+    if echo "$fallback_section" | grep -q "Step 1"; then
+        pass "Advisor fallback uses escalation ladder (Step 1)"
+    else
+        fail "Advisor fallback missing escalation ladder structure"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 7: Fable effort guidance
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 7: Fable effort guidance ---"
+
+test_fable_effort_guidance_exists() {
+    if grep -qi "fable.*effort\|effort.*fable" "$LANES"; then
+        pass "Fable effort guidance exists in lanes doc"
+    else
+        fail "Fable effort guidance missing from lanes doc"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Deliverable 8: Version bump
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Deliverable 8: Version bump ---"
+
+test_sdlc_version_bump() {
+    if grep -q "1.82.0" "$SDLC"; then
+        pass "SDLC.md has version 1.82.0"
+    else
+        fail "SDLC.md missing version 1.82.0"
+    fi
+}
+
+test_changelog_version_entry() {
+    if grep -q '\[1.82.0\]' "$CHANGELOG"; then
+        pass "CHANGELOG.md has 1.82.0 entry"
+    else
+        fail "CHANGELOG.md missing 1.82.0 entry"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Cross-cutting: Fable P1 checks
+# ────────────────────────────────────────────
+
+echo ""
+echo "--- Cross-cutting: Fable P1 verification ---"
+
+test_no_status_as_usage_source() {
+    # Fable P1 #1: /status is settings, NOT usage. No doc should attribute
+    # usage/cost breakdown to /status
+    if grep -qE '/status.*usage breakdown|/status.*cost.*breakdown|/status.*per-category' "$WIZARD"; then
+        fail "/status incorrectly attributed as usage source"
+    else
+        pass "/status not misattributed as usage source"
+    fi
+}
+
+test_correct_env_var_name() {
+    # Fable P1 #2: it's CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, not AUTOCOMPACT_PCT_OVERRIDE
+    if grep -q 'AUTOCOMPACT_PCT_OVERRIDE' "$WIZARD"; then
+        # Make sure ALL occurrences have the CLAUDE_ prefix
+        local bad_refs
+        bad_refs=$(grep -c 'AUTOCOMPACT_PCT_OVERRIDE' "$WIZARD")
+        local good_refs
+        good_refs=$(grep -c 'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE' "$WIZARD")
+        if [ "$bad_refs" = "$good_refs" ]; then
+            pass "All AUTOCOMPACT_PCT_OVERRIDE refs have CLAUDE_ prefix"
+        else
+            fail "Found AUTOCOMPACT_PCT_OVERRIDE without CLAUDE_ prefix ($bad_refs total, $good_refs with prefix)"
+        fi
+    else
+        pass "No AUTOCOMPACT_PCT_OVERRIDE references to check"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Run all tests
+# ────────────────────────────────────────────
+
+test_usage_row_mentions_per_category_breakdown
+test_usage_row_mentions_plan_limits
+test_usage_row_not_stale
+test_signals_subsection_exists
+test_signals_community_observed_caveat
+test_signals_advisor_not_subagent
+test_lanes_autocompact_crossref_exists
+test_lanes_autocompact_no_inline_numbers
+test_skill_usage_mention
+test_skill_char_budget
+test_advisor_fallback_exists
+test_advisor_fallback_escalation_ladder
+test_fable_effort_guidance_exists
+test_sdlc_version_bump
+test_changelog_version_entry
+test_no_status_as_usage_source
+test_correct_env_var_name
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **Fix stale `/usage` row** — updated description to match CC v2.1.170+ reality (per-category breakdown, plan limits)
- **Reading Usage Signals subsection** — 3-signal table (subagent-heavy, >150K context, 8+ hour sessions) with community-observed caveat
- **Autocompact cross-reference** in AI_SETUP_LANES.md — numbers-free pointer to wizard doc (prevents dual-source drift)
- **Advisor fallback procedure** — 3-step escalation ladder (restart → Fable driver → `-p` last resort)
- **Fable effort guidance** — default `high` adaptive thinking, "medium > prior xhigh" per Anthropic docs
- **SKILL.md `/usage` fold** — added within 20K char budget (19,996/20,000)
- **Version bump v1.82.0** — SDLC.md, package.json, CHANGELOG.md, wizard doc

## Motivation

Previous session token-burn spike (1.36M costly tokens vs ~86K median) revealed gaps in usage diagnostics documentation. Plan v3 reviewed by Opus Plan agent + 2x Fable 5 review rounds.

## Test plan

- [x] 17/17 new tests pass (tests/test-usage-diagnostics.sh)
- [x] 42/42 doc-consistency tests pass
- [x] 10/10 audit-session-load tests pass
- [x] 16/16 token-spike tests pass
- [x] 23/23 autocompact-methodology tests pass
- [x] Self-review via /code-review medium — 0 findings
- [ ] Codex xhigh cross-model review
- [ ] CI green