### PR TITLE
ci(rename): make the self-PR skip tolerant of both repo slugs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,8 +31,15 @@ jobs:
     # PRs (see SDLC skill), so the Claude PR review is redundant on self-repo.
     # Consumers using pr-review.yml in their own projects WILL run this normally —
     # the skip only fires when github.repository matches the wizard repo exactly.
+    # Both slugs are listed on purpose. A GitHub rename does not rewrite this
+    # string: the redirect covers web and git, not a literal comparison inside a
+    # workflow. With only the old slug here, renaming the repo would silently
+    # flip this condition true and start running the paid self-review on our own
+    # PRs — burning quota with nothing to indicate anything had changed. Listing
+    # both makes the rename a no-op for this gate, in either direction.
     if: |
       github.repository != 'BaseInfinity/claude-sdlc-wizard' &&
+      github.repository != 'BaseInfinity/claude-sdlc-harness' &&
       ((github.event.action == 'opened' && github.event.pull_request.draft != true) ||
        github.event.action == 'synchronize' ||
        github.event.action == 'ready_for_review' ||

--- a/tests/test-self-pr-review-skip.sh
+++ b/tests/test-self-pr-review-skip.sh
@@ -34,14 +34,24 @@ if [ ! -f "$WORKFLOW" ]; then
     exit 1
 fi
 
-# Test 1: Workflow has the EXACT NEGATIVE comparison `github.repository != 'BaseInfinity/claude-sdlc-wizard'`.
-# A literal `==` would invert the semantics (skip consumers, run on self) — must catch that.
-# Use single-line grep with the actual operator embedded in the pattern.
-if grep -qE "github\.repository[[:space:]]*!=[[:space:]]*['\"]BaseInfinity/claude-sdlc-wizard['\"]" "$WORKFLOW"; then
-    pass "Workflow uses exact negative comparison: github.repository != 'BaseInfinity/claude-sdlc-wizard'"
-else
-    fail "Workflow must use exact: github.repository != 'BaseInfinity/claude-sdlc-wizard' — verify operator and string both"
-fi
+# Test 1: Workflow has the EXACT NEGATIVE comparison for EVERY slug this repo
+# answers to. A literal `==` would invert the semantics (skip consumers, run on
+# self) — must catch that.
+#
+# Both the current and the planned slug are required, because a GitHub rename
+# does NOT rewrite this string. The condition would silently start matching, and
+# the paid self-review this skip exists to prevent would begin running on our own
+# PRs — costing quota with no signal that anything changed. GitHub redirects web
+# and git operations; it does not redirect a literal comparison inside a
+# workflow. Listing both slugs makes the rename a no-op for this gate, in either
+# direction, so it can be flipped without a flag day.
+for slug in "BaseInfinity/claude-sdlc-wizard" "BaseInfinity/claude-sdlc-harness"; do
+    if grep -qE "github\.repository[[:space:]]*!=[[:space:]]*['\"]${slug}['\"]" "$WORKFLOW"; then
+        pass "Workflow uses exact negative comparison: github.repository != '$slug'"
+    else
+        fail "Workflow must use exact: github.repository != '$slug' — verify operator and string both"
+    fi
+done
 
 # Test 1b: Negative control — explicitly fail if `==` operator is used (would skip consumers).
 if grep -qE "github\.repository[[:space:]]*==[[:space:]]*['\"]BaseInfinity/claude-sdlc-wizard['\"]" "$WORKFLOW"; then


### PR DESCRIPTION
Groundwork for renaming this repo to `claude-sdlc-harness`. Landed **before** the
rename so the rename itself cannot break anything.

## The defect this prevents

`pr-review.yml` skips the paid Claude review on this repo's own PRs:

```yaml
github.repository != 'BaseInfinity/claude-sdlc-wizard'
```

Both reviewers independently flagged the same failure: **a GitHub rename does not
rewrite that string.** The redirect covers web and git operations, not a literal
comparison inside a workflow. The moment the repo is renamed, the condition flips
true and the review this skip exists to prevent starts running on every self-PR —
burning quota with nothing to indicate anything changed.

Listing both slugs makes the rename a no-op for this gate **in either direction**,
so it can be flipped without a flag day and rolled back without a second one.

## Verification

- TDD RED observed first: the test demanded the new slug and failed for that reason
- Mutation: inverting `!=` to `==` still fails the negative control
- Suite 65/65

## What this does NOT cover — the step a redirect cannot do

**npm Trusted Publishing binds to the exact repository name.** `release.yml`
publishes via OIDC, and the publisher configured on npmjs.com names
`BaseInfinity/claude-sdlc-wizard` + `release.yml`. After the rename the OIDC claim
no longer matches, and **the next tagged release fails at publish** until the
publisher config is updated in the npm console. `package.json`'s `repository.url`
must be updated to match as well, since provenance verification checks it.

Codex live-tested the redirect claim rather than assuming it: marketplace `add` and
`update` both succeed through this repo's *previous* slug
(`BaseInfinity/agentic-ai-sdlc-wizard`) on Claude Code 2.1.221. So plugin installs
survive — but never create a new repo at either historical name, since that destroys
the redirect for every pinned install.

Part of the wizard → harness rename. Prose rename follows separately; it is not a
`sed` (`skills/sdlc/SKILL.md` lands at exactly 20,001 bytes against a 20,000 ceiling
if all 8 occurrences are replaced).