### PR TITLE
fix(sdlc): correct /model session gotcha per Codex P1

### DIFF
--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -120,7 +120,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max).** Pin in settings or `/model` at session start. `opusplan` = Opus Plan Mode + Sonnet execute — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in env block.
 
-**Session gotcha:** `/model` does not survive exit+continue. Re-run at session start or pin in project settings.json.
+**Session gotcha:** `/model` persists by default, but project/managed settings can override. Picker `s` (session-only) does not.
 
 **If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M). **Do not set this for `opusplan`** — 200K, 30% too aggressive.
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -120,7 +120,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Recommended: `claude-opus-4-6` or `opusplan` (Opus 4.6 max).** Pin in settings or `/model` at session start. `opusplan` = Opus Plan Mode + Sonnet execute — both Max-bundled. Persist effort: `CLAUDE_CODE_EFFORT_LEVEL=max` in env block.
 
-**Session gotcha:** `/model` does not survive exit+continue. Re-run at session start or pin in project settings.json.
+**Session gotcha:** `/model` persists by default, but project/managed settings can override. Picker `s` (session-only) does not.
 
 **If pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M). **Do not set this for `opusplan`** — 200K, 30% too aggressive.
 


### PR DESCRIPTION
## Summary

Codex round 1 on PR #415 flagged a P1 factual error: our text said `/model` doesn't survive exit+continue, but as of CC v2.1.153 it persists to user settings by default.

Corrected to: `/model` persists by default, but project/managed settings can override. Picker `s` (session-only) does not.

## Test plan

- [x] `tests/test-doc-consistency.sh` — 42/42
- [x] `tests/test-cowork-drift.sh` — 9/9
- [x] `tests/test-skill-graduations.sh` — 6/6
- [ ] CI validate passes