### PR TITLE
docs(sdlc): document /model session gotcha (#414)

### DIFF
--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -118,9 +118,11 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 ## Recommended Model
 
-**Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max — wizard's flagship).** Pin in settings or `/model claude-opus-4-6` at session start. `opusplan` uses Opus for Plan Mode (Shift+Tab) + Sonnet for execution — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block.
+**Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max).** Pin in settings or `/model` at session start. `opusplan` = Opus Plan Mode + Sonnet execute — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in env block.
 
-**If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — default compacts too early at ~76K on 1M. **Do not set this for `opusplan`** — 200K context, 30% = 60K too aggressive.
+**Session gotcha:** `/model` does not survive exit+continue. Re-run at session start or pin in project settings.json.
+
+**If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M). **Do not set this for `opusplan`** — 200K, 30% too aggressive.
 
 **Advisor (v2.1.170+):** Flagship → `advisorModel: "fable"`. OpusPlan → `advisorModel: "claude-opus-4-6"`. Set during `/setup-wizard` Step 9.5.
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -118,9 +118,11 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 ## Recommended Model
 
-**Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max — wizard's flagship).** Pin in settings or `/model claude-opus-4-6` at session start. `opusplan` uses Opus for Plan Mode (Shift+Tab) + Sonnet for execution — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block.
+**Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max).** Pin in settings or `/model` at session start. `opusplan` = Opus Plan Mode + Sonnet execute — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in env block.
 
-**If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` — default compacts too early at ~76K on 1M. **Do not set this for `opusplan`** — 200K context, 30% = 60K too aggressive.
+**Session gotcha:** `/model` does not survive exit+continue. Re-run at session start or pin in project settings.json.
+
+**If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M). **Do not set this for `opusplan`** — 200K, 30% too aggressive.
 
 **Advisor (v2.1.170+):** Flagship → `advisorModel: "fable"`. OpusPlan → `advisorModel: "claude-opus-4-6"`. Set during `/setup-wizard` Step 9.5.
 


### PR DESCRIPTION
## Summary

Closes #414 — documents that `/model` selection does not survive exit+continue.

One-liner added to Recommended Model section: re-run at session start or pin in project settings.json.

This is the **second signal** for the 1M context parking lot item (first was #403).

## Fable review

Fable batch-triaged #411/#413/#414: closed #411 + #413 as already-done, recommended this one-liner fix for #414.

## Test plan

- [x] `tests/test-doc-consistency.sh` — 42/42 (regression caught + fixed: trim preserved "Do not set this" phrasing)
- [x] `tests/test-skill-graduations.sh` — 6/6
- [x] `tests/test-cowork-drift.sh` — 9/9
- [ ] CI validate passes