### PR TITLE
test(hooks): #430 regression — no stray [1m] artifact in model warning

### DIFF
--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1840,6 +1840,26 @@ test_model_effort_check_stale_effort() {
     fi
 }
 
+# #430 regression: RECOMMENDED_MODEL(S) once hardcoded a stray "[1m]" fragment
+# (a broken ANSI-bold escape missing its leading \e) that printed as literal
+# text in the SessionStart warning. Already dead by unrelated evolution
+# (#403's multi-model string, then #440's medium-floor rewrite) — this locks
+# it so nothing can reintroduce the artifact.
+test_model_effort_check_no_stray_ansi_artifact() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.claude"
+    echo '{"effortLevel":"low"}' > "$tmpdir/.claude/settings.json"
+    local output
+    output=$(echo '{}' | CLAUDE_PROJECT_DIR="$tmpdir" HOME="$tmpdir" CLAUDE_CODE_EFFORT_LEVEL="" "$HOOKS_DIR/model-effort-check.sh" 2>/dev/null)
+    rm -rf "$tmpdir"
+    if ! printf '%s' "$output" | grep -qF '[1m]'; then
+        pass "#430: no stray [1m] ANSI-escape artifact in the model warning"
+    else
+        fail "#430: warning output contains a literal [1m] artifact: $output"
+    fi
+}
+
 # Test: high is silent — it's Sonnet 5's and Fable's tested default (v1.84.0)
 test_model_effort_check_high_silent() {
     local tmpdir
@@ -2071,6 +2091,7 @@ test_model_effort_check_exists
 test_model_effort_check_silent_on_unset
 test_model_effort_check_medium_silent
 test_model_effort_check_stale_effort
+test_model_effort_check_no_stray_ansi_artifact
 test_model_effort_check_high_silent
 test_model_effort_check_xhigh_silent
 test_model_effort_check_xhigh_env_var_silent


### PR DESCRIPTION
## Why

#430 reported `model-effort-check.sh` hardcoding `RECOMMENDED_MODEL="opus[1m]"` — a broken ANSI-bold escape (missing its leading `\e`) printing as literal text in the SessionStart warning.

## What I found

**The bug is already dead** — git history traces it: `opus[1m]` → `claude-opus-4-6[1m]` → `claude-opus-4-6` → today's `"sonnet, opus, opusplan, or fable (run: /model)"`. It died as a side effect of the #403 multi-model rewrite and #440's medium-floor migration, not a deliberate fix. No test ever guarded against it recurring.

## What this PR does

One test: `test_model_effort_check_no_stray_ansi_artifact` asserts the hook's warning output never contains a literal `[1m]` substring. **Mutation-verified**: reintroduced the exact reported string (`RECOMMENDED_MODELS="opus[1m]"`), confirmed the new test goes RED, then restored and confirmed GREEN.

Zero production code changed.

## Review trail

Codex xhigh (GPT-5.6 Sol), 1 round to CERTIFIED — independently replayed the mutation and confirmed clean restoration + one-file scope.

Closes #430.