### PR TITLE
--user-approved: let the human say the thing HARD_DENY demands

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1976,6 +1976,43 @@ This setting affects:
 
 Stored in `.claude/settings.json` as `"verbosity": "small|medium|large"`.
 
+#### Response length on Opus 5 — state it once, in CLAUDE.md
+
+Opus 5's user-facing responses run longer than prior Opus models by default, and
+**effort does not control this**. Anthropic's guide is explicit: effort governs how
+much the model *thinks*, not how much it *says* — "lowering effort can reduce
+thinking volume without reliably shortening the visible response. To control
+response length, prompt for it explicitly."
+
+Put one instruction in your root `CLAUDE.md`. Something like:
+
+```
+Lead with the outcome. Your first sentence should answer "what happened" or
+"what did you find" — the thing someone would ask for if they said "just give
+me the TLDR". Supporting detail comes after. Keep responses focused; spend most
+of the response on the main answer, not caveats.
+```
+
+**Put it at CLAUDE.md level, not in skills or hook output.** Two different
+things, stated separately so neither is overclaimed:
+
+- **Anthropic's guidance** is that a short conciseness instruction works, and
+  that *in a long system prompt* you may pair it with a brief reminder near the
+  end (`<tone_preference>Keep outputs reasonably concise.</tone_preference>`).
+  So a single reminder is endorsed, not discouraged.
+- **This repo additionally bans brevity caps in `SKILL.md` and hook stdout**,
+  enforced by CI. That is a narrower claim about a different situation: those
+  surfaces are injected repeatedly across many turns and many components, which
+  is not the same as one reminder in one system prompt. The evidence behind it
+  is a repo-local postmortem on Opus 4.6/4.7 where a strict length-limit prompt
+  contributed to degraded output — it does not establish a general Opus 5
+  repetition effect, and should not be cited as if it does.
+
+Separately, files Claude *writes* to disk (reports, summaries) also run long. If
+your workflow produces documents, add: "Match the length of written documents to
+what the task needs — cover the substance, don't pad with filler sections,
+redundant summaries, or boilerplate."
+
 ### Testing Philosophy
 
 **Testing approach** (infer from existing test patterns — test-first files, coverage config)

--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -139,10 +139,10 @@ The loop goes back to PLANNING, not TDD RED. Run `/code-review`; issues at confi
 
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 
-1. **Preflight** (`.reviews/preflight-{review_id}.md`) — what you already checked: `/code-review` passed, tests passing, manual verifications, known limits. Reduces reviewer findings to 0-1/round.
+1. **Preflight** (`.reviews/preflight-{review_id}.md`) — what you already checked: `/code-review` passed, tests passing, manual verifications, known limits. Avoids re-litigating verified ground.
 2. **Mission-first handoff** (`.reviews/handoff.json`) — required keys: `"review_id"`, `"status": "PENDING_REVIEW"`, `"round": 1`, `"mission"`/`"success"`/`"failure"` (without them you get "looks good"), `"files_changed"`, `"verification_checklist"` (verification checklist with file:line refs — NOT generic), `"review_instructions"`, `"preflight_path"`. Optional `"pr_number":` opts into PreCompact self-heal (#209: MERGED → implicit CERTIFIED).
 3. **Run reviewer:** `codex exec -c 'model_reasoning_effort="high"' -s danger-full-access -o .reviews/latest-review.md "<prompt>" < /dev/null`. Always `high`. Bash tool requires `run_in_background: true` + `dangerouslyDisableSandbox: true`; always append `< /dev/null`. **Why:** `< /dev/null` prevents codex stdin-hang at S/0% CPU; background avoids the Bash 10-min `timeout` cap that force-kills foreground codex (bundles take 5–30 min; `STALL_SECONDS=1800`). Foreground burned 70 min on a 7-min review (#364).
-4. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Do NOT expand the surface; any new P0/P1/P2 BLOCKS." **NEVER unilaterally dismiss** — always run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
+4. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Don't hunt new surfaces, but report every defect; any new P0/P1/P2 BLOCKS." **NEVER unilaterally dismiss** — always run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
 
 **Convergence:** judge by max severity per round. Escalate, never ship.
 
@@ -175,7 +175,7 @@ Mandatory steps:
 1. Push to remote
 2. `gh pr checks --watch`
 3. **Read CI logs even on pass** (`gh run view <RUN_ID> --log`) — green can hide warnings
-4. **Cross-model audit the CI logs** — same `codex exec` pattern (Cross-Model Review §3): audit for silent failures, skipped tests, degraded metrics
+4. **Cross-model audit the CI logs** — release/workflow/control-plane PRs only: silent failures, skipped tests, degraded metrics
 5. CI fails → fix, push (max 2 attempts)
 6. CI passes → `gh api .../pulls/PR/comments` for review feedback
 7. Implement valid suggestions (bugs, perf, dedup). Skip opinions. Max 3 iterations

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -291,10 +291,38 @@ fi
 PR_NUM="$1"
 shift
 CROSS_MODEL_CLEARED=0
+USER_APPROVED_REASON=""
+WAIVED_PATHS=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --cross-model-cleared) CROSS_MODEL_CLEARED=1 ;;
-        *) echo "Usage: scripts/merge-pr.sh <PR_NUMBER> [--cross-model-cleared]" >&2; exit 1 ;;
+        --user-approved)
+            # The reason is REQUIRED. A bare flag would be a silent bypass
+            # wearing an audit trail's clothes (ROADMAP #479).
+            shift
+            if [ $# -eq 0 ] || [ -z "$1" ]; then
+                echo "BLOCKED: --user-approved requires a non-empty reason, e.g. --user-approved \"maintainer decision: shipping the hook fix, certified round 3\". An override with no stated reason is unauditable." >&2
+                exit 1
+            fi
+            # A flag is not a reason. `--user-approved --cross-model-cleared`
+            # otherwise consumed the NEXT FLAG as the justification and fired a
+            # full override whose recorded reason was the literal string
+            # "--cross-model-cleared". Found by probing argument shapes before
+            # review reported; the two happy-path assertions did not cover it.
+            case "$1" in
+                -*)
+                    echo "BLOCKED: --user-approved's reason cannot start with '-' (got '$1'). That is a flag, not a decision — quote a real reason: --user-approved \"why you are overriding\"." >&2
+                    exit 1
+                    ;;
+            esac
+            # Whitespace is not a reason either.
+            if [ -z "$(printf '%s' "$1" | tr -d '[:space:]')" ]; then
+                echo "BLOCKED: --user-approved's reason is only whitespace. An override recorded with a blank reason is unauditable." >&2
+                exit 1
+            fi
+            USER_APPROVED_REASON="$1"
+            ;;
+        *) echo "Usage: scripts/merge-pr.sh <PR_NUMBER> [--cross-model-cleared] [--user-approved \"<reason>\"]" >&2; exit 1 ;;
     esac
     shift
 done
