### PR TITLE
fix(cowork): rewrite prompt hooks to match documented enforcement contract

### DIFF
--- a/cowork/README.md
+++ b/cowork/README.md
@@ -10,9 +10,9 @@ SDLC enforcement for Claude Cowork sessions. Provides methodology guidance via s
 |-----------|-------------------|---------|
 | SDLC skill | `/sdlc-wizard-cowork:sdlc` | Full SDLC workflow: planning, TDD, self-review |
 | Feedback skill | `/sdlc-wizard-cowork:feedback` | Privacy-first community feedback and pattern sharing |
-| TDD hook | `PreToolUse` (Write/Edit) | Reminds you to write failing tests before implementation |
-| SDLC baseline hook | `UserPromptSubmit` | Injects the SDLC checklist at every prompt |
-| Completion hook | `Stop` | Checks confidence stated, self-review done, tests passing |
+| TDD hook | `PreToolUse` (Write/Edit) | Denies creating a new non-test file that doesn't look like a test (filename heuristic — see limits below) |
+| SDLC baseline hook | `UserPromptSubmit` | Denies prompts that explicitly ask to skip planning/testing/review |
+| Completion hook | `Stop` | Denies stopping if code changed but tests weren't shown passing, self-review is missing, or no confidence was stated |
 
 ## Hooks — Prompt-Based Enforcement
 
@@ -24,9 +24,11 @@ This plugin ships 3 **prompt-based hooks** (`"type": "prompt"`) that enforce SDL
 | SDLC baseline | `sdlc-prompt-check.sh` | `UserPromptSubmit` |
 | Completion check | _(new — no CC equivalent)_ | `Stop` |
 
