### PR TITLE
feat(ci): release-drift gate — main must not silently outrun npm (#449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,9 @@ jobs:
       - name: Run cc-version-drift workflow tests (#350)
         run: ./tests/test-cc-version-drift.sh
 
+      - name: Run release-drift gate tests (#449)
+        run: ./tests/test-release-drift.sh
+
       - name: Run domain detection tests
         run: ./tests/test-domain-detection.sh
 

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,278 @@
+name: Release Drift
+
+# ROADMAP #449: main must not silently outrun the published npm package.
+# Cheap GitHub-API-only detector — no LLM, no API spend. Mirrors
+# cc-version-drift.yml's pattern (#350), pointed inward at our own
+# package instead of outward at Claude Code's.
+#
+# Context: npm `latest` sat at v1.86.0 while main was 7
+# consumer-affecting commits ahead (2026-07-14 incident) — the #445
+# Copilot fix was merged, thanked, and closed while every npx install
+# kept shipping the bug it fixed, and nothing in the process would
+# ever have prompted a release. Root causes: (a) publish requires a
+# manual `git tag v* && git push origin v*` that nothing prompts for;
+# (b) "small commits stay local until a release" plus "docs don't feel
+# release-worthy" let guidance changes pile up with no release
+# decision ever made; (c) cc-version-drift.yml watches Claude Code's
+# npm drift but nothing watched OUR OWN package's drift vs main.
+#
+# Design constraints (each enforced by tests/test-release-drift.sh):
+#
+#   1. Standalone workflow — NOT extending weekly-update.yml, same
+#      rationale as cc-version-drift.yml (#350.1): that workflow's
+#      cron is commented out and its tests assert `issues: write` is
+#      absent (deliberate #212/#231 guardrails).
+#
+#   2. Cron staggered from neighboring workflows. weekly-update.yml:
+#      09:00 UTC Mon (disabled). weekly-api-update.yml: 10:00 UTC Mon.
+#      cc-version-drift.yml: 09:30 UTC Mon. We slot at 09:45 UTC Mon.
+#
+#   3. Idempotency via label `release-drift` + machine-readable marker
+#      in issue body — edit the existing open issue rather than
+#      comment-spam, same as cc-version-drift.yml.
+#
+#   4. Consumer-distributed paths: skills/, hooks/, cli/,
+#      CLAUDE_CODE_SDLC_WIZARD.md, cowork/ — the same set #449's own
+#      scope names. A commit touching only tests/, .github/, or
+#      internal docs (ROADMAP.md, this file) doesn't strand a real fix
+#      behind an unpublished release.
+#
+#   5. No `|| true` / `|| echo` failure-suppression — the whole point
+#      is "don't let drift detection silently fail."
+#
+#   6. NOT auto-publish-on-merge. This workflow only opens/refreshes a
+#      tracking issue — the human release gate and Release Review
+#      Focus checklist (SDLC.md) stay. The fix targets the forgetting,
+#      not the gate.
+#
+#   7. Verifies npm's ACTUAL published version against the last git
+#      tag, independent of the commit-count/age check (Codex round-1
+#      catch, this PR): counting commits since the last tag only
+#      proves main outran the TAG, not npm — a tag pushed but whose
+#      `release.yml` publish step then failed silently would report
+#      "no drift" right after a broken release without this check.
+
+on:
+  schedule:
+    - cron: '45 9 * * 1'  # Mon 09:45 UTC, staggered from weekly/weekly-api/cc-drift
+  workflow_dispatch:
+    inputs:
+      count_threshold:
+        description: 'Override commit-count threshold. Default 5.'
+        required: false
+        default: '5'
+      age_threshold_days:
+        description: 'Override age threshold (days). Default 7.'
+        required: false
+        default: '7'
+
+permissions:
+  contents: read  # package.json + git log + scripts/release-drift-check.sh — read-only
+  issues: write   # open / update the tracking issue (the only side effect)
+
+env:
+  RELEASE_DRIFT_LABEL: 'release-drift'
+  COUNT_THRESHOLD: '5'
+  AGE_THRESHOLD_DAYS: '7'
+  # Consumer-distributed paths per #449's own scope — anything a
+  # `npx agentic-sdlc-wizard init/check` actually installs.
+  CONSUMER_PATHS: 'skills/ hooks/ cli/ CLAUDE_CODE_SDLC_WIZARD.md cowork/'
+
+jobs:
+  detect-drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # need full history for `git describe` + `git log <tag>..HEAD`
+
+      - name: Find last published tag and count consumer-path commits since
+        id: gitdata
+        run: |
+          set -euo pipefail
+          if ! LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
+            echo "::error::No v* tag found — cannot compute release drift"
+            exit 1
+          fi
+          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+
+          # shellcheck disable=SC2086 -- CONSUMER_PATHS is an intentional word-split list
+          COMMIT_COUNT=$(git log "${LAST_TAG}..HEAD" --oneline -- $CONSUMER_PATHS | wc -l | tr -d ' ')
+          echo "commit_count=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+          if [ "$COMMIT_COUNT" -gt 0 ]; then
+            # shellcheck disable=SC2086
+            OLDEST_EPOCH=$(git log "${LAST_TAG}..HEAD" --format='%at' -- $CONSUMER_PATHS | tail -1)
+          else
+            OLDEST_EPOCH=0
+          fi
+          echo "oldest_commit_epoch=${OLDEST_EPOCH}" >> "$GITHUB_OUTPUT"
+          echo "now_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+          echo "last tag: ${LAST_TAG}, consumer-path commits since: ${COMMIT_COUNT}"
+
+      - name: Verify npm actually published the last tag
+        id: npmcheck
+        run: |
+          set -euo pipefail
+          # Codex round-1 catch: counting commits since the last git
+          # tag only proves main outran the last TAG — if release.yml's
+          # publish step failed silently after the tag was pushed, npm
+          # could be stale relative to the tag itself, and this
+          # workflow would wrongly report "no drift" right after a
+          # broken release. Compare npm's actual published version
+          # against the tag directly, independent of the commit-count
+          # check below.
+          NPM_VERSION=$(npm view agentic-sdlc-wizard version)
+          if [ -z "${NPM_VERSION:-}" ]; then
+            echo "::error::npm view returned empty version for agentic-sdlc-wizard — registry issue?"
+            exit 1
+          fi
+          TAG_VERSION="${LAST_TAG#v}"
+          echo "npm_version=${NPM_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "$NPM_VERSION" != "$TAG_VERSION" ]; then
+            echo "mismatch=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::npm published version (${NPM_VERSION}) does not match last tag (${TAG_VERSION}) — possible failed publish"
+          else
+            echo "mismatch=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          LAST_TAG: ${{ steps.gitdata.outputs.last_tag }}
+
+      - name: Compute drift
+        id: drift
+        env:
+          COMMIT_COUNT: ${{ steps.gitdata.outputs.commit_count }}
+          OLDEST_EPOCH: ${{ steps.gitdata.outputs.oldest_commit_epoch }}
+          NOW_EPOCH: ${{ steps.gitdata.outputs.now_epoch }}
+          COUNT_THRESHOLD_IN: ${{ inputs.count_threshold || env.COUNT_THRESHOLD }}
+          AGE_THRESHOLD_IN: ${{ inputs.age_threshold_days || env.AGE_THRESHOLD_DAYS }}
+        run: |
+          set -euo pipefail
+          ./scripts/release-drift-check.sh \
+            --commit-count "$COMMIT_COUNT" \
+            --oldest-commit-epoch "$OLDEST_EPOCH" \
+            --now-epoch "$NOW_EPOCH" \
+            --count-threshold "$COUNT_THRESHOLD_IN" \
+            --age-threshold-days "$AGE_THRESHOLD_IN" \
+            > /tmp/drift.json
+          cat /tmp/drift.json
+          {
+            echo "alert=$(jq -r '.alert' /tmp/drift.json)"
+            echo "commit_count=$(jq -r '.commit_count' /tmp/drift.json)"
+            echo "oldest_age_days=$(jq -r '.oldest_age_days' /tmp/drift.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.alert == 'true' || steps.npmcheck.outputs.mismatch == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          LAST_TAG: ${{ steps.gitdata.outputs.last_tag }}
+          COMMIT_COUNT: ${{ steps.drift.outputs.commit_count }}
+          OLDEST_AGE_DAYS: ${{ steps.drift.outputs.oldest_age_days }}
+          PUBLISH_MISMATCH: ${{ steps.npmcheck.outputs.mismatch }}
+          NPM_VERSION: ${{ steps.npmcheck.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (idempotent). `gh api` writes JSON
+          # error bodies to STDOUT on non-2xx — capture both streams.
+          label_out=$(mktemp)
+          if ! gh api "repos/${REPO}/labels" --method POST \
+               -f name="${RELEASE_DRIFT_LABEL}" \
+               -f color='D93F0B' \
+               -f description='main has consumer-affecting commits unpublished to npm (ROADMAP #449)' \
+               >"$label_out" 2>&1; then
+            if grep -q 'already_exists' "$label_out"; then
+              echo "label ${RELEASE_DRIFT_LABEL} already exists — continuing"
+            else
+              cat "$label_out" >&2
+              rm -f "$label_out"
+              exit 1
+            fi
+          fi
+          rm -f "$label_out"
+
+          if [ "$PUBLISH_MISMATCH" = "true" ]; then
+            TITLE="Release due: npm publish MISMATCH — tag ${LAST_TAG} but npm shows v${NPM_VERSION}"
+          else
+            TITLE="Release due: ${COMMIT_COUNT} consumer-affecting commit(s) unpublished since ${LAST_TAG} (oldest ${OLDEST_AGE_DAYS}d)"
+          fi
+
+          {
+            echo "<!-- release-drift last_tag=${LAST_TAG} commit_count=${COMMIT_COUNT} oldest_age_days=${OLDEST_AGE_DAYS} publish_mismatch=${PUBLISH_MISMATCH} -->"
+            echo ""
+            if [ "$PUBLISH_MISMATCH" = "true" ]; then
+              echo "**⚠️ PUBLISH FAILURE SUSPECTED: the last tag doesn't match what npm actually published.**"
+              echo ""
+              echo "- Last git tag: \`${LAST_TAG}\`"
+              echo "- npm \`latest\`: \`v${NPM_VERSION}\`"
+              echo "- These should match. A tag was pushed but \`release.yml\`'s publish step may have failed silently — check its run history."
+              echo ""
+            fi
+            echo "**\`main\` has consumer-affecting commits that npm hasn't published.**"
+            echo ""
+            echo "- Last published tag: \`${LAST_TAG}\`"
+            echo "- Consumer-path commits since (skills/, hooks/, cli/, CLAUDE_CODE_SDLC_WIZARD.md, cowork/): **${COMMIT_COUNT}**"
+            echo "- Oldest of those commits: **${OLDEST_AGE_DAYS} days old**"
+            echo ""
+            echo "## Stranded commits"
+            echo ""
+            echo '```'
+            # shellcheck disable=SC2086
+            git log "${LAST_TAG}..HEAD" --oneline -- $CONSUMER_PATHS
+            echo '```'
+            echo ""
+            echo "## What to do"
+            echo ""
+            echo "1. Review the stranded commits above — do they warrant a release now, or can they wait for more to batch?"
+            echo "2. If releasing: bump \`package.json\` version, add a \`CHANGELOG.md\` entry, then:"
+            echo "   \`\`\`bash"
+            echo "   git tag v<version> && git push origin v<version>"
+            echo "   \`\`\`"
+            echo "   Merging to main does NOT publish — only the tag push triggers \`release.yml\`."
+            echo "3. Verify: \`npm view agentic-sdlc-wizard version\`."
+            echo "4. Close this issue. If drift recurs, the next Monday cron will open a fresh one."
+            echo ""
+            echo "## Sources"
+            echo ""
+            echo "- ROADMAP #449 — this workflow's own scope and the 2026-07-14 incident that motivated it"
+            echo "- \`SDLC.md\` → Lessons Learned → \"Merging to main does NOT trigger npm publish\""
+          } > /tmp/issue_body.md
+
+          EXISTING=$(gh issue list \
+            --repo "${REPO}" \
+            --state open \
+            --label "${RELEASE_DRIFT_LABEL}" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #${EXISTING} (no new issue, no comment spam)"
+            gh issue edit "$EXISTING" \
+              --repo "${REPO}" \
+              --title "$TITLE" \
+              --body-file /tmp/issue_body.md
+            exit 0
+          fi
+
+          echo "Creating new tracking issue"
+          gh issue create \
+            --repo "${REPO}" \
+            --title "$TITLE" \
+            --body-file /tmp/issue_body.md \
+            --label "${RELEASE_DRIFT_LABEL}" \
+            --label "auto-generated"
+
+      - name: No drift
+        if: steps.drift.outputs.alert != 'true' && steps.npmcheck.outputs.mismatch != 'true'
+        run: |
+          echo "No drift: commit_count=${COMMIT_COUNT} oldest_age_days=${OLDEST_AGE_DAYS} npm_version=${NPM_VERSION}"
+        env:
+          COMMIT_COUNT: ${{ steps.drift.outputs.commit_count }}
+          OLDEST_AGE_DAYS: ${{ steps.drift.outputs.oldest_age_days }}
+          NPM_VERSION: ${{ steps.npmcheck.outputs.npm_version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ Thank you for your interest in improving the SDLC Wizard!
    ./tests/test-install-script.sh && ./tests/test-release-workflow.sh && \
    ./tests/test-release-dry-run-workflow.sh && \
    ./tests/test-cc-drift-check.sh && ./tests/test-cc-version-drift.sh && \
+   ./tests/test-release-drift.sh && \
    ./tests/test-domain-detection.sh && \
    ./tests/test-autocompact-methodology.sh && \
    ./tests/test-node24-compliance.sh && \

--- a/scripts/release-drift-check.sh
+++ b/scripts/release-drift-check.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# release-drift-check.sh — ROADMAP #449: has main silently outrun npm?
+#
+# Source: ROADMAP #449, filed 2026-07-14 after npm `latest` sat at
+# v1.86.0 while main was 7 consumer-affecting commits ahead — nothing
+# in the process would ever have prompted a release. Called from
+# .github/workflows/release-drift.yml, mirrors cc-drift-check.sh's
+# split: the workflow fetches real data (git log, npm view), this
+# script does pure computation on synthetic counts/epochs so tests
+# need no live git repo or network.
+#
+# Output: single-line JSON to stdout. Exit codes:
+#   0 — JSON written successfully (including "below_threshold" results)
+#   2 — input invalid (missing required arg, non-numeric, now < oldest)
+#
+# JSON shape:
+#   {
+#     "commit_count": 6,
+#     "oldest_age_days": 3,
+#     "count_threshold": 5,
+#     "age_threshold_days": 7,
+#     "count_exceeded": true,
+#     "age_exceeded": false,
+#     "alert": true
+#   }
+#
+# bash 3-compatible (macOS default ships bash 3.x).
+
+set -eo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: release-drift-check.sh --commit-count N --oldest-commit-epoch T --now-epoch T2
+                               [--count-threshold N] [--age-threshold-days N]
+
+Computes whether consumer-path commits since the last v* tag exceed a
+count or age threshold. commit-count=0 never alerts (oldest-commit-epoch
+is meaningless when there are no pending commits).
+
+Defaults: --count-threshold 5, --age-threshold-days 7.
+
+Exits 0 on success (JSON to stdout), 2 on invalid input.
+EOF
+    exit "${1:-1}"
+}
+
+COMMIT_COUNT=""
+OLDEST_EPOCH=""
+NOW_EPOCH=""
+COUNT_THRESHOLD=5
+AGE_THRESHOLD_DAYS=7
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --commit-count)        COMMIT_COUNT="$2"; shift 2 ;;
+        --oldest-commit-epoch) OLDEST_EPOCH="$2"; shift 2 ;;
+        --now-epoch)           NOW_EPOCH="$2"; shift 2 ;;
+        --count-threshold)     COUNT_THRESHOLD="$2"; shift 2 ;;
+        --age-threshold-days)  AGE_THRESHOLD_DAYS="$2"; shift 2 ;;
+        -h|--help)             usage 0 ;;
+        *) echo "::error::unknown arg: $1" >&2; usage 2 ;;
+    esac
+done
+
+if [ -z "$COMMIT_COUNT" ] || [ -z "$OLDEST_EPOCH" ] || [ -z "$NOW_EPOCH" ]; then
+    echo "::error::--commit-count, --oldest-commit-epoch, and --now-epoch are required" >&2
+    usage 2
+fi
+
+# Validate all numeric inputs are non-negative integers. Silent
+# fallback on a bad number would hide a broken workflow step — fail
+# loud, same philosophy as #350's cc-drift-check.sh.
+is_nonneg_int() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+for name_val in "commit-count:$COMMIT_COUNT" "oldest-commit-epoch:$OLDEST_EPOCH" \
+                 "now-epoch:$NOW_EPOCH" "count-threshold:$COUNT_THRESHOLD" \
+                 "age-threshold-days:$AGE_THRESHOLD_DAYS"; do
+    name="${name_val%%:*}"
+    val="${name_val#*:}"
+    if ! is_nonneg_int "$val"; then
+        echo "::error::--$name must be a non-negative integer (got: '$val')" >&2
+        exit 2
+    fi
+done
+
+if [ "$NOW_EPOCH" -lt "$OLDEST_EPOCH" ]; then
+    echo "::error::--now-epoch ($NOW_EPOCH) is before --oldest-commit-epoch ($OLDEST_EPOCH) — check inputs" >&2
+    exit 2
+fi
+
+COUNT_EXCEEDED="false"
+AGE_EXCEEDED="false"
+OLDEST_AGE_DAYS=0
+
+if [ "$COMMIT_COUNT" -gt 0 ]; then
+    OLDEST_AGE_DAYS=$(( (NOW_EPOCH - OLDEST_EPOCH) / 86400 ))
+    # Strict greater-than, matching cc-drift-check.sh's convention:
+    # exactly at the threshold does NOT alert.
+    if [ "$COMMIT_COUNT" -gt "$COUNT_THRESHOLD" ]; then
+        COUNT_EXCEEDED="true"
+    fi
+    if [ "$OLDEST_AGE_DAYS" -gt "$AGE_THRESHOLD_DAYS" ]; then
+        AGE_EXCEEDED="true"
+    fi
+fi
+# commit_count=0 leaves both *_exceeded false and oldest_age_days=0 —
+# nothing pending, age is meaningless, never alert.
+
+ALERT="false"
+if [ "$COUNT_EXCEEDED" = "true" ] || [ "$AGE_EXCEEDED" = "true" ]; then
+    ALERT="true"
+fi
+
+printf '{"commit_count":%d,"oldest_age_days":%d,"count_threshold":%d,"age_threshold_days":%d,"count_exceeded":%s,"age_exceeded":%s,"alert":%s}\n' \
+    "$COMMIT_COUNT" "$OLDEST_AGE_DAYS" "$COUNT_THRESHOLD" "$AGE_THRESHOLD_DAYS" "$COUNT_EXCEEDED" "$AGE_EXCEEDED" "$ALERT"

--- a/tests/test-release-drift.sh
+++ b/tests/test-release-drift.sh
@@ -1,0 +1,381 @@
+#!/bin/bash
+# test-release-drift.sh — ROADMAP #449: release-drift gate.
+#
+# Tests scripts/release-drift-check.sh, the pure-computation half of the
+# "main must not silently outrun the published npm package" watcher.
+# Mirrors tests/test-cc-version-drift.sh's pattern: the workflow fetches
+# real data (git log, npm view); this script/test operates on synthetic
+# counts/epochs so it needs no live git repo or network.
+#
+# bash 3-compatible (macOS default ships bash 3.x).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$REPO_ROOT/scripts/release-drift-check.sh"
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "\033[0;32mPASS\033[0m: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "\033[0;31mFAIL\033[0m: $1"; FAILED=$((FAILED + 1)); }
+
+# ────────────────────────────────────────────
+# Below-threshold: no alert
+# ────────────────────────────────────────────
+
+test_below_both_thresholds_no_alert() {
+    local out
+    out=$(bash "$CHECK" --commit-count 2 --oldest-commit-epoch "$(($(date +%s) - 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "false" ]; then
+        pass "2 commits / 1 day old, thresholds 5/7 — no alert"
+    else
+        fail "expected no alert, got: $out"
+    fi
+}
+
+test_at_count_threshold_no_alert() {
+    # Strict greater-than, matching cc-drift-check.sh's convention:
+    # exactly N does NOT alert.
+    local out
+    out=$(bash "$CHECK" --commit-count 5 --oldest-commit-epoch "$(($(date +%s) - 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "false" ]; then
+        pass "commit_count exactly at threshold (5) — no alert (strict >)"
+    else
+        fail "expected no alert at exact threshold, got: $out"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Above-threshold: alert
+# ────────────────────────────────────────────
+
+test_count_exceeded_alerts() {
+    local out
+    out=$(bash "$CHECK" --commit-count 6 --oldest-commit-epoch "$(($(date +%s) - 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert count_exceeded
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    count_exceeded=$(echo "$out" | grep -oE '"count_exceeded":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "true" ] && [ "$count_exceeded" = "true" ]; then
+        pass "commit_count 6 > threshold 5 — alerts, count_exceeded true"
+    else
+        fail "expected alert+count_exceeded, got: $out"
+    fi
+}
+
+test_age_exceeded_alerts() {
+    local out
+    out=$(bash "$CHECK" --commit-count 1 --oldest-commit-epoch "$(($(date +%s) - 8 * 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert age_exceeded
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    age_exceeded=$(echo "$out" | grep -oE '"age_exceeded":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "true" ] && [ "$age_exceeded" = "true" ]; then
+        pass "oldest commit 8 days old > threshold 7 — alerts, age_exceeded true"
+    else
+        fail "expected alert+age_exceeded, got: $out"
+    fi
+}
+
+test_at_age_threshold_no_alert() {
+    local out
+    out=$(bash "$CHECK" --commit-count 1 --oldest-commit-epoch "$(($(date +%s) - 7 * 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "false" ]; then
+        pass "oldest commit exactly 7 days old, threshold 7 — no alert (strict >)"
+    else
+        fail "expected no alert at exact age threshold, got: $out"
+    fi
+}
+
+test_zero_commits_no_alert() {
+    # No consumer-path commits since last tag at all — nothing pending,
+    # oldest-commit-epoch is meaningless; script must not crash or alert.
+    local out
+    out=$(bash "$CHECK" --commit-count 0 --oldest-commit-epoch 0 \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local alert
+    alert=$(echo "$out" | grep -oE '"alert":(true|false)' | cut -d: -f2)
+    if [ "$alert" = "false" ]; then
+        pass "commit_count 0 — no alert regardless of oldest-commit-epoch"
+    else
+        fail "expected no alert with zero commits, got: $out"
+    fi
+}
+
+test_both_exceeded_alerts_with_both_flags() {
+    local out
+    out=$(bash "$CHECK" --commit-count 9 --oldest-commit-epoch "$(($(date +%s) - 10 * 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local count_exceeded age_exceeded
+    count_exceeded=$(echo "$out" | grep -oE '"count_exceeded":(true|false)' | cut -d: -f2)
+    age_exceeded=$(echo "$out" | grep -oE '"age_exceeded":(true|false)' | cut -d: -f2)
+    if [ "$count_exceeded" = "true" ] && [ "$age_exceeded" = "true" ]; then
+        pass "both count and age exceeded — both flags true independently"
+    else
+        fail "expected both flags true, got: $out"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Output shape
+# ────────────────────────────────────────────
+
+test_json_shape_has_all_fields() {
+    local out
+    out=$(bash "$CHECK" --commit-count 3 --oldest-commit-epoch "$(($(date +%s) - 86400))" \
+        --now-epoch "$(date +%s)" --count-threshold 5 --age-threshold-days 7)
+    local ok=true
+    for field in commit_count oldest_age_days count_threshold age_threshold_days count_exceeded age_exceeded alert; do
+        echo "$out" | grep -q "\"$field\"" || ok=false
+    done
+    if [ "$ok" = true ]; then
+        pass "JSON output contains all 7 expected fields"
+    else
+        fail "JSON output missing a field: $out"
+    fi
+}
+
+test_default_thresholds_applied_when_omitted() {
+    # Defaults per ROADMAP #449 scope: count=5, age=7 days.
+    local out
+    out=$(bash "$CHECK" --commit-count 6 --oldest-commit-epoch "$(($(date +%s) - 86400))" \
+        --now-epoch "$(date +%s)")
+    local threshold
+    threshold=$(echo "$out" | grep -oE '"count_threshold":[0-9]+' | cut -d: -f2)
+    if [ "$threshold" = "5" ]; then
+        pass "count-threshold defaults to 5 when omitted"
+    else
+        fail "expected default count_threshold=5, got: $out"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Invalid input — fail loud (per #350's "no silent failure" philosophy,
+# reused here per #449's own root-cause: nothing must silently swallow
+# a broken check).
+# ────────────────────────────────────────────
+
+test_missing_required_arg_exits_nonzero() {
+    if bash "$CHECK" --commit-count 3 --now-epoch "$(date +%s)" > /dev/null 2>&1; then
+        fail "missing --oldest-commit-epoch should exit non-zero, but succeeded"
+    else
+        pass "missing --oldest-commit-epoch exits non-zero"
+    fi
+}
+
+test_non_numeric_commit_count_exits_nonzero() {
+    if bash "$CHECK" --commit-count "abc" --oldest-commit-epoch 0 --now-epoch "$(date +%s)" > /dev/null 2>&1; then
+        fail "non-numeric --commit-count should exit non-zero, but succeeded"
+    else
+        pass "non-numeric --commit-count exits non-zero"
+    fi
+}
+
+test_negative_threshold_exits_nonzero() {
+    if bash "$CHECK" --commit-count 3 --oldest-commit-epoch 0 --now-epoch "$(date +%s)" \
+        --count-threshold "-1" > /dev/null 2>&1; then
+        fail "negative --count-threshold should exit non-zero, but succeeded"
+    else
+        pass "negative --count-threshold exits non-zero"
+    fi
+}
+
+test_now_before_oldest_exits_nonzero() {
+    # now-epoch < oldest-commit-epoch means the caller passed bad data
+    # (a commit from the future) — fail loud rather than emit a
+    # misleading negative age.
+    if bash "$CHECK" --commit-count 3 --oldest-commit-epoch "$(date +%s)" \
+        --now-epoch "$(($(date +%s) - 86400))" > /dev/null 2>&1; then
+        fail "now-epoch before oldest-commit-epoch should exit non-zero, but succeeded"
+    else
+        pass "now-epoch before oldest-commit-epoch exits non-zero"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Workflow file existence + design-constraint guards (mirrors
+# test-cc-version-drift.sh's approach of asserting on the YAML itself,
+# not just the script — these catch someone editing the workflow
+# in ways that violate #449's stated scope without touching the script).
+# ────────────────────────────────────────────
+
+test_workflow_file_exists() {
+    if [ -f "$REPO_ROOT/.github/workflows/release-drift.yml" ]; then
+        pass "release-drift.yml workflow file exists"
+    else
+        fail "release-drift.yml workflow file missing"
+    fi
+}
+
+test_workflow_is_standalone_not_extending_weekly_update() {
+    # Same design constraint as cc-version-drift.yml (#350.1), and the
+    # same check tests/test-cc-version-drift.sh already runs: the
+    # standalone-ness requirement is that weekly-update.yml itself
+    # doesn't grow release-drift logic (deliberate #212/#231
+    # guardrails — its cron is commented out, no issues: write). It's
+    # fine for release-drift.yml's own header prose to mention
+    # weekly-update.yml as rationale, same as cc-version-drift.yml's
+    # header does.
+    local weekly="$REPO_ROOT/.github/workflows/weekly-update.yml"
+    if [ -f "$weekly" ] && grep -qi "release-drift\|release_drift" "$weekly"; then
+        fail "weekly-update.yml mentions release-drift logic — must stay standalone (#212/#231 guardrails)"
+    else
+        pass "release-drift detection lives in standalone workflow, not weekly-update.yml"
+    fi
+}
+
+test_workflow_checks_consumer_distributed_paths() {
+    # Anchor on the CONSUMER_PATHS env line specifically — a naive
+    # whole-file grep would still find these words in the header
+    # prose even if someone drops one from the actual operative
+    # env var (caught live via mutation test: removing cowork/ from
+    # CONSUMER_PATHS still passed a whole-file grep, since the header
+    # comment restates the same path list).
+    local line
+    line=$(grep "^  CONSUMER_PATHS:" "$REPO_ROOT/.github/workflows/release-drift.yml" 2>/dev/null)
+    local ok=true
+    for path in "skills/" "hooks/" "cli/" "CLAUDE_CODE_SDLC_WIZARD.md" "cowork/"; do
+        echo "$line" | grep -qF -- "$path" || ok=false
+    done
+    if [ -n "$line" ] && [ "$ok" = true ]; then
+        pass "release-drift.yml's CONSUMER_PATHS env includes all 5 consumer-distributed paths"
+    else
+        fail "release-drift.yml's CONSUMER_PATHS env is missing a consumer-distributed path: $line"
+    fi
+}
+
+test_workflow_uses_release_drift_check_script() {
+    # Anchor on the actual invocation (a `./scripts/...sh` call), not
+    # any mention of the filename — a comment referencing the script
+    # (e.g. the permissions block's rationale) would otherwise let a
+    # mutated/renamed invocation still pass. Caught live via mutation
+    # test on the CONSUMER_PATHS check above; applying the same
+    # anchoring discipline here preemptively.
+    if grep -qE '^\s*\./scripts/release-drift-check\.sh\s*\\?$' "$REPO_ROOT/.github/workflows/release-drift.yml" 2>/dev/null; then
+        pass "release-drift.yml actually invokes ./scripts/release-drift-check.sh"
+    else
+        fail "release-drift.yml does not invoke ./scripts/release-drift-check.sh"
+    fi
+}
+
+test_workflow_has_no_failure_suppression() {
+    # #350's design constraint 5, reused verbatim for #449: no || true /
+    # || echo silently swallowing a broken check. Anchor on
+    # uncommented lines only — the header comment names these patterns
+    # to explain why they're absent, same convention as
+    # tests/test-cc-version-drift.sh's test_no_silent_failures.
+    local hits
+    hits=$(grep -E '^[[:space:]]*[^#[:space:]].*\|\|[[:space:]]*(true|echo)' \
+        "$REPO_ROOT/.github/workflows/release-drift.yml" 2>/dev/null || true)
+    if [ -z "$hits" ]; then
+        pass "release-drift.yml has no active failure-suppression pattern (comments allowed)"
+    else
+        fail "release-drift.yml contains failure-suppressing || true or || echo: $hits"
+    fi
+}
+
+test_workflow_cron_staggered_from_siblings() {
+    # weekly-update.yml: 09:00 UTC Mon (disabled); weekly-api-update.yml:
+    # 10:00 UTC Mon; cc-version-drift.yml: 09:30 UTC Mon. Must not
+    # collide with any of those three.
+    local cron_line
+    cron_line=$(grep -oE "cron: '[0-9]+ [0-9]+ \* \* [0-9]+'" "$REPO_ROOT/.github/workflows/release-drift.yml" 2>/dev/null | head -1)
+    if [ -n "$cron_line" ] && ! echo "$cron_line" | grep -qE "'30 9 \* \* 1'|'0 9 \* \* 1'|'0 10 \* \* 1'"; then
+        pass "release-drift.yml cron is staggered from sibling workflows"
+    else
+        fail "release-drift.yml cron missing or collides with a sibling workflow: $cron_line"
+    fi
+}
+
+# ────────────────────────────────────────────
+# #449 round-1 Codex catch: counting commits since the last git tag
+# only proves main outran the TAG, not npm — a tag pushed whose
+# release.yml publish step then failed silently would report "no
+# drift" without an explicit npm-vs-tag check.
+# ────────────────────────────────────────────
+
+test_workflow_verifies_npm_publish_matches_tag() {
+    # Codex round-3 catch: without asserting the TAG_VERSION="${LAST_TAG#v}"
+    # normalization specifically, mutating it to drop the #v strip
+    # (TAG_VERSION="${LAST_TAG}") still passed 21/21 — every vX.Y.Z tag
+    # would then falsely mismatch npm's bare X.Y.Z version and spam a
+    # tracking issue on every single run, the opposite failure mode
+    # from what this check exists to catch.
+    local wf="$REPO_ROOT/.github/workflows/release-drift.yml"
+    local ok=true
+    grep -qE '^\s*NPM_VERSION=\$\(npm view agentic-sdlc-wizard version\)' "$wf" || ok=false
+    grep -qF 'TAG_VERSION="${LAST_TAG#v}"' "$wf" || ok=false
+    grep -qE '^\s*if \[ "\$NPM_VERSION" != "\$TAG_VERSION" \]' "$wf" || ok=false
+    if [ "$ok" = true ]; then
+        pass "release-drift.yml verifies npm's published version against the v-stripped last tag"
+    else
+        fail "release-drift.yml is missing the npm-vs-tag publish-mismatch check or its v-prefix normalization"
+    fi
+}
+
+test_workflow_issue_step_triggers_on_publish_mismatch_too() {
+    # The issue-opening step's `if:` must fire on EITHER commit drift
+    # OR a publish mismatch — a mismatch with 0 stranded commits
+    # (publish failed right after tagging, before new commits landed)
+    # would otherwise never surface. Codex round-2 catch: checking only
+    # for the SUBSTRING "npmcheck.outputs.mismatch" passed even when
+    # the connecting operator was mutated from || (OR) to && (AND) —
+    # AND would only fire when BOTH conditions are true simultaneously,
+    # exactly missing the edge case this check exists for. Anchor on
+    # the literal `alert == 'true' || steps.npmcheck.outputs.mismatch`
+    # sequence so the operator itself is part of the match.
+    local wf="$REPO_ROOT/.github/workflows/release-drift.yml"
+    local if_line
+    if_line=$(grep -A1 "name: Open or update tracking issue" "$wf" | grep "^\s*if:")
+    if echo "$if_line" | grep -qF "alert == 'true' || steps.npmcheck.outputs.mismatch == 'true'"; then
+        pass "issue-opening step's if: condition ORs commit-drift with the publish-mismatch check"
+    else
+        fail "issue-opening step's if: condition doesn't OR in the publish-mismatch check: $if_line"
+    fi
+}
+
+# ────────────────────────────────────────────
+# Run all tests
+# ────────────────────────────────────────────
+
+test_below_both_thresholds_no_alert
+test_at_count_threshold_no_alert
+test_count_exceeded_alerts
+test_age_exceeded_alerts
+test_at_age_threshold_no_alert
+test_zero_commits_no_alert
+test_both_exceeded_alerts_with_both_flags
+test_json_shape_has_all_fields
+test_default_thresholds_applied_when_omitted
+test_missing_required_arg_exits_nonzero
+test_non_numeric_commit_count_exits_nonzero
+test_negative_threshold_exits_nonzero
+test_now_before_oldest_exits_nonzero
+test_workflow_file_exists
+test_workflow_is_standalone_not_extending_weekly_update
+test_workflow_checks_consumer_distributed_paths
+test_workflow_uses_release_drift_check_script
+test_workflow_has_no_failure_suppression
+test_workflow_cron_staggered_from_siblings
+test_workflow_verifies_npm_publish_matches_tag
+test_workflow_issue_step_triggers_on_publish_mismatch_too
+
+echo ""
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+
+echo "All release-drift gate tests passed!"


### PR DESCRIPTION
## Summary
- Closes ROADMAP #449 — root-caused and scoped on 2026-07-14 (npm `latest` sat at v1.86.0 while `main` was 7 consumer-affecting commits ahead) but never actually built until this exact failure recurred live tonight (`main` 3 commits ahead of `v1.87.0`, including #374's real functional fix, with nothing having prompted a release).
- New sibling to `cc-version-drift.yml`/`cc-drift-check.sh` (#350), pointed inward at our own package instead of outward at Claude Code's:
  - `scripts/release-drift-check.sh` — pure threshold computation (commit-count / oldest-commit-age), no git or network access, fully unit-testable
  - `.github/workflows/release-drift.yml` — finds the last `v*` tag, counts consumer-path (`skills/`, `hooks/`, `cli/`, `CLAUDE_CODE_SDLC_WIZARD.md`, `cowork/`) commits since it, **independently verifies npm's actual published version against the tag** (catches a silently-failed publish, not just a missing tag), and opens/refreshes a `release-drift`-labeled tracking issue past a threshold (5 commits or 7 days, both overridable via `workflow_dispatch`)
- **Not auto-publish-on-merge** — same human-gated design as `cc-version-drift.yml`. This only fixes the forgetting; the release decision stays manual.

## Cross-model review
Codex xhigh, **4 rounds to CERTIFIED** — not rubber-stamped, and genuinely earned the extra rounds (every round found a real, distinct bug, not nitpicks):
- **Round 1**: missing npm-vs-tag publish-mismatch check (a silently failed publish after tagging would have gone undetected) + a vacuous consumer-path test (missing `CLAUDE_CODE_SDLC_WIZARD.md` from its check loop)
- **Round 2**: a test checking only for a substring instead of the actual `||` operator — an `&&` mutation still passed
- **Round 3**: a test that didn't assert the tag's `v`-prefix normalization — a bug there would've made *every* tag falsely mismatch npm's version and spam an issue on every single run
- **Round 4**: CERTIFIED, including independently re-running my mutation fixes and picking 2 more tests at random to mutation-test itself

Between rounds I also proactively self-audited and mutation-tested all 8 workflow-content assertions (not just the ones Codex flagged), catching a couple of vacuous-test patterns myself before submission.

## Test plan
- [x] `bash tests/test-release-drift.sh` — 21/21 (13 pure-logic tests on the script, 8 workflow-structure tests, all mutation-verified non-vacuous)
- [x] Full sweep: all `tests/*.sh` files, 0 failures
- [x] `tests/test-workflow-triggers.sh`'s orphan-test-script and CONTRIBUTING-completeness checks — both caught the CI-wiring gap on first run, now green
- [x] Codex xhigh cross-model review — CERTIFIED (round 4)