@@ -393,7 +421,23 @@ fi
         [ -z "$f" ] && continue
         for pattern in "${HARD_DENY[@]}"; do
             if printf '%s' "$f" | grep -qiE "$pattern"; then
-                echo "BLOCKED: PR #$PR_NUM touches '$f', part of the merge-evidence chain ($pattern). --cross-model-cleared does NOT apply here: on these paths the PR defines its own CI check, runs its own gate, and posts its own clearance, so every leg of the evidence would be self-produced. A human decides this one." >&2
+                if [ -n "$USER_APPROVED_REASON" ]; then
+                    # HARD_DENY's own message says "a human decides this one",
+                    # and until now offered no way to say so — the maintainer's
+                    # only route was the GitHub UI, which bypasses this harness
+                    # entirely and leaves NO record in the repo.
+                    #
+                    # Stated honestly: this does NOT prove a human typed it.
+                    # Nothing available to a local script can. What it changes
+                    # is that an override becomes explicit, reasoned and logged
+                    # instead of silent and out-of-band. Do not describe it as
+                    # proof of human authorship.
+                    echo "USER-APPROVED OVERRIDE: PR #$PR_NUM touches '$f' ($pattern), a merge-evidence path where self-produced clearance cannot apply. Proceeding on the stated human decision:" >&2
+                    echo "  reason:   $USER_APPROVED_REASON" >&2
+                    WAIVED_PATHS="$WAIVED_PATHS$f (merge-evidence path)\n"
+                    continue
+                fi
+                echo "BLOCKED: PR #$PR_NUM touches '$f', part of the merge-evidence chain ($pattern). --cross-model-cleared does NOT apply here: on these paths the PR defines its own CI check, runs its own gate, and posts its own clearance, so every leg of the evidence would be self-produced. A human decides this one. If you ARE the human and have decided, re-run with --user-approved \"<reason>\" — it merges and records the reason." >&2
                 exit 1
             fi
         done
@@ -404,11 +448,22 @@ fi
         [ -z "$f" ] && continue
         for pattern in "${ACKABLE_DENY[@]}"; do
             if printf '%s' "$f" | grep -qiE "$pattern"; then
+                if [ -n "$USER_APPROVED_REASON" ]; then
+                    # A human authorised to override the tier that DECIDES
+                    # whether a merge is allowed is necessarily authorised to
+                    # override the tier that merely steers behaviour. Requiring
+                    # a second, different flag for the lesser bar is incoherent
+                    # — found live merging PR #494, where --user-approved
+                    # cleared six hooks/ paths and then blocked on a doc.
+                    echo "USER-APPROVED OVERRIDE: '$f' is guidance this PR changes, normally cleared by posted review. Proceeding on the stated human decision." >&2
+                    WAIVED_PATHS="$WAIVED_PATHS$f (guidance path)\n"
+                    continue
+                fi
                 if [ "$CROSS_MODEL_CLEARED" -eq 1 ] && verify_cross_model_clearance; then
                     echo "DENYLIST ACKNOWLEDGED: '$f' matches $pattern, cleared by $CLEARED_BY. Every other check still ran." >&2
                     continue
                 fi
-                echo "BLOCKED: PR #$PR_NUM touches '$f' ($pattern). Post cross-model clearance to the PR and re-run with --cross-model-cleared." >&2
+                echo "BLOCKED: PR #$PR_NUM changes '$f', a file that steers how future work is done. Clear it either way: post cross-model review to the PR and re-run with --cross-model-cleared, or decide it yourself with --user-approved \"<reason>\"." >&2
                 exit 1
             fi
         done
@@ -423,8 +478,17 @@ fi
         if [ "$f" = "package.json" ]; then
             PKG_PATCH=$(printf '%s' "$PR_FILES" | grep -oE '"filename"[[:space:]]*:[[:space:]]*"package\.json"[^}]*"patch"[[:space:]]*:.*')
             if printf '%s' "$PKG_PATCH" | grep -qE '[+-][[:space:]]*\\"version\\"'; then
