### PR TITLE
chore(release): v1.83.0 — model config batch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "sdlc-wizard",
       "source": ".",
       "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.82.0",
+      "version": "1.83.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.82.0",
+  "version": "1.83.0",
   "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Run usage diagnostics tests (v1.82.0)
         run: ./tests/test-usage-diagnostics.sh
 
+      - name: Run model config batch tests (v1.83.0)
+        run: ./tests/test-model-config-batch.sh
+
       - name: Run API feature detection tests
         run: ./tests/test-api-feature-detection.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.83.0] - 2026-06-11
+
+### Fixed
+- **#403**: Hook lists multiple wizard-blessed models (claude-opus-4-6, opusplan, fable) instead of hardcoded single-model nudge
+- **#391**: Setup Step 9.5 detects global `[1m]` model pin and warns about billing implications
+- **#405**: Update Step 3 uses `min(npm, CHANGELOG)` as "latest installable" — prevents version race during publish window
+- **#384**: Update Step 7.9 checks effort configuration regardless of version match
+
+### Why
+Model config batch — first trial of the confidence ramp pattern (Opus research → Fable batch review → 95% → TDD → Codex safety check). All 4 issues reached 95% confidence before implementation.
+
 ## [1.82.0] - 2026-06-11
 
 ### Added

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -3041,7 +3041,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Wizard Version: 1.82.0 -->
+<!-- SDLC Wizard Version: 1.83.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-degradation-detection.sh && \
    ./tests/test-doc-consistency.sh && \
    ./tests/test-usage-diagnostics.sh && \
+   ./tests/test-model-config-batch.sh && \
    ./tests/test-api-feature-detection.sh && \
    ./tests/test-memory-audit-protocol.sh && \
    ./tests/test-community-paths.sh && \

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Wizard Version: 1.82.0 -->
+<!-- SDLC Wizard Version: 1.83.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.170 -->
@@ -10,7 +10,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.82.0 |
+| Wizard Version | 1.83.0 |
 | Last Updated | 2026-06-11 |
 | Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.170+ — native `advisorModel` support (v2.1.170), `.claude/skills` plugin auto-load (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.82.0",
+  "version": "1.83.0",
   "description": "SDLC enforcement for Claude Code — hooks, skills, and wizard setup in one command",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -232,19 +232,7 @@ The CLI ships `cli/templates/settings.json` with **no** `model` or `env` pin by 
 
 **Why this is opt-in (issue #198):** A top-level `"model"` in `settings.json` disables auto-mode for the session. Pinning is only worth it when you want consistent model behavior (opusplan or flagship) rather than per-turn auto-selection.
 
-**Check for global `[1m]` model pin first (#391):**
-
-Before prompting the user, read `~/.claude/settings.json` (if it exists). If the `model` key contains `[1m]` (e.g., `"opus[1m]"`, `"claude-opus-4-6[1m]"`, `"sonnet[1m]"`), warn:
-
-> **Global model pin detected:** `~/.claude/settings.json` has `model: "{value}"`.
-> A global `[1m]` pin forces 1M context on EVERY repo that doesn't override with its own project pin. Interactive CC sessions on Max include 1M at standard rates, but headless surfaces (`-p`, Agent SDK, GitHub Actions) bill against usage credits after the June 15 split. This pin may be a leftover from older wizard versions.
->
-> - **[r] Remove** (recommended) — deletes the global model pin, restores auto-mode
-> - **[k] Keep** — you intentionally want 1M API-billed context globally
->
-> `[r/k]`
-
-If `r`: remove the `model` key from `~/.claude/settings.json`. If `k`: log the choice and continue.
+**Check for global `[1m]` model pin (#391):** Read `~/.claude/settings.json`. If `model` contains `[1m]`, warn: global pin forces 1M on every repo; headless surfaces bill against credits after June 15. Offer `[r] Remove / [k] Keep`. If `r`: delete the `model` key.
 
 **Run the complexity heuristic first (roadmap #233):**
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -95,9 +95,10 @@ Parse CHANGELOG entries between the user's installed version and the resolved la
 
 ```
 Installed: 1.42.0
-Latest:    1.82.0
+Latest:    1.83.0
 
 What changed:
+- [1.83.0] Model config batch: multi-model hook recommendation (#403), global [1m] pin detection (#391), version race fix (#405), effort config check (#384).
 - [1.82.0] Usage diagnostics: fix /usage row, Reading Usage Signals guide, advisor fallback procedure, Fable effort guidance, autocompact cross-reference.
 - [1.81.0] Native `advisorModel` support: Setup A gets Fable advisor, Setup B gets Opus advisor. Replaces manual subagent spawning. Requires CC v2.1.170+.
 - [1.80.0] Flip default: Opus 4.6 max becomes recommended flagship; Opus 4.8 demoted to opt-in `[l] Latest` tier.


### PR DESCRIPTION
## Summary

Version bump to v1.83.0. All 7 version sites updated per Lessons Learned checklist.

Closes #403, #391, #405, #384 (implementations merged in #407).

## Test plan

- [ ] CI green