-Prompt hooks work by injecting instructions into Claude's context at the right moment — no bash, no shell, no filesystem access needed.
+**Prompt hooks do not inject text into the main conversation.** Per Anthropic's documented `prompt` hook contract (`code.claude.com/docs/en/hooks`), each hook sends its `prompt` field to a separate, single-turn evaluator model (Haiku by default), with the hook's JSON input either substituted at `$ARGUMENTS` or auto-appended if `$ARGUMENTS` is omitted. The evaluator must respond `{"ok": true}` to allow, or `{"ok": false, "reason": "..."}` to deny — no shell, no filesystem access needed, but also no soft reminders: it's a real gate, not a nudge. Blocking semantics differ per event — `Stop`'s reason is fed back to Claude and the turn continues (it can actually fix things and retry); `UserPromptSubmit`'s block ends the turn outright with no retry, so it's scoped narrowly (see the hook's own prompt in `hooks/hooks.json`).
 
-> **Note:** These hooks use the same format as Claude Code plugin hooks and match the spec documented in Anthropic's `cowork-plugin-management` plugin. However, they have not yet been tested in a live Cowork session. If hooks don't fire after install, file a bug on the [wizard repo](https://github.com/BaseInfinity/claude-sdlc-wizard/issues).
+**Known limit:** the `PreToolUse` TDD check can only see the current file write, not prior turns or the filesystem — it's a best-effort filename heuristic (denies creating a new non-test file), not proof a failing test was actually run first. A `type: "agent"` hook (multi-turn, with Read/Grep/Glob access) would be the mechanically correct fix for real TDD-order verification; that's a larger, separate change, tracked as a follow-up rather than attempted here.
+
+> **Note:** Live-tested via Codex Desktop computer-use E2E runs (issue [#432](https://github.com/BaseInfinity/claude-sdlc-wizard/issues/432), 2026-07-19/20). An earlier version of these hooks was authored against an incorrect understanding of the mechanism (wrong response schema, checklist-style prompts with no explicit final decision request) — see [#456](https://github.com/BaseInfinity/claude-sdlc-wizard/issues/456) — and has since been rewritten to match Anthropic's documented examples. If hooks still misbehave after install, file a bug on the [wizard repo](https://github.com/BaseInfinity/claude-sdlc-wizard/issues).
 
 ### What's NOT Ported (and Why)
 

--- a/cowork/hooks/hooks.json
+++ b/cowork/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "TDD CHECK: Before this file edit, verify: Is there a FAILING TEST for this change? If you are writing implementation code before a failing test exists, STOP. Write the test first (TDD RED), then implement (TDD GREEN). If the test already exists and fails, proceed with the implementation.",
+            "prompt": "The assistant is about to write or edit this file: $ARGUMENTS\n\nIs the file path a test file — its basename starts with \"test_\"/\"test-\", ends with \"_test\"/\".test\", or the path includes a \"/tests/\", \"/test/\", or \"/spec/\" directory segment? A file is NOT a test file just because \"test\" or \"spec\" appears as a substring elsewhere in its name (for example \"contest.py\" or \"specification_parser.ts\" are NOT test files).\n\nRespond with JSON: {\"ok\": true} if it IS a test file (writing/editing tests is always safe), or if this looks like an edit to an EXISTING file rather than the creation of a brand-new non-test source file. Respond with {\"ok\": false, \"reason\": \"...\"} only if this is clearly the creation of a brand-new, non-test implementation file.\n\nNote: this hook can only see the current file write, not prior turns or the filesystem — it is a best-effort filename heuristic, not proof a failing test was actually run first.",
             "timeout": 15
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "SDLC BASELINE: Before proceeding with this task, ensure you follow the SDLC workflow: 1. Plan tasks FIRST (outline steps before coding). 2. STATE CONFIDENCE: HIGH/MEDIUM/LOW. 3. LOW confidence? ASK USER before proceeding. 4. FAILED 2x? STOP and ASK USER. 5. ALL TESTS MUST PASS BEFORE COMMIT - NO EXCEPTIONS.",
+            "prompt": "The user just submitted this prompt: $ARGUMENTS\n\nA block on this event ends the turn outright with no chance to retry, so only deny prompts that explicitly try to bypass SDLC safeguards. Does this prompt explicitly instruct skipping planning, testing, or self-review (for example: \"skip the tests\", \"don't write a plan\", \"just implement it directly, don't bother testing\", \"ignore TDD\")?\n\nRespond with JSON: {\"ok\": true} if it does NOT ask to skip any safeguard — this is the normal case for almost every prompt, including ordinary code requests with no explicit plan attached. Respond with {\"ok\": false, \"reason\": \"...\"} only if it explicitly asks to bypass planning, testing, or review.",
             "timeout": 10
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "COMPLETION CHECK: Before finishing, verify: 1. Did you state your confidence level (HIGH/MEDIUM/LOW)? 2. Did you read back the files you modified (self-review)? 3. Are all tests passing? 4. Is there any dead code, legacy fallbacks, or scope creep in your changes? If any check fails, address it before presenting your response.",
+            "prompt": "You are evaluating whether the assistant should stop responding. Context: $ARGUMENTS\n\nCheck these conditions:\n1. If code was changed this turn, was a test suite run AND shown to PASS (not just attempted or run with failures)?\n2. If code was changed this turn, does the response show evidence of reading back / reviewing the changed files (self-review)?\n3. Was a confidence level (HIGH/MEDIUM/LOW) stated?\n4. If no code was changed, was a substantive response given at all?\n\nRespond with JSON: {\"ok\": true} if all applicable conditions are met, or {\"ok\": false, \"reason\": \"...\"} if code was changed but tests weren't shown passing, self-review is missing, or no confidence was stated.",
             "timeout": 15
           }
         ]

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -301,6 +301,131 @@ else
   fail "hooks.json not found (skipping type check)"
 fi
 
+# Test 14b (#456): every prompt hook should explicitly reference $ARGUMENTS.
+# Per Anthropic's documented prompt-hook contract (code.claude.com/docs/en/hooks,
+# verified against the raw docs, not a summarized fetch — an earlier round of
+# this fix mis-cited this contract from a hallucinated WebFetch summary and was
+# corrected by Codex xhigh review), the hook input JSON is auto-appended to the
+# prompt even if $ARGUMENTS is omitted — so omitting it does NOT make the
+# evaluator blind. Referencing it explicitly is still best practice (it lets you
+# control where the context appears relative to your instructions, matching
+# Anthropic's own official examples), so this stays a requirement, just not for
+# the "otherwise blind" reason originally claimed here.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  if python3 -c "
+import json
+d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+missing = []
+for event, matchers in d.items():
+    for m in matchers:
+        for h in m.get('hooks', []):
+            if h.get('type') == 'prompt' and '\$ARGUMENTS' not in h.get('prompt', ''):
+                missing.append(event)
+assert not missing, f'missing \$ARGUMENTS in: {missing}'
+" 2>/dev/null; then
+    pass "every prompt hook explicitly references \$ARGUMENTS (best practice, though input JSON auto-appends if omitted)"
+  else
+    fail "at least one prompt hook doesn't explicitly reference \$ARGUMENTS (not blind — auto-appended — but still worse practice)"
+  fi
+else
+  fail "hooks.json not found (skipping \$ARGUMENTS check)"
+fi
+
+# Test 14c (#456, corrected — the original version of this test asserted
+# numbered checklists are always wrong, which Codex xhigh review disproved:
+# Anthropic's own official Stop-hook example at code.claude.com/docs/en/hooks
+# uses a numbered multi-condition list feeding one decision. The REAL defect
+# in the original hooks.json wasn't the numbered format — it was never telling
+# the evaluator the required response schema at all). Every prompt hook must
+# explicitly instruct the evaluator to respond with the real schema
+# ({"ok": true} / {"ok": false, "reason": ...}), matching Anthropic's own
+# examples — not the "yes"/"no" schema this fix originally (incorrectly)
+# assumed, which was itself corrected after Codex disputed it with a citation.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  if python3 -c "
+import json
+d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+missing = []
+for event, matchers in d.items():
+    for m in matchers:
+        for h in m.get('hooks', []):
+            if h.get('type') != 'prompt':
+                continue
+            prompt = h.get('prompt', '')
+            if '\"ok\": true' not in prompt or '\"ok\": false' not in prompt:
+                missing.append(event)
+assert not missing, f'missing explicit ok/false response schema in: {missing}'
+" 2>/dev/null; then
+    pass "every prompt hook explicitly instructs the real {ok: true/false} response schema"
+  else
+    fail "at least one prompt hook doesn't explicitly instruct the {\"ok\": true/false} response format"
+  fi
+else
+  fail "hooks.json not found (skipping response-schema check)"
+fi
+
+# Test 14d (#456 Codex round-1 finding 2): PreToolUse's test-file heuristic must
+# guard against the substring false-positive Codex demonstrated ("contest.py",
+# "specification_parser.ts" both contain "test"/"spec" as substrings but are NOT
+# test files) — checked by requiring the prompt spell out that guard explicitly.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  if python3 -c "
+import json
+d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+prompt = next((hk.get('prompt','') for m in d.get('PreToolUse',[]) for hk in m.get('hooks',[]) if hk.get('type')=='prompt'), '')
+assert 'contest.py' in prompt or 'substring' in prompt.lower(), 'no substring-false-positive guard found'
+" 2>/dev/null; then
+    pass "PreToolUse prompt guards against the substring false-positive (contest.py etc.)"
+  else
+    fail "PreToolUse prompt doesn't guard against 'test'/'spec' substring false positives"
+  fi
+else
+  fail "hooks.json not found (skipping substring-guard check)"
+fi
+
+# Test 14e (#456 Codex round-1 finding 3): UserPromptSubmit must NOT deny plain
+# code requests just for lacking a user-authored plan — a block on this event
+# ends the turn with no retry, so denying ordinary prompts (e.g. "write a
+# function to sort a list", the exact prompt from the #432 E2E test) would be
+# actively disruptive. It must instead only deny prompts that explicitly try to
+# bypass safeguards.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  if python3 -c "
+import json
+d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+prompt = next((hk.get('prompt','') for m in d.get('UserPromptSubmit',[]) for hk in m.get('hooks',[]) if hk.get('type')=='prompt'), '')
+assert 'skip' in prompt.lower() or 'bypass' in prompt.lower(), 'no explicit-bypass framing found'
+assert 'already state a plan' not in prompt.lower(), 'still requires the USER to pre-state a plan (denies ordinary requests)'
+" 2>/dev/null; then
+    pass "UserPromptSubmit denies only explicit bypass requests, not ordinary code prompts"
+  else
+    fail "UserPromptSubmit still denies ordinary code prompts for lacking a user-stated plan, or lost the bypass framing"
+  fi
+else
+  fail "hooks.json not found (skipping UserPromptSubmit scope check)"
+fi
+
+# Test 14f (#456 Codex round-1 finding 4): Stop must require tests to actually
+# PASS, not merely run — Codex demonstrated "HIGH confidence; pytest ran with 3
+# failures" satisfied the prior (broken) criteria. Must also restore the
+# self-review requirement the README promises but the prior rewrite dropped.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  if python3 -c "
+import json
+d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+prompt = next((hk.get('prompt','') for m in d.get('Stop',[]) for hk in m.get('hooks',[]) if hk.get('type')=='prompt'), '')
+p = prompt.lower()
+assert 'pass' in p, 'no requirement that tests PASS (not just run)'
+assert 'self-review' in p, 'self-review requirement missing (README promises it)'
+" 2>/dev/null; then
+    pass "Stop requires tests to pass (not just run) and restores the self-review check"
+  else
+    fail "Stop is missing the tests-must-pass requirement or the self-review check"
+  fi
+else
+  fail "hooks.json not found (skipping Stop pass/self-review check)"
+fi
+
 echo ""
 echo "--- ROADMAP Tracking Tests ---"
 


### PR DESCRIPTION
## Summary
- Closes #456: 2 of 3 Cowork plugin hooks failed outright in a live E2E test (#432), the third was unreliable.
- Root cause: the hooks were authored against an incorrect understanding of the `prompt` hook mechanism. Verified against Anthropic's live docs — a prompt hook sends its `prompt` field to a separate single-turn evaluator model, which must respond `{"ok": true}` / `{"ok": false, "reason": "..."}`, not injected conversation context. All 3 original prompts were imperative checklists with no explicit response-format instruction.
- Rewrote all 3 to match Anthropic's own documented examples:
  - **PreToolUse**: denies creating a new non-test file, with an explicit false-positive guard (`contest.py`, `specification_parser.ts` aren't test files) and an honest disclosure this is a best-effort heuristic (single-turn, no filesystem access).
  - **UserPromptSubmit**: denies only prompts that explicitly ask to bypass planning/testing/review — a block on this event ends the turn outright with no retry, so a stricter gate would be actively disruptive on ordinary requests.
  - **Stop**: requires tests to be shown *passing* (not just run) and restores the self-review condition the README already promised.

## Review
3 rounds of Codex xhigh cross-model review. **Round 1 correctly disputed my initial root-cause citation itself** — a hallucinated WebFetch summary claimed the wrong response schema (`{"yes"}` vs the real `{"ok"}`) and an incorrect "numbered checklists are always wrong" rule that Anthropic's own official example directly contradicts — plus found 3 further real defects in the rewritten hooks. Re-verified the docs via raw fetch (bypassing WebFetch's summarization) and fixed all 4 findings. Round 2 caught one leftover stale test-message string. Round 3: **CERTIFIED.**

**Honestly disclosed residual limit**: no test here proves the live evaluator's actual judgment quality — only structural correctness against the documented contract. Live re-verification requires another Cowork E2E run, not performed in this session.

## Test plan
- [x] `tests/test-cowork-drift.sh` (27 assertions, 4 new/reworked for this fix, all individually mutation-verified — including catching 2 of my own mutation-script bugs before trusting a false "vacuous" signal)
- [x] Full ~55-file regression sweep green (one pre-existing environmental flake unrelated to this change, confirmed by reproducing identically against clean `main`)
- [ ] Not yet re-verified via a second live Cowork E2E run