-                echo "BLOCKED: PR #$PR_NUM changes package.json's version field — release-adjacent. Explicit user confirmation is required." >&2
-                exit 1
+                if [ -n "$USER_APPROVED_REASON" ]; then
+                    # This check demands "explicit user confirmation", and
+                    # --user-approved with a stated reason IS that confirmation.
+                    # Third instance of the same gap: a gate asking for a human
+                    # decision while providing no way to express one.
+                    echo "USER-APPROVED OVERRIDE: version bump in package.json is release-adjacent and requires explicit confirmation — given, on the stated reason." >&2
+                    WAIVED_PATHS="$WAIVED_PATHS package.json version bump (release-adjacent confirmation)\n"
+                else
+                    echo "BLOCKED: PR #$PR_NUM changes package.json's version field — release-adjacent. Explicit user confirmation is required: re-run with --user-approved \"<reason>\"." >&2
+                    exit 1
+                fi
             fi
         fi
     done <<< "$CLASSIFY_PATHS"
@@ -443,7 +507,7 @@ fi
         | sed 's/.*"previous_filename"[[:space:]]*:[[:space:]]*"//; s/"$//' || true)
     ALL_REMOVED_TESTS=$(printf '%s\n%s' "$DELETED_TESTS" "$RENAMED_OUT_OF_TESTS" | grep -v '^$' || true)
     if [ -n "$ALL_REMOVED_TESTS" ]; then
-        echo "BLOCKED: PR #$PR_NUM net-removes test file(s) (deleted or renamed out of tests/): $ALL_REMOVED_TESTS. Explicit user confirmation is required." >&2
+        echo "BLOCKED: PR #$PR_NUM net-removes test file(s) (deleted or renamed out of tests/): $ALL_REMOVED_TESTS. NOT WAIVABLE — --user-approved cannot clear this. Restore the tests, or merge in the GitHub UI and own it." >&2
         exit 1
     fi
 
@@ -463,36 +527,76 @@ fi
             | head -1)
     fi
     if [ "$VALIDATE_CONCLUSION" != "success" ]; then
-        echo "BLOCKED: CI 'validate' check is '${VALIDATE_CONCLUSION:-missing}', not green (must be exactly 'success' — pending/skipped/neutral/failure all block). Explicit user confirmation is required." >&2
+        echo "BLOCKED: CI 'validate' check is '${VALIDATE_CONCLUSION:-missing}', not green (must be exactly 'success' — pending/skipped/neutral/failure all block). Explicit user confirmation is required. NOT WAIVABLE — --user-approved cannot clear this. Fix CI." >&2
         exit 1
     fi
 
     # --- Clearance artifact check ---
+    #
+    # WHAT --user-approved MAY AND MAY NOT WAIVE. Every message in this block
+    # already says "explicit user confirmation is required" — they are process
+    # requirements, and a human is the thing they are asking for. So the flag
+    # waives them.
+    #
+    # It does NOT waive the two checks above: a red CI 'validate' and a
+    # net-removal of test files. Those are not paperwork, they are objective
+    # statements about whether the code works and whether the evidence that it
+    # works still exists. "The tests are failing" and "the tests are gone" are
+    # not decisions a human gets to override from a shell flag; fix them or
+    # merge in the browser and own it. Keep that split when adding gates.
     CLEARANCE_FILE=".reviews/merge-clearance-$PR_NUM.json"
-    if [ ! -f "$CLEARANCE_FILE" ]; then
-        echo "BLOCKED: no clearance artifact found at $CLEARANCE_FILE. Run the full cross-model review protocol and write this file before merging without explicit confirmation." >&2
+    if [ -n "$USER_APPROVED_REASON" ]; then
+        WAIVED_PATHS="$WAIVED_PATHS clearance-artifact checks (.reviews/merge-clearance-$PR_NUM.json)\n"
+        echo "USER-APPROVED OVERRIDE: skipping the clearance-artifact checks — they exist to demand a human decision, and one was given. The CI-green and test-removal checks above still ran and passed; those are NOT waivable." >&2
+    else
+        if [ ! -f "$CLEARANCE_FILE" ]; then
+            echo "BLOCKED: no clearance artifact found at $CLEARANCE_FILE. Run the full cross-model review protocol and write this file, or decide it yourself with --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CL_STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        if [ "$CL_STATUS" != "CERTIFIED" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE status is '${CL_STATUS:-missing}', not CERTIFIED. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CL_ROUND=$(grep -o '"round"[[:space:]]*:[[:space:]]*[0-9]*' "$CLEARANCE_FILE" | head -1 | sed 's/.*"round"[[:space:]]*:[[:space:]]*//')
+        if [ -z "$CL_ROUND" ] || [ "$CL_ROUND" -lt 2 ]; then
+            echo "BLOCKED: $CLEARANCE_FILE shows round=${CL_ROUND:-missing} — a round-1-only CERTIFIED is treated as an insufficient dialogue (real adversarial review takes at least one recheck round). Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CL_SHA=$(grep -o '"sha"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        if [ "$CL_SHA" != "$HEAD_SHA" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE is stale — its sha ($CL_SHA) does not match the current remote head ($HEAD_SHA). New commits landed since certification. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CL_REVIEW_FILE=$(grep -o '"review_file"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"review_file"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        if [ -z "$CL_REVIEW_FILE" ] || [ ! -s "$CL_REVIEW_FILE" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE's referenced review artifact ('$CL_REVIEW_FILE') is missing or empty — can't verify the dialogue was substantive. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+    fi
+
+# --- Durable override record, BEFORE the merge ---
+#
+# The reason used to go to stderr only, so it evaporated with the session. That
+# made the flag's entire justification false: it was sold as replacing a
+# browser click that "leaves no record in the repo" with a logged override, and
+# PR #494 was merged with it leaving exactly zero durable trace — no comment, no
+# artifact, indistinguishable from any token merge. Found by cross-model review.
+#
+# Posted BEFORE the merge deliberately: if the comment fails, the merge does not
+# happen. An unrecorded override is the thing this exists to prevent, so failing
+# to record it must block rather than proceed silently.
+if [ -n "$USER_APPROVED_REASON" ]; then
+    OVERRIDE_BODY=$(printf '**USER-APPROVED MERGE OVERRIDE**\n\n**Reason:** %s\n\n**Waived** (would otherwise have blocked):\n%s\n\n**Still verified, not waivable:** CI `validate` green, no net-removed test files.\n\nHead: `%s`\n\n_Posted by `scripts/merge-pr.sh --user-approved` before merging. This flag does not prove a human authored it; it makes an override explicit and durable instead of silent._' \
+        "$USER_APPROVED_REASON" \
+        "$(printf '%s\n' "$WAIVED_PATHS" | sed '/^$/d' | sed 's/^/- `/; s/$/`/')" \
+        "$HEAD_SHA")
+    if ! gh pr comment "$PR_NUM" --body "$OVERRIDE_BODY" >/dev/null 2>&1; then
+        echo "BLOCKED: could not post the override record to PR #$PR_NUM. Refusing to merge — an unrecorded override is precisely what --user-approved exists to prevent." >&2
         exit 1
     fi
