### PR TITLE
fix(skills): namespace setup/update skill names to fix OpenCode collision (#374)

### DIFF
--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -75,7 +75,7 @@ Reach for Setup B when the change can damage a consumer repo, has high blast rad
 
 - Architecture or methodology changes
 - Tagged release prep
-- Installer behavior (`cli/`, `init`, `setup-wizard`)
+- Installer behavior (`cli/`, `init`, `claude-setup-wizard`)
 - Destructive file operations
 - Package publishing
 - Generated repo modifications (template changes)

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -241,7 +241,7 @@ When Anthropic provides official plugins or tools that handle something:
 | **Claude Code v2.1.69+** | Required for InstructionsLoaded hook, skill directory variable, and Tasks system |
 | **Git repository** | Files should be committed for team sharing |
 
-**Blank repos (no CLAUDE.md, no code):** The wizard works on empty repos. Run `npx -y agentic-sdlc-wizard@latest init` — it installs hooks, skills, and the wizard doc. (The `@latest` pin guards against stale npx caches per #358.) On first session, the hooks detect missing SDLC files and redirect to `/setup-wizard`, which generates CLAUDE.md, SDLC.md, TESTING.md, and ARCHITECTURE.md interactively. You do NOT need to run Claude's built-in `/init` first — the setup wizard handles everything.
+**Blank repos (no CLAUDE.md, no code):** The wizard works on empty repos. Run `npx -y agentic-sdlc-wizard@latest init` — it installs hooks, skills, and the wizard doc. (The `@latest` pin guards against stale npx caches per #358.) On first session, the hooks detect missing SDLC files and redirect to `/claude-setup-wizard`, which generates CLAUDE.md, SDLC.md, TESTING.md, and ARCHITECTURE.md interactively. You do NOT need to run Claude's built-in `/init` first — the setup wizard handles everything.
 
 ---
 
@@ -369,7 +369,7 @@ Claude Code now has built-in auto-memory that persists context across sessions. 
 
 **Wizard behavior** (v1.42.0, phase a only):
 
-- **Setup skill detects existing AGENTS.md** during Step 1 auto-scan. If found, Step 4.5 surfaces a 3-way decision: dual-maintain (default, recommended), merge (manual in phase a), or skip. The user's choice is recorded as a one-line comment in their project's `SDLC.md` for their own reference. **`/update-wizard` does NOT parse this comment** — that wiring is phase (d) work, not v1.42.0 scope.
+- **Setup skill detects existing AGENTS.md** during Step 1 auto-scan. If found, Step 4.5 surfaces a 3-way decision: dual-maintain (default, recommended), merge (manual in phase a), or skip. The user's choice is recorded as a one-line comment in their project's `SDLC.md` for their own reference. **`/claude-update-wizard` does NOT parse this comment** — that wiring is phase (d) work, not v1.42.0 scope.
 - **No automatic merge / symlink yet** — phase (a) is detection + decision surfacing only. Option B in the prompt is "record your intent, do the copy by hand"; the wizard does not perform any merge in this phase.
 
 **Deferred phases** (not in v1.42.0 scope):
@@ -536,7 +536,7 @@ CC 2.1.118 introduced `type: "mcp_tool"` for hooks — a hook can now directly i
 
 **Per-hook decision** (each row applies at least one criterion explicitly):
 
-- **`sdlc-prompt-check.sh`** (UserPromptSubmit, ~137 lines) — emits the SDLC BASELINE text on every prompt (fires-once-per-session sentinel), plus a setup-wizard redirect when SDLC.md/TESTING.md are missing. Decision: **Stay bash.** Portability criterion: same script ships to Codex sibling unchanged. Local-state criterion: sentinel cache is local-only. **#236(b) 2026-07-06:** the ROADMAP #195 effort-bump signal log described here previously was removed — never fired in ~2 months of live use.
+- **`sdlc-prompt-check.sh`** (UserPromptSubmit, ~137 lines) — emits the SDLC BASELINE text on every prompt (fires-once-per-session sentinel), plus a claude-setup-wizard redirect when SDLC.md/TESTING.md are missing. Decision: **Stay bash.** Portability criterion: same script ships to Codex sibling unchanged. Local-state criterion: sentinel cache is local-only. **#236(b) 2026-07-06:** the ROADMAP #195 effort-bump signal log described here previously was removed — never fired in ~2 months of live use.
 - **`instructions-loaded-check.sh`** (~291 lines) — InstructionsLoaded event; wizard-version + CC-version staleness nudges (both npm-cached daily), cross-model-review staleness check, autocompact compound-misconfig check, dual-channel-install check. Decision: **Stay bash.** Portability criterion: Codex sibling has its own equivalent of session-start validation; bash port is direct. Local-state criterion: cache files are local. **#236(b) 2026-07-06:** the SDLC.md/TESTING.md missing-file warning previously described here was removed (redundant with `sdlc-prompt-check.sh`'s louder version).
 - **`tdd-pretool-check.sh`** (~129 lines) — PreToolUse on Write/Edit/MultiEdit; emits a TDD reminder, and (since #436) **blocks** with `exit 2` when a `src/**` write (or `SDLC_TDD_SRC_PATTERN`-overridden path, added #236(b) for this repo's own `src/`-less dogfooding) happens before any test file was touched this session (an edit-ordering proxy for TDD RED, session-scoped via a cache-dir sentinel). Decision: **Stay bash.** Fail-closed gating criterion applies now that this hook blocks: bash `exit 2` fails closed by definition, whereas an `mcp_tool` hook's block decision is lost if the MCP server errors — wrong default for a gate. Portability criterion: still trivially portable.
 - **`model-effort-check.sh`** (~87 lines) — SessionStart event; reads `CLAUDE_CODE_EFFORT_LEVEL` env var (falling back to `effortLevel` in the settings cascade), emits nothing when effort is `high`/`xhigh`/`max`/unset, otherwise a loud warning. Decision: **Stay bash.** Portability criterion: env-var read maps 1:1 to any agent runtime. Local-state criterion: not applicable, hook is stateless. **#236(b) 2026-07-06:** unset used to loud-warn too (CC's own default state) — now silent; only an explicit low-effort value or the settings-only-`max` quirk warns.
@@ -2503,7 +2503,7 @@ When the reviewer finds issues, respond per-finding instead of silently fixing e
 
 3 recheck rounds (4 total including initial review) is the default budget for a typical change. If still NOT CERTIFIED after round 4, escalate to the user with a summary of open findings rather than spinning indefinitely.
 
-**Exception — known-large migrations:** the round cap is a heuristic against spinning on a shrinking tail of nitpicks, not a hard stop. Judge convergence by the *trend* in finding quality, not the round number: if every round is still surfacing a genuinely new, independently-verified, real issue — especially if severity is flat or increasing (later rounds finding live-code bugs, not just prose) — keep going past round 4. Only stop when a round returns CERTIFIED, or consecutive rounds return nothing but nitpicks/false positives. (Source: v1.84.0 release review — a repo-wide model-recommendation migration ran 11 rounds, each finding something real; round 8 found a mandatory-reading setup-wizard template whose tutorial hook code had silently drifted from the real shipped hook (broken, non-blocking), more consequential than anything in rounds 1-3. Escalating at round 4 per the default heuristic would have shipped that bug. 2026-07-04.)
+**Exception — known-large migrations:** the round cap is a heuristic against spinning on a shrinking tail of nitpicks, not a hard stop. Judge convergence by the *trend* in finding quality, not the round number: if every round is still surfacing a genuinely new, independently-verified, real issue — especially if severity is flat or increasing (later rounds finding live-code bugs, not just prose) — keep going past round 4. Only stop when a round returns CERTIFIED, or consecutive rounds return nothing but nitpicks/false positives. (Source: v1.84.0 release review — a repo-wide model-recommendation migration ran 11 rounds, each finding something real; round 8 found a mandatory-reading claude-setup-wizard template whose tutorial hook code had silently drifted from the real shipped hook (broken, non-blocking), more consequential than anything in rounds 1-3. Escalating at round 4 per the default heuristic would have shipped that bug. 2026-07-04.)
 
 **CERTIFIED is not the finish line.** A CERTIFIED verdict and a green CI run are different verification layers that catch different bug classes — a CERTIFIED review does not substitute for actually pushing and watching CI. Confirmed on the same v1.84.0 release: after round-11 CERTIFIED and a full local test sweep, real CI still caught 3 more genuine bugs the review never touched — a content regression in an unrelated section silently dropped by an earlier edit (caught by a pre-existing local test that simply hadn't been re-run since), an environment-specific CLI output-format change invisible to any local run against an older tool version, and a new test file committed without the executable bit (passes every local `bash tests/foo.sh` invocation, only fails when CI runs it as `./tests/foo.sh`). Budget for at least one more fix-push-recheck cycle after CERTIFIED, and don't treat CERTIFIED as license to skip reading the actual CI logs — see the CI Feedback Loop section below.
 
@@ -4105,10 +4105,10 @@ If Claude repeatedly struggles in a codebase area:
 
 ### How to Update
 
-Use the `/update-wizard` skill for a guided, selective update experience:
-> `/update-wizard` — full guided update (shows changelog, per-file diff, selective adoption)
-> `/update-wizard check-only` — just show what changed, don't apply anything
-> `/update-wizard force-all` — apply all updates without per-file approval
+Use the `/claude-update-wizard` skill for a guided, selective update experience:
+> `/claude-update-wizard` — full guided update (shows changelog, per-file diff, selective adoption)
+> `/claude-update-wizard check-only` — just show what changed, don't apply anything
+> `/claude-update-wizard force-all` — apply all updates without per-file approval
 
 Or ask Claude directly:
 > "Check for SDLC wizard updates"
@@ -4133,7 +4133,7 @@ Claude fetches from these URLs (via WebFetch):
 ```
 If no version comment exists, treat as `0.0.0`.
 
-**Step 2: Fetch CHANGELOG first** from the CHANGELOG URL above. Parse all entries between user's installed version and the latest version. Show the user what changed. If versions match, run the global plugin-registration cleanup (see the `/update-wizard` skill's Step 7.7 — `~/.claude/settings.json` hygiene is independent of file versions and must run even when up-to-date), then say "You're up to date!" and stop.
+**Step 2: Fetch CHANGELOG first** from the CHANGELOG URL above. Parse all entries between user's installed version and the latest version. Show the user what changed. If versions match, run the global plugin-registration cleanup (see the `/claude-update-wizard` skill's Step 7.7 — `~/.claude/settings.json` hygiene is independent of file versions and must run even when up-to-date), then say "You're up to date!" and stop.
 
 **Step 3: Fetch full wizard and compare.** For each wizard step, check if the user already has it:
 
@@ -4226,7 +4226,7 @@ Every wizard step has a unique ID for tracking:
 | `question-git-workflow` | Git workflow preference | 1.2.0 |
 | `step-update-notify` | Optional: CI update notification | 1.13.0 |
 | `step-cross-model-review` | Cross-model review (REQUIRED for high-stakes) | 1.16.0 |
-| `step-update-wizard` | /update-wizard smart update skill | 1.18.0 |
+| `step-update-wizard` | /claude-update-wizard smart update skill | 1.18.0 |
 
 When checking for updates, Claude compares user's completed steps against this registry.
 

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,7 +1,7 @@
 <!-- SDLC Wizard Version: 1.87.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
-<!-- Claude Code Baseline: v2.1.195 -->
+<!-- Claude Code Baseline: v2.1.210 -->
 <!-- ROADMAP #350: this single-line anchor is the source of truth for cc-version-drift.yml. -->
 <!-- Update both this comment AND the "Claude Code Recommended" row when bumping CC support. -->
 # SDLC Configuration
@@ -13,7 +13,7 @@
 | Wizard Version | 1.87.0 |
 | Last Updated | 2026-07-04 |
 | Claude Code Minimum | v2.1.154+ (required for `opus[1m]` alias resolution); v2.1.105+ for `PreCompact` hook |
-| Claude Code Recommended | v2.1.195+ — comma-separated hook matcher fix (v2.1.191), hyphenated matcher exact-match fix (v2.1.195), `sandbox.credentials` setting (v2.1.187), `autoMode.classifyAllShell` setting (v2.1.193) |
+| Claude Code Recommended | v2.1.210+ — `SessionStart`/`Setup`/`SubagentStart` hooks no longer hide stderr on exit 2 (v2.1.199, relevant to #436's exit-code semantics), hook events no longer silently dropped during `SessionStart` in headless sessions (v2.1.204, relevant to our hooks running under `claude -p`/CI), duplicate skill-instruction context bloat on re-invocation fixed (v2.1.202), hook-callback timeouts no longer misreported as user rejection in unattended sessions (v2.1.210), `$1`/`$2` positional placeholders in skills preserved verbatim (v2.1.210, wizard skills use `$ARGUMENTS` — unaffected) |
 | Recommended Model | Sonnet 5 (default) — beats Opus 4.6 on benchmarks at generally lower quota (savings vary by effort; narrows at `high`/`xhigh`). Escalate to Opus 4.8 `xhigh` when stuck. Opus 4.6 `max` remains valid for proven consistency. See `AI_SETUP_LANES.md`. |
 | Recommended Effort | Model-aware — Sonnet 5: `medium` default (CodeRabbit-tested), escalate `high` → `xhigh` for hard tasks. Opus 4.8/Fable: `xhigh`/`high`. Opus 4.6: `max` only (its one `xhigh`-less sweet spot). Set per-session with `/effort`, not a shell-rc env var. |
 
@@ -44,7 +44,7 @@ This repository uses the SDLC Wizard to enforce:
 
 | Hook | Trigger | Purpose |
 |------|---------|---------|
-| `sdlc-prompt-check.sh` | Every prompt | SDLC baseline reminder, setup-wizard redirect when SDLC.md/TESTING.md missing |
+| `sdlc-prompt-check.sh` | Every prompt | SDLC baseline reminder, claude-setup-wizard redirect when SDLC.md/TESTING.md missing |
 | `tdd-pretool-check.sh` | Before Write/Edit/MultiEdit | Blocks (exit 2) implementation writes to `src/**` unless a test file was touched earlier this session. This repo's own gate is scoped to `hooks/`, `cli/`, `.github/workflows/` via `SDLC_TDD_SRC_PATTERN` (no `src/` dir here) |
 | `codex-gate-check.sh` | Before `git commit` (Bash) | Blocks (exit 2) commits without a REVIEWED/CERTIFIED `.reviews/handoff.json`, or with a stale (`commit_sha` mismatch) certification |
 | `instructions-loaded-check.sh` | Session start | Wizard-version + CC-version staleness nudges, cross-model-review staleness check, autocompact compound-misconfig check, dual-channel-install check |
@@ -86,7 +86,7 @@ When Claude Code releases new features:
 ├── settings.json                  # Hook configuration
 ├── hooks/
 │   ├── _find-sdlc-root.sh        # Shared helper (sourced by other hooks, not a CC hook entrypoint)
-│   ├── sdlc-prompt-check.sh      # SDLC baseline + setup-wizard redirect
+│   ├── sdlc-prompt-check.sh      # SDLC baseline + claude-setup-wizard redirect
 │   ├── tdd-pretool-check.sh      # TDD RED enforcement (blocks src/** writes)
 │   ├── codex-gate-check.sh       # Blocks git commit without cross-model review
 │   ├── instructions-loaded-check.sh  # Session start: version/staleness/misconfig nudges
@@ -130,7 +130,7 @@ Portable technical gotchas promoted from private memory via the Memory Audit Pro
 
 ### Cross-Model Review
 
-- **A repo-wide policy migration hides in more places than the docs you set out to fix — check hooks, skill menus/logic, tutorial/template code blocks, and user-facing guidance snippets too, not just prose sections.** The v1.84.0 "Opus-4.6-flagship → Sonnet-5-model-aware" migration was scoped as "3 doc sections," but a double-digit-round Codex review kept finding it elsewhere: round 2 found it in `skills/sdlc/SKILL.md`'s own frontmatter; round 4 found the actual live `/setup-wizard` and `/update` skill menus/logic had never been touched at all (a new user would never be offered the new default); round 5 found a live `SessionStart` hook (`model-effort-check.sh`) actively contradicting the new policy; round 6 found a "copy this into your CLAUDE.md" guidance snippet still asserting the old policy; round 8 found the wizard doc's "Step 5: Create the TDD Hook" — a literal, mandatory-reading template `/setup-wizard` copies verbatim — still showed the pre-#436 advisory-only (non-blocking) hook, meaning a manual setup would have shipped a broken TDD gate. Rule: when migrating a blanket recommendation, explicitly check all of: prose docs, skill frontmatter, skill body logic/menus, hooks, tutorial/template code blocks that get copied verbatim, tests (which can bake in the old policy as an assertion and mask a regression), and any user-facing copy-paste snippets — before the first review round, not discovered one category per round. (Source: v1.84.0 release review, 2026-07-04)
+- **A repo-wide policy migration hides in more places than the docs you set out to fix — check hooks, skill menus/logic, tutorial/template code blocks, and user-facing guidance snippets too, not just prose sections.** The v1.84.0 "Opus-4.6-flagship → Sonnet-5-model-aware" migration was scoped as "3 doc sections," but a double-digit-round Codex review kept finding it elsewhere: round 2 found it in `skills/sdlc/SKILL.md`'s own frontmatter; round 4 found the actual live `/claude-setup-wizard` and `/update` skill menus/logic had never been touched at all (a new user would never be offered the new default); round 5 found a live `SessionStart` hook (`model-effort-check.sh`) actively contradicting the new policy; round 6 found a "copy this into your CLAUDE.md" guidance snippet still asserting the old policy; round 8 found the wizard doc's "Step 5: Create the TDD Hook" — a literal, mandatory-reading template `/claude-setup-wizard` copies verbatim — still showed the pre-#436 advisory-only (non-blocking) hook, meaning a manual setup would have shipped a broken TDD gate. Rule: when migrating a blanket recommendation, explicitly check all of: prose docs, skill frontmatter, skill body logic/menus, hooks, tutorial/template code blocks that get copied verbatim, tests (which can bake in the old policy as an assertion and mask a regression), and any user-facing copy-paste snippets — before the first review round, not discovered one category per round. (Source: v1.84.0 release review, 2026-07-04)
 - **Cross-model review convergence should be judged by finding-quality-per-token, not a fixed round cap or wall-clock time.** The default "2 rounds sweet spot, 3 max, escalate after" guidance (see "Cross-Model Review" above) assumes findings taper off quickly. For a genuinely large-scope migration, that assumption can be wrong for many rounds in a row — round 8 above was more consequential than rounds 1-3 combined, and time spent was never the constraint. Maintainer's own framing: "i dont care how long it takes if its efficient and effective its not about time, its about quality and tokens." Keep iterating as long as each round's finding is independently verified as real and worth fixing; stop on CERTIFIED, when consecutive rounds return nothing but nitpicks, or explicitly flag (don't silently fix) anything genuinely out of scope so tokens aren't spent chasing it. (Source: same session, 2026-07-04)
 - **When a review finds a live-behavior bug (not just stale prose), turn it into a test, not just a CHANGELOG entry.** Round 8's tutorial-template-vs-real-hook drift is exactly the class of bug this repo's own Post-Mortem discipline (`Incident → Root Cause → New Rule → Test That Proves the Rule → Ship`) exists for — a human/reviewer had to read prose to catch it, when a mechanical check could: for every "Create `.claude/hooks/X.sh`" tutorial code block in `CLAUDE_CODE_SDLC_WIZARD.md`, if the real `hooks/X.sh` contains `exit 2` (blocks), the tutorial block must too. See `tests/test-wizard-doc-hook-templates.sh` (added same session) for the shipped version of this check. (Source: same session, 2026-07-04)
 

--- a/cli/init.js
+++ b/cli/init.js
@@ -45,7 +45,7 @@ const WIZARD_HOOK_MARKERS = FILES
 const GITIGNORE_ENTRIES = ['.claude/plans/', '.claude/settings.local.json'];
 
 // Paths where the Claude plugin form of this wizard installs.
-// If present, running `npx init` creates duplicate /update-wizard (#181).
+// If present, running `npx init` creates duplicate /claude-update-wizard (#181).
 const PLUGIN_INSTALL_PATHS = [
   '.claude/plugins-local/sdlc-wizard-wrap',
   '.claude/plugins/cache/sdlc-wizard-local',
@@ -369,7 +369,7 @@ function init(targetDir, { force = false, dryRun = false, preserveCustomized = f
     if (pluginPaths.length > 0) {
       console.error(`\n${YELLOW}Claude plugin install detected:${RESET}`);
       for (const p of pluginPaths) console.error(`  ${p}`);
-      console.error('\nInstalling via npm on top of the plugin creates duplicate /update-wizard commands.');
+      console.error('\nInstalling via npm on top of the plugin creates duplicate /claude-update-wizard commands.');
       console.error('Pick one channel:');
       console.error(`  - Keep plugin:   exit and use ${CYAN}/plugin update sdlc-wizard${RESET}`);
       console.error(`  - Switch to CLI: remove plugin dir above, then rerun ${CYAN}init${RESET}`);

--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -123,7 +123,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Effort is model-aware, not blanket `max`** — `max` overthinks on Sonnet 5/Opus 4.8. Set via `/effort` per session, not a shell-rc env var (overrides post-switch — see SDLC.md). `/model` persists; picker `s` does not.
 
-**Pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M) — do not set this for `opusplan` (200K, too aggressive). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/setup-wizard` Step 9.5.
+**Pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M) — do not set this for `opusplan` (200K, too aggressive). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/claude-setup-wizard` Step 9.5.
 
 ## Self-Review Loop
 

--- a/hooks/instructions-loaded-check.sh
+++ b/hooks/instructions-loaded-check.sh
@@ -124,10 +124,10 @@ if [ -f "$SDLC_MD" ]; then
                 echo "   Installed: ${INSTALLED_VERSION}"
                 echo "   Latest:    ${LATEST_VERSION}"
                 echo "   You're missing bug fixes and features shipped across ${MINOR_DELTA} releases."
-                echo "   Strongly recommend running /update-wizard before starting new work."
+                echo "   Strongly recommend running /claude-update-wizard before starting new work."
                 echo ""
             else
-                echo "SDLC Wizard update available: ${INSTALLED_VERSION} → ${LATEST_VERSION} (run /update-wizard)"
+                echo "SDLC Wizard update available: ${INSTALLED_VERSION} → ${LATEST_VERSION} (run /claude-update-wizard)"
             fi
         fi
     fi
@@ -191,7 +191,7 @@ if [ -d "$PROJECT_DIR/.claude/skills/update" ] && [ ! -f "$DUAL_ACK_FILE" ]; the
         if [ -d "$plugin_path" ]; then
             echo "WARNING: dual-install detected — CLI skills in .claude/skills/ AND Claude plugin at:"
             echo "  $plugin_path"
-            echo "  Duplicate /update-wizard commands come from running both channels. Pick one:"
+            echo "  Duplicate /claude-update-wizard commands come from running both channels. Pick one:"
             echo "    - Keep plugin: remove .claude/skills/ from this project"
             echo "    - Keep CLI:    /plugin uninstall sdlc-wizard (or remove plugin dir)"
             echo "    - Keep both:   mkdir -p \"$DUAL_CACHE_DIR\" && touch \"$DUAL_ACK_FILE\"  (silences this nudge)"

--- a/hooks/sdlc-prompt-check.sh
+++ b/hooks/sdlc-prompt-check.sh
@@ -59,7 +59,7 @@ if [ ! -s "$PROJECT_DIR/SDLC.md" ] || [ ! -s "$PROJECT_DIR/TESTING.md" ]; then
     cat << 'SETUP'
 SETUP NOT COMPLETE: SDLC.md and/or TESTING.md are missing.
 
-MANDATORY FIRST ACTION: Invoke Skill tool, skill="setup-wizard"
+MANDATORY FIRST ACTION: Invoke Skill tool, skill="claude-setup-wizard"
 Do NOT proceed with any other task until setup is complete.
 Tell the user: "I need to run the SDLC setup wizard first to configure your project."
 SETUP

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -123,7 +123,7 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Effort is model-aware, not blanket `max`** — `max` overthinks on Sonnet 5/Opus 4.8. Set via `/effort` per session, not a shell-rc env var (overrides post-switch — see SDLC.md). `/model` persists; picker `s` does not.
 
-**Pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M) — do not set this for `opusplan` (200K, too aggressive). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/setup-wizard` Step 9.5.
+**Pinning `claude-opus-4-6`:** pair with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` (1M) — do not set this for `opusplan` (200K, too aggressive). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/claude-setup-wizard` Step 9.5.
 
 ## Self-Review Loop
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup-wizard
+name: claude-setup-wizard
 description: Setup wizard — scans codebase, builds confidence per data point, only asks what it can't figure out, generates SDLC files. Use for first-time setup or re-running setup.
 argument-hint: "[optional: regenerate | verify-only]"
 effort: high
@@ -126,7 +126,7 @@ Reference: See "Step 8" in `CLAUDE_CODE_SDLC_WIZARD.md` for the full template.
 >
 > Pick A, B, or C: `[A/B/C]`
 
-Default if no response: **A** (dual-maintain). Document the user's choice as a one-line comment in their project's `SDLC.md` (e.g. `<!-- AGENTS.md interop: dual-maintain (per ROADMAP #205 phase a) -->`). v1.42.0 does NOT teach `/update-wizard` to parse this metadata key — that's phase (d) work. The comment is for the user's own reference and for whatever future `/update-wizard` version adds AGENTS-aware behavior.
+Default if no response: **A** (dual-maintain). Document the user's choice as a one-line comment in their project's `SDLC.md` (e.g. `<!-- AGENTS.md interop: dual-maintain (per ROADMAP #205 phase a) -->`). v1.42.0 does NOT teach `/claude-update-wizard` to parse this metadata key — that's phase (d) work. The comment is for reference and future `/claude-update-wizard` AGENTS-aware behavior.
 
 **If NO `AGENTS.md` exists**: skip this step silently. Phase (b) of #205 (offer to ALSO generate AGENTS.md alongside CLAUDE.md) is deferred — not in v1.42.0 scope.
 
@@ -299,7 +299,7 @@ Tell the user: "Opus 4.6 max everywhere with Fable advisor — legacy flagship (
 
 Mention the escape hatch in all four cases:
 - To opt out later: remove the `model` line (and optionally the `env`/`effortLevel` keys) from `.claude/settings.json`, or run `/model` and pick "Default (recommended)".
-- To switch tiers later: edit `.claude/settings.json` and replace the `model` value, or re-run `/setup-wizard` Step 9.5.
+- To switch tiers later: edit `.claude/settings.json` and replace the `model` value, or re-run `/claude-setup-wizard` Step 9.5.
 - For CI pipelines with short tasks (Setup B only), consider `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60` — compact early to stay fast.
 
 This is project-scoped and shared with the team via git.

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update-wizard
+name: claude-update-wizard
 description: Smart update for SDLC wizard — shows changelog, compares files, lets you selectively adopt changes while preserving customizations.
 argument-hint: "[optional: check-only | force-all]"
 effort: high
@@ -28,11 +28,11 @@ Read `SDLC.md` and extract from the metadata comment:
 <!-- SDLC Wizard Version: X.X.X -->
 <!-- Completed Steps: ... -->
 ```
-No version comment → treat as `0.0.0` (suggest `/setup-wizard` instead).
+No version comment → treat as `0.0.0` (suggest `/claude-setup-wizard` instead).
 
 ### Step 1.5: Check CLI Version (ROADMAP #232)
 
-The wizard files in the user's project are one half of the install. The other half is the **npm CLI** (`agentic-sdlc-wizard`) — the binary powering `npx agentic-sdlc-wizard init`/`check`/`complexity`. If the user ran `init` months ago, their npx cache (or global install) can be stuck on an old version even after `/update-wizard` patches the project files in-session. This step closes that gap.
+The wizard files in the user's project are one half of the install. The other half is the **npm CLI** (`agentic-sdlc-wizard`) — the binary powering `npx agentic-sdlc-wizard init`/`check`/`complexity`. If `init` ran months ago, npx cache (or global install) can be stuck on an old version even after `/claude-update-wizard` patches project files in-session. This step closes that gap.
 
 **Detection — try both paths:**
 
@@ -57,7 +57,7 @@ Cache the result (also used in Step 3).
 
 **Upgrade options when behind:**
 
-> Your `agentic-sdlc-wizard` CLI is at **{installed}**, npm has **{latest}**. The in-session `/update-wizard` will refresh project files via Step 6, but your `npx` cache will keep the old CLI on disk for `npx agentic-sdlc-wizard check`/`init`/`complexity`.
+> Your `agentic-sdlc-wizard` CLI is at **{installed}**, npm has **{latest}**. Step 6 refreshes project files, but `npx` cache keeps the old CLI on disk for `npx agentic-sdlc-wizard check`/`init`/`complexity`.
 >
 > **A. Refresh just the CLI cache (recommended).** No project changes; Step 6 handles the rest with diffs:
 > ```bash
@@ -73,7 +73,7 @@ Cache the result (also used in Step 3).
 >
 > Pick A, B, or C: `[A/B/C]` (default A)
 
-If A: prompt the user to run the one-liner, then re-invoke `/update-wizard`. If B: same with the warning. If C: log the choice and continue.
+If A: prompt the user to run the one-liner, then re-invoke `/claude-update-wizard`. If B: same with the warning. If C: log the choice and continue.
 
 **`check-only` precedence:** if the user passed `check-only`, Step 1.5 runs in report-only mode — print the gap if found, but do NOT prompt and do NOT run `init --force`. The check-only contract is "tell me what's drifted, don't change anything," and that supersedes the CLI bump path. **Graceful fallback** when CLI undetectable: skip the bump prompt, surface the unknown-state in the report, continue to Step 2.
 
@@ -267,6 +267,6 @@ All updated files should show MATCH. User-skipped files still show CUSTOMIZED �
 1. **NEVER modify CLAUDE.md.** Fully custom to user's project. Wizard never touches it.
 2. **NEVER auto-apply without showing what will change first** (unless `force-all`).
 3. **Offline fallback:** WebFetch fails → tell user "Cannot reach GitHub. Run `npx agentic-sdlc-wizard init --force` to update from your locally installed CLI."
-4. **First-time users:** SDLC.md missing or no version metadata → suggest `/setup-wizard`.
+4. **First-time users:** SDLC.md missing or no version metadata → suggest `/claude-setup-wizard`.
 5. **Respect customizations.** CUSTOMIZED files are intentional — show what's different, let them decide. Don't pressure.
 6. **Reference the wizard doc** for full protocol details (step registry, URLs, version tracking) rather than hardcoding.

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -325,12 +325,12 @@ test_hook_content() {
     (cd "$d" && node "$CLI" init > /dev/null 2>&1)
     local ok=true
     grep -q "SDLC BASELINE" "$d/.claude/hooks/sdlc-prompt-check.sh" || ok=false
-    grep -q "setup-wizard" "$d/.claude/hooks/sdlc-prompt-check.sh" || ok=false
+    grep -q "claude-setup-wizard" "$d/.claude/hooks/sdlc-prompt-check.sh" || ok=false
     grep -q "TDD CHECK" "$d/.claude/hooks/tdd-pretool-check.sh" || ok=false
     if [ "$ok" = true ]; then
         pass "Template hooks contain expected content"
     else
-        fail "Template hooks should contain SDLC BASELINE + setup-wizard (sdlc-prompt-check.sh), TDD CHECK (tdd-pretool-check.sh)"
+        fail "Template hooks should contain SDLC BASELINE + claude-setup-wizard (sdlc-prompt-check.sh), TDD CHECK (tdd-pretool-check.sh)"
     fi
     rm -rf "$d"
 }
@@ -695,18 +695,18 @@ test_check_drift_gitignore() {
     rm -rf "$d"
 }
 
-# Test 23: Template setup-wizard skill has correct frontmatter
+# Test 23: Template claude-setup-wizard skill has correct frontmatter
 test_setup_wizard_frontmatter() {
     local d
     d=$(make_temp)
     (cd "$d" && node "$CLI" init > /dev/null 2>&1)
     local ok=true
-    grep -q "^name: setup-wizard$" "$d/.claude/skills/setup/SKILL.md" || ok=false
+    grep -q "^name: claude-setup-wizard$" "$d/.claude/skills/setup/SKILL.md" || ok=false
     grep -q "^effort: high$" "$d/.claude/skills/setup/SKILL.md" || ok=false
     if [ "$ok" = true ]; then
-        pass "Template setup-wizard skill has correct frontmatter (name + effort)"
+        pass "Template claude-setup-wizard skill has correct frontmatter (name + effort)"
     else
-        fail "setup-wizard skill should have name: setup-wizard and effort: high in frontmatter"
+        fail "claude-setup-wizard skill should have name: claude-setup-wizard and effort: high in frontmatter"
     fi
     rm -rf "$d"
 }

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1561,6 +1561,39 @@ PYEOF
     fi
 }
 
+# #374: setup/update skill names collided with opencode-sdlc-wizard's own
+# identically-named skills under OpenCode (which reads multiple skill trees
+# by `name:`, not by directory) — causing non-deterministic wrong-wizard
+# resolution. Fix: namespace the frontmatter name + live dispatch string.
+# ROADMAP*.md/CHANGELOG.md/.reviews/ are historical record, intentionally
+# excluded.
+test_no_bare_setup_update_wizard_collision() {
+    local bad=""
+    grep -q "^name: claude-setup-wizard$" "$REPO_ROOT/skills/setup/SKILL.md" \
+        || bad="$bad skills/setup/SKILL.md:name-not-namespaced"
+    grep -q "^name: claude-update-wizard$" "$REPO_ROOT/skills/update/SKILL.md" \
+        || bad="$bad skills/update/SKILL.md:name-not-namespaced"
+    grep -q 'skill="claude-setup-wizard"' "$REPO_ROOT/hooks/sdlc-prompt-check.sh" \
+        || bad="$bad hooks/sdlc-prompt-check.sh:dispatch-not-namespaced"
+
+    local hits
+    hits=$(grep -rlE '/(setup|update)-wizard\b' "$REPO_ROOT" \
+        --include="*.md" --include="*.sh" --include="*.js" \
+        --exclude="ROADMAP.md" --exclude="ROADMAP_ARCHIVE.md" \
+        --exclude="CHANGELOG.md" \
+        --exclude-dir=".reviews" --exclude-dir="node_modules" \
+        --exclude-dir=".git" 2>/dev/null || true)
+    [ -n "$hits" ] && bad="$bad bare-invocation-still-present-in:$(echo "$hits" | tr '\n' ',')"
+
+    if [ -z "$bad" ]; then
+        pass "#374: setup/update skill names namespaced (claude-setup-wizard / claude-update-wizard), no bare-name collision with opencode-sdlc-wizard remains"
+    else
+        fail "#374 regression:$bad"
+    fi
+}
+
+test_no_bare_setup_update_wizard_collision
+
 test_argument_hint_frontmatter_is_string
 
 # ────────────────────────────────────────────

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -733,7 +733,7 @@ test_sdlc_update_frequency() {
     fi
 }
 
-# Test 26: sdlc-prompt-check outputs setup-wizard directive when SDLC.md missing
+# Test 26: sdlc-prompt-check outputs claude-setup-wizard directive when SDLC.md missing
 test_sdlc_hook_setup_redirect_missing_sdlc() {
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -741,14 +741,14 @@ test_sdlc_hook_setup_redirect_missing_sdlc() {
     local output
     output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
-        pass "sdlc-prompt-check.sh redirects to setup-wizard when SDLC.md missing"
+    if echo "$output" | grep -q "claude-setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
+        pass "sdlc-prompt-check.sh redirects to claude-setup-wizard when SDLC.md missing"
     else
-        fail "Should output setup-wizard directive (not SDLC BASELINE) when SDLC.md missing"
+        fail "Should output claude-setup-wizard directive (not SDLC BASELINE) when SDLC.md missing"
     fi
 }
 
-# Test 27: sdlc-prompt-check outputs setup-wizard directive when TESTING.md missing
+# Test 27: sdlc-prompt-check outputs claude-setup-wizard directive when TESTING.md missing
 test_sdlc_hook_setup_redirect_missing_testing() {
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -756,10 +756,10 @@ test_sdlc_hook_setup_redirect_missing_testing() {
     local output
     output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
-        pass "sdlc-prompt-check.sh redirects to setup-wizard when TESTING.md missing"
+    if echo "$output" | grep -q "claude-setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
+        pass "sdlc-prompt-check.sh redirects to claude-setup-wizard when TESTING.md missing"
     else
-        fail "Should output setup-wizard directive (not SDLC BASELINE) when TESTING.md missing"
+        fail "Should output claude-setup-wizard directive (not SDLC BASELINE) when TESTING.md missing"
     fi
 }
 
@@ -788,14 +788,14 @@ test_sdlc_hook_setup_redirect_empty_stubs() {
     local output
     output=$(cd "$tmpdir" && CLAUDE_PROJECT_DIR="$tmpdir" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
-        pass "sdlc-prompt-check.sh redirects to setup-wizard for empty stub files"
+    if echo "$output" | grep -q "claude-setup-wizard" && ! echo "$output" | grep -q "SDLC BASELINE"; then
+        pass "sdlc-prompt-check.sh redirects to claude-setup-wizard for empty stub files"
     else
-        fail "Empty stub files should trigger setup-wizard redirect, not baseline"
+        fail "Empty stub files should trigger claude-setup-wizard redirect, not baseline"
     fi
 }
 
-# Test 30: Template hook redirects to setup-wizard on partial setup (one file present)
+# Test 30: Template hook redirects to claude-setup-wizard on partial setup (one file present)
 test_template_hook_setup_redirect() {
     local TEMPLATE_HOOK="$SCRIPT_DIR/../hooks/sdlc-prompt-check.sh"
     if [ ! -f "$TEMPLATE_HOOK" ]; then fail "Template hook not found"; return; fi
@@ -807,10 +807,10 @@ test_template_hook_setup_redirect() {
     local output
     output=$(cd "$tmpdir/project" && CLAUDE_PROJECT_DIR="" HOME="$tmpdir" bash "$TEMPLATE_HOOK" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "setup-wizard"; then
-        pass "Template hook redirects to setup-wizard on partial setup"
+    if echo "$output" | grep -q "claude-setup-wizard"; then
+        pass "Template hook redirects to claude-setup-wizard on partial setup"
     else
-        fail "Template hook should redirect to setup-wizard, got: $output"
+        fail "Template hook should redirect to claude-setup-wizard, got: $output"
     fi
 }
 
@@ -1193,7 +1193,7 @@ test_update_notification_no_version_metadata() {
     fi
 }
 
-# Test 40: Update notification mentions /update-wizard
+# Test 40: Update notification mentions /claude-update-wizard
 test_update_notification_mentions_update_wizard() {
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -1205,10 +1205,10 @@ test_update_notification_mentions_update_wizard() {
     local output
     output=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" CLAUDE_PROJECT_DIR="$tmpdir" SDLC_WIZARD_CACHE_DIR="$tmpdir/cache" "$HOOKS_DIR/instructions-loaded-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "/update-wizard"; then
-        pass "Update notification mentions /update-wizard"
+    if echo "$output" | grep -q "/claude-update-wizard"; then
+        pass "Update notification mentions /claude-update-wizard"
     else
-        fail "Update notification should mention /update-wizard, got: $output"
+        fail "Update notification should mention /claude-update-wizard, got: $output"
     fi
 }
 
@@ -1233,7 +1233,7 @@ test_update_notification_loud_when_3_minor_behind() {
     # count and a WARNING/!! marker so the nudge stands out.
     echo "$output" | grep -qE '(9.*minor.*behind|behind.*9.*minor|9[[:space:]]*versions.*behind)' || ok=false
     echo "$output" | grep -qE 'WARNING|!!|⚠|strongly recommend' || ok=false
-    echo "$output" | grep -q '/update-wizard' || ok=false
+    echo "$output" | grep -q '/claude-update-wizard' || ok=false
     if [ "$ok" = true ]; then
         pass "Loud nudge fires when ≥3 minor versions behind (1.25.0 → 1.34.0)"
     else
@@ -1721,10 +1721,10 @@ test_sdlc_hook_cwd_walkup_empty_stubs() {
     local output
     output=$(cd "$tmpdir/project/src" && CLAUDE_PROJECT_DIR="" "$HOOKS_DIR/sdlc-prompt-check.sh" 2>/dev/null)
     rm -rf "$tmpdir"
-    if echo "$output" | grep -q "setup-wizard"; then
+    if echo "$output" | grep -q "claude-setup-wizard"; then
         pass "CWD walk-up still triggers setup for empty stub files"
     else
-        fail "Empty stubs found by CWD walk should still trigger setup-wizard"
+        fail "Empty stubs found by CWD walk should still trigger claude-setup-wizard"
     fi
 }
 

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -297,7 +297,7 @@ test_wizard_skill_cross_model_review_instructions() {
     fi
 }
 
-# --- /update-wizard Skill Tests (#33) ---
+# --- /claude-update-wizard Skill Tests (#33) ---
 
 # Test 22: Update skill file exists in local skills directory
 test_update_skill_exists() {
@@ -334,7 +334,7 @@ test_update_skill_parity() {
 test_update_skill_content() {
     local skill_file="$SCRIPT_DIR/../.claude/skills/update/SKILL.md"
     local ok=true
-    grep -q "name: update-wizard" "$skill_file" || ok=false
+    grep -q "name: claude-update-wizard" "$skill_file" || ok=false
     grep -q "WebFetch" "$skill_file" || ok=false
     grep -q "CHANGELOG" "$skill_file" || ok=false
     grep -qi "selective\|per-file\|selectively" "$skill_file" || ok=false

--- a/tests/test-update-skill-cli-version.sh
+++ b/tests/test-update-skill-cli-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Quality test: /update-wizard must detect stale local CLI before in-session file updates.
+# Quality test: /claude-update-wizard must detect stale local CLI before in-session file updates.
 #
-# ROADMAP #232: previously /update-wizard fetched the latest wizard files from GitHub raw
+# ROADMAP #232: previously /claude-update-wizard fetched the latest wizard files from GitHub raw
 # and patched in-session, but the user's local npx-cached CLI (the thing that runs `check`,
 # `init`, etc.) could remain on an old version forever. Symptom: user sees "you're up to
 # date" on wizard files, but their `npx agentic-sdlc-wizard ...` is still 1.30.0 missing


### PR DESCRIPTION
## Summary
- Closes #374 — `skills/setup/SKILL.md` (`name: setup-wizard`) and `skills/update/SKILL.md` (`name: update-wizard`) collide with `opencode-sdlc-wizard`'s identically-named skills. OpenCode reads multiple skill trees by `name:`, not directory, so `skill({ name: "update-wizard" })` resolved non-deterministically — sometimes silently loading the wrong wizard's updater. Claude Code only reads `.claude/skills`, so this never bit there.
- Renamed to `claude-setup-wizard` / `claude-update-wizard`: frontmatter `name:`, the live dispatch string in `hooks/sdlc-prompt-check.sh:62`, and every user-facing `/setup-wizard`/`/update-wizard` reference across docs, hooks, and tests
- **Directories intentionally unchanged** (`skills/setup/`, `skills/update/` stay as-is) — presented 3 options to the user, this was the explicit pick. Only the `name:` identifier moves, since that's what OpenCode actually resolves collisions on; renaming directories too would've touched `cli/init.js` install paths for zero additional collision-fixing benefit.
- `step-update-wizard`/`step-setup-wizard` step-registry keys and `CHANGELOG.md`/`ROADMAP.md`/`ROADMAP_ARCHIVE.md` historical citations correctly left untouched (internal tracking labels and historical record, not the invocable identifier)

## Token-budget note
Namespacing added ~8 chars per occurrence, pushing both `SKILL.md` files just over the 20000-char audit threshold (same class of regression `test-audit-session-load.sh` caught in #440). Trimmed two verbose sentences in each file — reread both in context to confirm meaning was preserved, not just word count.

## Cross-model review
Codex xhigh, CERTIFIED round 1. Verified the live dispatch string, ran all four affected suites independently, confirmed the sweep was complete with no stragglers outside the intentionally-excluded files.

## Test plan
- [x] `bash tests/test-doc-consistency.sh` — 74/74 (new regression test `test_no_bare_setup_update_wizard_collision`, mutation-verified RED before the fix)
- [x] `bash tests/test-cli.sh` — 97/97
- [x] `bash tests/test-self-update.sh` — 153/153
- [x] `bash tests/test-hooks.sh` — 161/161
- [x] Full sweep: all 58 `tests/*.sh` files, 0 failures
- [x] Codex xhigh cross-model review — CERTIFIED (round 1)