### PR TITLE
fix(sdlc): bump CC baseline v2.1.170 → v2.1.185

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -247,8 +247,8 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 | 63 | ~~Evaluate: Batched Codex Release Review~~ KILLED | Per-PR review + release review checklist already covers it. No evidence of gap. The roadmap item itself says "may not be needed" — that's the answer |
 | 65 | ~~Testing Diamond Boundary~~ DONE | Completed in v1.23.0 |
 | 66 | ~~Convert to Plugin Format~~ Absorbed into #89 | Plugin format + marketplace submission combined into single item #89. Plugins now support hooks (updated finding from 2026-04-03 research) |
-| 67 | Add Agent Team Hooks | DEFERRED — Agent Teams requires experimental feature flag (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`). Hooks would be inert for most users. Main session enforcement already covers subagent workflows (subagents do what the main session tells them). Revisit when Agent Teams exits experimental. Prove It Gate: can't prove value without GA feature |
-| 68 | ~~Hook `if` Conditionals~~ DONE | PR #151. PreToolUse tdd-pretool-check.sh wired with CC v2.1.85 `if:` field in .claude/settings.json to filter Write/Edit/MultiEdit by path glob |
+| 67 | ~~Add Agent Team Hooks~~ KILLED | Agent Teams API changed in v2.1.178: `TeamCreate`/`TeamDelete` removed, teams are now implicit. Main session enforcement covers subagent workflows. Dynamic Workflows (#425) is the public multi-agent orchestration path. No demand signal for team-specific hooks. |
+| 68 | ~~Hook `if` Conditionals~~ DONE | PR #151. PreToolUse tdd-pretool-check.sh wired with CC v2.1.85 `if:` field in .claude/settings.json to filter Write/Edit/MultiEdit by path glob. Note: file-path `if` matching was buggy until v2.1.176 fix — minimum CC version for reliable path filtering. |
 | 69 | ~~Skill Frontmatter Docs~~ DONE | Completed in v1.23.0 |
 | 70 | ~~`--bare` Docs~~ DONE | Completed in v1.23.0 |
 | 71 | Monitor KAIROS/Coordinator Mode | Proactive always-on agent mode and multi-agent coordination. Wizard's enforcement model (hooks on tool calls) needs to scale to always-on monitoring. Track feature flags, prepare skill content for both contexts. Spawned from #59 research |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,7 +1,7 @@
 <!-- SDLC Wizard Version: 1.83.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
-<!-- Claude Code Baseline: v2.1.170 -->
+<!-- Claude Code Baseline: v2.1.185 -->
 <!-- ROADMAP #350: this single-line anchor is the source of truth for cc-version-drift.yml. -->
 <!-- Update both this comment AND the "Claude Code Recommended" row when bumping CC support. -->
 # SDLC Configuration
@@ -13,7 +13,7 @@
 | Wizard Version | 1.83.0 |
 | Last Updated | 2026-06-11 |
 | Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
-| Claude Code Recommended | v2.1.170+ — native `advisorModel` support (v2.1.170), `.claude/skills` plugin auto-load (v2.1.157), native `/goal` (v2.1.139), `/code-review --comment` (v2.1.147) |
+| Claude Code Recommended | v2.1.185+ — hook `if` path-filter fix (v2.1.176), `Tool(param:value)` permission rules (v2.1.178), TUI stability under subagent load (v2.1.183), auto-mode safety hardening (v2.1.183) |
 | Recommended Model | `claude-opus-4-6` or `opusplan` — run `/model claude-opus-4-6` or `/model opusplan` |
 | Recommended Effort | `max` — persist via `CLAUDE_CODE_EFFORT_LEVEL=max` in settings env block |
 


### PR DESCRIPTION
## Summary
- Bump CC baseline from v2.1.170 to v2.1.185 (closes 15-release drift gap)
- Kill ROADMAP #67 (Agent Team Hooks) — TeamCreate/TeamDelete removed in v2.1.178, teams now implicit
- Document hook `if` path-filter bug fix (v2.1.176) on ROADMAP #68

## Key findings from drift analysis
- **v2.1.176**: Hook `if` conditions for file paths were broken — our `tdd-pretool-check.sh` was silently not filtering
- **v2.1.178**: `Tool(param:value)` permission rules, TeamCreate/TeamDelete removed
- **v2.1.181**: `!` bash commands now auto-respond (breaking), 5-level subagent nesting limit
- **v2.1.183**: TUI corruption under heavy subagent load fixed, auto-mode safety hardening

## Test plan
- [x] 17/17 cowork drift tests pass
- [x] 13/13 version logic tests pass
- [x] No TeamCreate/TeamDelete references found in codebase
- [ ] CI green

Closes #425