-    CL_STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//; s/"$//')
-    if [ "$CL_STATUS" != "CERTIFIED" ]; then
-        echo "BLOCKED: $CLEARANCE_FILE status is '${CL_STATUS:-missing}', not CERTIFIED. Explicit user confirmation is required." >&2
-        exit 1
-    fi
-    CL_ROUND=$(grep -o '"round"[[:space:]]*:[[:space:]]*[0-9]*' "$CLEARANCE_FILE" | head -1 | sed 's/.*"round"[[:space:]]*:[[:space:]]*//')
-    if [ -z "$CL_ROUND" ] || [ "$CL_ROUND" -lt 2 ]; then
-        echo "BLOCKED: $CLEARANCE_FILE shows round=${CL_ROUND:-missing} — a round-1-only CERTIFIED is treated as an insufficient dialogue (real adversarial review takes at least one recheck round). Explicit user confirmation is required." >&2
-        exit 1
-    fi
-    CL_SHA=$(grep -o '"sha"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
-    if [ "$CL_SHA" != "$HEAD_SHA" ]; then
-        echo "BLOCKED: $CLEARANCE_FILE is stale — its sha ($CL_SHA) does not match the current remote head ($HEAD_SHA). New commits landed since certification. Explicit user confirmation is required." >&2
-        exit 1
-    fi
-    CL_REVIEW_FILE=$(grep -o '"review_file"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"review_file"[[:space:]]*:[[:space:]]*"//; s/"$//')
-    if [ -z "$CL_REVIEW_FILE" ] || [ ! -s "$CL_REVIEW_FILE" ]; then
-        echo "BLOCKED: $CLEARANCE_FILE's referenced review artifact ('$CL_REVIEW_FILE') is missing or empty — can't verify the dialogue was substantive. Explicit user confirmation is required." >&2
-        exit 1
-    fi
+    echo "Override recorded on PR #$PR_NUM." >&2
+fi
 
 # --- Execute: always squash, no passthrough flags, atomically bound to the
 # checked SHA. Only the PR number is accepted as input, closing the
@@ -505,5 +609,20 @@ if [ "$MERGE_EXIT" -ne 0 ]; then
 fi
 
 echo "$MERGE_OUTPUT"
-echo "MERGED: PR #$PR_NUM at $HEAD_SHA (squash, match-head-commit). Verified: no test deletions, CI validate green, clearance CERTIFIED round>=2 fresh, and $([ "$CROSS_MODEL_CLEARED" -eq 1 ] && echo "denylist acknowledged by $CLEARED_BY" || echo 'denylist clear')."
+
+# The success line must state what ACTUALLY happened. The first version printed
+# "clearance CERTIFIED round>=2 fresh, denylist clear" unconditionally — so an
+# override that skipped clearance and waived every denylist hit still produced
+# an audit record claiming both were verified. A false claim in the audit trail
+# is worse than no audit trail: it is the same defect class as a gate that reads
+# evidence structure and never the verdict inside it. Found by cross-model
+# review, 2026-08-05.
+if [ -n "$USER_APPROVED_REASON" ]; then
+    echo "MERGED: PR #$PR_NUM at $HEAD_SHA (squash, match-head-commit)."
+    echo "  VERIFIED (not waivable): no test deletions, CI validate green."
+    echo "  OVERRIDDEN by --user-approved: denylist tiers, version-bump confirmation, and the clearance-artifact checks were NOT verified — they were waived on the stated human decision."
+    echo "  reason: $USER_APPROVED_REASON"
+else
+    echo "MERGED: PR #$PR_NUM at $HEAD_SHA (squash, match-head-commit). Verified: no test deletions, CI validate green, clearance CERTIFIED round>=2 fresh, and $([ "$CROSS_MODEL_CLEARED" -eq 1 ] && echo "denylist acknowledged by $CLEARED_BY" || echo 'denylist clear')."
+fi
 exit 0

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -139,10 +139,10 @@ The loop goes back to PLANNING, not TDD RED. Run `/code-review`; issues at confi
 
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 
-1. **Preflight** (`.reviews/preflight-{review_id}.md`) — what you already checked: `/code-review` passed, tests passing, manual verifications, known limits. Reduces reviewer findings to 0-1/round.
+1. **Preflight** (`.reviews/preflight-{review_id}.md`) — what you already checked: `/code-review` passed, tests passing, manual verifications, known limits. Avoids re-litigating verified ground.
 2. **Mission-first handoff** (`.reviews/handoff.json`) — required keys: `"review_id"`, `"status": "PENDING_REVIEW"`, `"round": 1`, `"mission"`/`"success"`/`"failure"` (without them you get "looks good"), `"files_changed"`, `"verification_checklist"` (verification checklist with file:line refs — NOT generic), `"review_instructions"`, `"preflight_path"`. Optional `"pr_number":` opts into PreCompact self-heal (#209: MERGED → implicit CERTIFIED).
 3. **Run reviewer:** `codex exec -c 'model_reasoning_effort="high"' -s danger-full-access -o .reviews/latest-review.md "<prompt>" < /dev/null`. Always `high`. Bash tool requires `run_in_background: true` + `dangerouslyDisableSandbox: true`; always append `< /dev/null`. **Why:** `< /dev/null` prevents codex stdin-hang at S/0% CPU; background avoids the Bash 10-min `timeout` cap that force-kills foreground codex (bundles take 5–30 min; `STALL_SECONDS=1800`). Foreground burned 70 min on a 7-min review (#364).
-4. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Do NOT expand the surface; any new P0/P1/P2 BLOCKS." **NEVER unilaterally dismiss** — always run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
+4. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Don't hunt new surfaces, but report every defect; any new P0/P1/P2 BLOCKS." **NEVER unilaterally dismiss** — always run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
 
 **Convergence:** judge by max severity per round. Escalate, never ship.
 
@@ -175,7 +175,7 @@ Mandatory steps:
 1. Push to remote
 2. `gh pr checks --watch`
 3. **Read CI logs even on pass** (`gh run view <RUN_ID> --log`) — green can hide warnings
-4. **Cross-model audit the CI logs** — same `codex exec` pattern (Cross-Model Review §3): audit for silent failures, skipped tests, degraded metrics
+4. **Cross-model audit the CI logs** — release/workflow/control-plane PRs only: silent failures, skipped tests, degraded metrics
 5. CI fails → fix, push (max 2 attempts)
 6. CI passes → `gh api .../pulls/PR/comments` for review feedback
 7. Implement valid suggestions (bugs, perf, dedup). Skip opinions. Max 3 iterations

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -2689,6 +2689,96 @@ test_shipped_entries_predicate_is_not_vacuous() {
 }
 test_shipped_entries_predicate_is_not_vacuous
 
+# ────────────────────────────────────────────
+# GH #486 — align shipped guidance with Anthropic's Opus 5 prompting guide.
+#
+# Three low-risk items. The fourth (deleting the same-model self-review layer)
+# is coupled to the E2E scorer's must-pass list and five other suites, so it
+# ships separately.
+# ────────────────────────────────────────────
+
+# (1) Concision must be stated ONCE, at CLAUDE.md level — never in SKILL.md or
+# hook stdout. tests/test-postmortem-lessons.sh Test 4 already fails CI on
+# brevity caps in those surfaces, because per-injection repetition compounds.
+# The Opus 5 guide is the reason it belongs somewhere: "Claude Opus 5's default
+# user-facing responses run longer than prior Opus models'... To control
+# response length, prompt for it explicitly."
+test_concision_guidance_shipped_once_at_the_right_level() {
+    local doc="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    local bad=""
+
+    grep -qiE 'lead with the outcome|response length|keep responses' "$doc" \
+        || bad="$bad\n  wizard doc has no response-length guidance (Opus 5 defaults long; the guide says prompt for it explicitly)"
+
+    # And it must NOT have leaked into the compounding surfaces.
+    grep -qiE 'keep (responses|outputs) (focused|brief|concise)' "$REPO_ROOT/skills/sdlc/SKILL.md" 2>/dev/null \
+        && bad="$bad\n  brevity cap leaked into skills/sdlc/SKILL.md — compounds per injection (test-postmortem-lessons.sh Test 4)"
+
+    if [ -z "$bad" ]; then
+        pass "#486: response-length guidance shipped once at CLAUDE.md level, not in SKILL.md"
+    else
+        fail "#486 concision guidance misplaced or missing:$(printf '%b' "$bad")"
+    fi
+}
+test_concision_guidance_shipped_once_at_the_right_level
+
+# (2) The per-push cross-model CI-log audit has exactly ONE recorded catch in
+# the repo's history (PR #206, pre-existing CI infra). Running it on every push
+# stacks a verification layer regardless of risk — the pattern the Opus 5 guide
+# names. Scope it; keep the unconditional "read CI logs even on pass", which
+# has independent evidence (v1.84.0: 3 real bugs found post-CERTIFIED).
+test_ci_log_audit_is_risk_scoped_not_universal() {
+    local skill="$REPO_ROOT/skills/sdlc/SKILL.md" line
+    line=$(grep -n 'Cross-model audit the CI logs' "$skill" | head -1 | cut -d: -f2-)
+
+    if [ -z "$line" ]; then
+        fail "#486: the CI-log audit step vanished entirely — it should be SCOPED, not deleted"
+        return
+    fi
+
+    if printf '%s' "$line" | grep -qiE 'release|workflow|control-plane|high-stakes'; then
+        pass "#486: cross-model CI-log audit is scoped to risk, not run on every push"
+    else
+        fail "#486: cross-model CI-log audit still applies to every push — one recorded catch does not justify a per-push verification layer"
+    fi
+}
+test_ci_log_audit_is_risk_scoped_not_universal
+
+# (3) Two prompt tightens. The Opus 5 guide: a review prompt saying "only
+# report high-severity issues" or "be conservative" makes the model report
+# LESS, including real defects. Neither shipped line should read that way.
+test_review_prompts_do_not_suppress_findings() {
+    local skill="$REPO_ROOT/skills/sdlc/SKILL.md" bad=""
+
+    # Preflight framed FEWER FINDINGS as the goal.
+    grep -q 'Reduces reviewer findings to 0-1/round' "$skill" \
+        && bad="$bad\n  preflight still frames fewer findings as the goal ('Reduces reviewer findings to 0-1/round')"
+
+    # POSITIVE ANCHOR, not a search for removed wording. The first version
+    # grepped for 'Do NOT expand the surface' — the exact phrase the fix
+    # DELETES — so after the fix the grep found nothing, `recheck` was empty,
+    # and the whole check was skipped. Cross-model review removed 'report every
+    # defect' and the test still passed. It guarded nothing.
+    #
+    # Anchor on the recheck prompt itself (which must exist), then assert the
+    # report-everything clause is IN it.
+    local recheck
+    recheck=$(grep -n 'TARGETED RECHECK' "$skill" | head -1 | cut -d: -f2-)
+    if [ -z "$recheck" ]; then
+        bad="$bad\n  the TARGETED RECHECK prompt is missing entirely — cannot verify it does not suppress findings"
+    else
+        printf '%s' "$recheck" | grep -qiE 'report every defect|every defect you see|report all findings' \
+            || bad="$bad\n  the recheck prompt has no explicit report-everything clause — a scope limiter alone reads as severity suppression"
+    fi
+
+    if [ -z "$bad" ]; then
+        pass "#486: no shipped review prompt frames fewer findings as success"
+    else
+        fail "#486 review prompts can suppress findings:$(printf '%b' "$bad")"
+    fi
+}
+test_review_prompts_do_not_suppress_findings
+
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -416,6 +416,16 @@ elif [ "$1" = "api" ]; then
             ;;
     esac
     exit 0
+elif [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+    # The override record. COMMENT_FAILS=1 simulates the post failing, which
+    # must block the merge — an unrecorded override is exactly what
+    # --user-approved exists to prevent.
+    if [ "${COMMENT_FAILS:-0}" = "1" ]; then
+        echo "stub: comment post failed" >&2
+        exit 1
+    fi
+    echo "GH_COMMENT_POSTED: $*"
+    exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
     echo "GH_MERGE_INVOKED: $*"
     exit 0
@@ -934,6 +944,209 @@ test_clearance_accepts_two_yes_verdicts
 test_sub_threshold_message_prescribes_next_action
 
 echo ""
+# --- --user-approved: the human decision HARD_DENY demands (ROADMAP #479) -----
+#
+# HARD_DENY says "a human decides this one" and then provides no way for the
+# human to say so. The maintainer hit this three times in one session; the last
+# time the only route left was clicking merge in a browser, which bypasses the
+# hook harness entirely and leaves no record in the repo.
+#
+# This flag does NOT prove a human typed it — nothing available here can. What
+# it changes is that an override becomes EXPLICIT, REASONED and LOGGED instead
+# of silent and out-of-band. That is the honest claim; the header comment in
+# merge-pr.sh must not overstate it.
+
+# Args are passed through as SEPARATE PARAMETERS, never as one string. An
+# earlier version took a single string and word-split it unquoted, so
+# `--user-approved ""` arrived as the literal two-character token `""` (which
+# is non-empty, and merged) and a multi-word reason split into a usage error.
+# Both failures were the harness, not the wrapper.
+run_hard_deny() {   # "$@" = extra args, already separated
+    local tmpdir out code
+    tmpdir=$(setup_wrapper_fixture)
+    printf 'DIFF_FILES=hooks/codex-gate-check.sh\n' >> "$tmpdir/.gh-stub-config"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    echo "review body" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 "$@" 2>&1) && code=0 || code=$?
+    printf 'exit=%s %s' "$code" "$out"
+    rm -rf "$tmpdir"
+}
+
+test_hard_deny_still_blocks_without_the_flag() {
+    refute_merge "$(run_hard_deny)" \
+        "HARD_DENY path still blocks with no --user-approved"
+}
+test_hard_deny_still_blocks_without_the_flag
+
+test_hard_deny_blocks_when_reason_is_missing() {
+    # A bare flag is not a decision. If the reason can be omitted, the flag
+    # becomes a silent bypass wearing an audit trail's clothes.
+    refute_merge "$(run_hard_deny --user-approved)" \
+        "--user-approved with no reason does not merge"
+}
+test_hard_deny_blocks_when_reason_is_missing
+
+test_hard_deny_blocks_when_reason_is_blank() {
+    refute_merge "$(run_hard_deny --user-approved "")" \
+        "--user-approved with an empty reason does not merge"
+}
+test_hard_deny_blocks_when_reason_is_blank
+
+test_cross_model_cleared_still_cannot_clear_hard_deny() {
+    # The whole point of the tier: self-produced evidence never clears it.
+    refute_merge "$(run_hard_deny --cross-model-cleared)" \
+        "--cross-model-cleared still cannot clear a HARD_DENY path"
+}
+test_cross_model_cleared_still_cannot_clear_hard_deny
+
+test_user_approved_with_reason_merges_and_logs() {
+    local result
+    result=$(run_hard_deny --user-approved "maintainer decision: gate fix, certified round 3")
+
+    if ! printf '%s' "$result" | grep -q "GH_MERGE_INVOKED"; then
+        fail "--user-approved with a reason did not merge: $result"
+    elif ! printf '%s' "$result" | grep -qi "USER-APPROVED OVERRIDE"; then
+        fail "--user-approved merged but logged no override record — a silent bypass: $result"
+    elif ! printf '%s' "$result" | grep -q "maintainer decision: gate fix"; then
+        fail "--user-approved merged but did not record the stated reason: $result"
+    else
+        pass "--user-approved with a reason merges AND logs an auditable override"
+    fi
+}
+test_user_approved_with_reason_merges_and_logs
+
+test_user_approved_records_the_path_it_overrode() {
+    # The record has to name WHAT was overridden. "Approved" without the path
+    # is unauditable after the fact.
+    local result
+    result=$(run_hard_deny --user-approved "shipping the hook fix")
+    if printf '%s' "$result" | grep -q "hooks/codex-gate-check.sh"; then
+        pass "--user-approved names the HARD_DENY path it overrode"
+    else
+        fail "override record does not name the path it cleared: $result"
+    fi
+}
+test_user_approved_records_the_path_it_overrode
+
+test_user_approved_also_clears_the_weaker_ackable_tier() {
+    # Design gap found live merging PR #494: --user-approved cleared HARD_DENY
+    # (the STRICTER tier) and then blocked on ACKABLE_DENY (the WEAKER one).
+    # A human authorised to override the merge-evidence chain is necessarily
+    # authorised to override the tier that only steers behaviour. Requiring a
+    # second, different flag for the lesser bar is incoherent.
+    local tmpdir out code
+    tmpdir=$(setup_wrapper_fixture)
+    # Both tiers at once: a hooks/ path (HARD) and the wizard doc (ACKABLE).
+    # Quoted multi-line value: the stub does `printf '%s\n' "$DIFF_FILES"`, so
+    # two separate config lines would leave the second as a bare token the
+    # sourced file cannot assign — which fails closed on a truncated file set.
+    printf 'DIFF_FILES=%s\n' "'hooks/codex-gate-check.sh
+CLAUDE_CODE_SDLC_WIZARD.md'" >> "$tmpdir/.gh-stub-config"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    echo "review body" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --user-approved "maintainer decision" 2>&1) && code=0 || code=$?
+    rm -rf "$tmpdir"
+
+    if printf '%s' "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "--user-approved clears BOTH tiers, not just the stricter one"
+    else
+        fail "--user-approved cleared HARD_DENY but still blocked on the weaker ACKABLE tier (exit=$code): $out"
+    fi
+}
+test_user_approved_also_clears_the_weaker_ackable_tier
+
+# The two things --user-approved must NEVER waive. These are not paperwork:
+# they are objective statements about whether the code works and whether the
+# evidence that it works still exists. If a human can wave those away from a
+# shell flag, the gate is decoration.
+test_user_approved_cannot_waive_red_ci() {
+    local tmpdir out code
+    tmpdir=$(setup_wrapper_fixture)
+    sed -i.bak 's#VALIDATE_CONCLUSION=success#VALIDATE_CONCLUSION=failure#' "$tmpdir/.gh-stub-config"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --user-approved "ship it anyway" 2>&1) && code=0 || code=$?
+    rm -rf "$tmpdir"
+    refute_merge "$(printf 'exit=%s %s' "$code" "$out")" \
+        "--user-approved cannot merge over a red CI validate check"
+}
+test_user_approved_cannot_waive_red_ci
+
+test_user_approved_cannot_waive_deleted_tests() {
+    local tmpdir out code
+    tmpdir=$(setup_wrapper_fixture)
+    sed -i.bak 's#DELETED_TEST_FILES=#DELETED_TEST_FILES=tests/test-merge-gate.sh#' "$tmpdir/.gh-stub-config"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --user-approved "removing a flaky suite" 2>&1) && code=0 || code=$?
+    rm -rf "$tmpdir"
+    refute_merge "$(printf 'exit=%s %s' "$code" "$out")" \
+        "--user-approved cannot merge a PR that net-removes test files"
+}
+test_user_approved_cannot_waive_deleted_tests
+
+# Argument shaping. Found by probing before the reviewers reported:
+# `--user-approved --cross-model-cleared` made the NEXT FLAG the reason, firing
+# a full override whose stated justification was the string "--cross-model-cleared".
+# A reason that is actually a flag is not a reason.
+test_user_approved_rejects_a_flag_as_its_reason() {
+    refute_merge "$(run_hard_deny --user-approved --cross-model-cleared)" \
+        "--user-approved does not accept the next flag as its reason"
+}
+test_user_approved_rejects_a_flag_as_its_reason
+
+test_user_approved_rejects_whitespace_only_reason() {
+    refute_merge "$(run_hard_deny --user-approved "   ")" \
+        "--user-approved does not accept a whitespace-only reason"
+}
+test_user_approved_rejects_whitespace_only_reason
+
+# The audit record must not claim verification that did not happen. The first
+# version printed "clearance CERTIFIED round>=2 fresh ... denylist clear"
+# unconditionally, so an override that skipped both still produced a record
+# saying both were checked. Cross-model review reproduced the contradiction.
+test_override_audit_record_does_not_claim_false_verification() {
+    local result
+    result=$(run_hard_deny --user-approved "maintainer decision")
+
+    if ! printf '%s' "$result" | grep -q "GH_MERGE_INVOKED"; then
+        fail "fixture did not merge, cannot check the audit line: $result"
+    elif printf '%s' "$result" | grep -q "clearance CERTIFIED round>=2 fresh"; then
+        fail "audit record claims clearance was verified when the override SKIPPED it: $result"
+    elif printf '%s' "$result" | grep -q "denylist clear"; then
+        fail "audit record claims the denylist was clear when the override WAIVED it: $result"
+    elif ! printf '%s' "$result" | grep -q "OVERRIDDEN by --user-approved"; then
+        fail "audit record does not say which checks were waived: $result"
+    elif ! printf '%s' "$result" | grep -q "VERIFIED (not waivable)"; then
+        fail "audit record does not separate what WAS verified from what was waived: $result"
+    else
+        pass "override audit record states what was verified vs what was waived"
+    fi
+}
+test_override_audit_record_does_not_claim_false_verification
+
+test_override_posts_a_durable_record_to_the_pr() {
+    local result
+    result=$(run_hard_deny --user-approved "maintainer decision")
+    # The wrapper suppresses gh's own output, so assert on its confirmation.
+    # That line only prints when the post succeeded — proven by the
+    # COMMENT_FAILS test below, which shows a failed post blocks the merge.
+    if printf '%s' "$result" | grep -q "Override recorded on PR"; then
+        pass "override posts a durable record to the PR, not just stderr"
+    else
+        fail "override merged with no durable record — the reason evaporates with the session: $result"
+    fi
+}
+test_override_posts_a_durable_record_to_the_pr
+
+test_override_refuses_to_merge_if_the_record_cannot_be_posted() {
+    local tmpdir out code
+    tmpdir=$(setup_wrapper_fixture)
+    printf 'DIFF_FILES=hooks/codex-gate-check.sh\n' >> "$tmpdir/.gh-stub-config"
+    printf 'COMMENT_FAILS=1\n' >> "$tmpdir/.gh-stub-config"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --user-approved "maintainer decision" 2>&1) && code=0 || code=$?
+    rm -rf "$tmpdir"
+    refute_merge "$(printf 'exit=%s %s' "$code" "$out")" \
+        "an override that cannot be recorded does not merge"
+}
+test_override_refuses_to_merge_if_the_record_cannot_be_posted
+
 echo "=== Results ==="
 echo "Passed: $PASSED"
 echo "Failed: $FAILED"
@@ -941,6 +1154,7 @@ echo "Failed: $FAILED"
 if [ $FAILED -gt 0 ]; then
     exit 1
 fi
+
 
 echo ""
 echo "All merge gate tests passed!"


### PR DESCRIPTION
## What

`./scripts/merge-pr.sh <PR#> --user-approved "<reason>"`

HARD_DENY printed *"a human decides this one"* and gave the human no way to say so. Three times in one session the only route left was clicking merge in the GitHub UI — which bypasses the hook harness and leaves **no record in the repo**. PR #479 was merged exactly that way.

**Waives process gates:** both denylist tiers, the version-bump confirmation, the clearance-artifact checks.
**Cannot waive facts:** a red CI `validate`, or a PR that net-removes tests. Both reviewers attacked that split and could not defeat it.

Posts a durable override record to the PR — reason plus every waived path — **before** merging, and refuses to merge if that post fails.

It does **not** prove a human typed it. Nothing available to a local script can. It makes an override explicit and durable instead of silent.

## Four defects found while building it

- Cleared the **stricter** tier then blocked on the weaker one.
- `--user-approved --cross-model-cleared` consumed the next flag **as the reason** — a full override justified by the string `--cross-model-cleared`. Whitespace reasons passed too. Found by probing, not by my tests.
- The success line always claimed `clearance CERTIFIED round>=2 fresh, denylist clear` — a **false audit record** when the override skipped both.
- The reason went to stderr and evaporated. PR #494 was merged with this flag and left **zero durable trace** — exactly what it was built to replace.

## Also: #486, three low-risk edits

Fable and Codex cross-examined each other and both concluded `SKILL.md` should **not** split per model. These are the agreed items.

- Concision guidance at CLAUDE.md level. Anthropic's actual position (a reminder in long prompts is fine) kept separate from this repo's stricter local ban — the first draft overstated the evidence.
- Cross-model CI-log audit scoped to release/workflow/control-plane PRs. One recorded catch doesn't justify a per-push layer.
- Preflight no longer frames *fewer findings* as success; the recheck's scope limiter is paired with "report every defect".

The #486 regression test was itself vacuous — it grepped for the wording the fix deletes. Now positively anchored and verified against the reviewer's own mutation.

## Status

**REVIEWED, not CERTIFIED.** Both reviewers returned NOT_CERTIFIED round 1; every finding is fixed, but neither has seen the fixes.

`SKILL.md` byte-neutral at 19,988/20,000, cowork byte-identical. Suite 65/65, merge gate 60/60.

Closes #479. Part of #486.