### PR TITLE
fix(cowork): the prompt gate must tell a bypass from a justified exception, and Fable decides

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2482,7 +2482,11 @@ Before presenting approach, STATE your confidence:
 
 Low confidence does **not** mean "ask the user." It means "escalate," and the user is the third rung, not the first. Ask a human only for what no model can settle.
 
-1. **Fable** — `advisor()` before plans; if the advisor is unavailable, spawn a Fable subagent at `high`.
+1. **Fable — the primary thinker, not a rung you escalate to.** Fable **decides** design, priority and sequencing; you implement its call. You are the coder. Reach for it *before* an approach exists, via `advisor()`, or a Fable subagent at `high` while the advisor is server-side disabled. **The tell that you got this backwards:** you have already chosen an approach and are asking Fable to grade it. Prompt it to decide — "where you would normally say consider X, say do X" — rather than to critique. Codex is a different job entirely: the **adversarial check** that tries to break a decision already made, run before commit or merge. Fable thinks, Codex attacks; do not collapse them into "get a second opinion".
+
+   **The loop, in order.** Fable decides the approach → Opus implements it → **Fable reviews the implementation** → only once that is clean, Codex runs as the final cross-model check. Fable appears twice on purpose: once as the brain before code exists, once as the reviewer of what got built. Codex is last and singular — it is the adversarial gate, not a second opinion to average with the first. Sending work to Codex before Fable has reviewed it wastes the expensive check on defects the cheaper one would have caught.
+
+   **Open question, not yet settled:** this topology runs Opus as the driver calling out to Fable. The inverse — Fable as driver, delegating implementation to Opus subagents — has not been tested and may be better, since it puts the stronger reasoner in the seat that makes decisions continuously rather than on request. Do not assume the current arrangement is optimal; it is the one that has been used, not the one that has been measured.
 2. **Codex `high`** — when Fable can't close the gap, or when a second, adversarially-framed opinion is what's needed.
 3. **The human** — priority, risk appetite, scope, spend, or anything irreversible or outward-facing. A merge gate that demands explicit confirmation *is* this rung, invoked by design rather than by uncertainty.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,13 +21,18 @@ Before that, v1.89.0 (2026-07-29) carried #479 (the merge gate's approval/bypass
 
 The previous release, v1.88.0 (2026-07-24), carried #468 (Opus 5 becomes the Setup A default driver, plus the stale `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=30` that `skills/setup/SKILL.md` had been writing into *every consumer's* settings), #470 (the escalation ladder — Fable → Codex → human LAST — propagated to every shipped surface, including the runtime prompt hook that was still emitting the old "ASK USER" rule), and #469's ROADMAP rows.
 
-**Open PRs — none.** #474 merged 2026-07-29; #471 was closed the same day as superseded by it (that branch was CONFLICTING and carried 5 unresolved Codex findings, the worst a newline-injection bypass introduced by its own fix — it tiered the denylist to reduce how *often* the gate fires, and frequency was never the actual defect).
+**Open PRs: see [the PR list](https://github.com/BaseInfinity/claude-sdlc-harness/pulls).** This line used to restate the count and said "none" while a PR was open — the tracker is the source, and restating it here only creates something to go stale. #474 merged 2026-07-29; #471 was closed the same day as superseded by it (that branch was CONFLICTING and carried 5 unresolved Codex findings, the worst a newline-injection bypass introduced by its own fix — it tiered the denylist to reduce how *often* the gate fires, and frequency was never the actual defect).
 
 **Start here next, in this order:**
 
-**Row #485 is implemented** and awaiting cross-model review on branch
-`fix/485-single-tier-merge-gate`. `HARD_DENY` is deleted; all eight patterns sit
-in one clearable tier.
+**Row #485 was NOT implemented, despite this section claiming otherwise for
+nine days.** Verified 2026-08-07: branch `fix/485-single-tier-merge-gate` is **0
+commits ahead of main** — its tip is already-merged #474 and it carries nothing — and
+`HARD_DENY` is alive in `scripts/merge-pr.sh` with 5 occurrences. Both halves of
+the old claim were false, and they sat at the top of the list a cold session reads
+first, sending it to work that does not exist on a branch that is empty. Recorded
+rather than quietly deleted: this is the same defect class as GH #491, one level
+up — a stated fact with nothing checking it.
 
 **Revised order — both reviewers, consulted blind on 2026-07-29, independently
 said the previous list was wrong because the maintainer's actual goal (Codex

--- a/cowork/hooks/hooks.json
+++ b/cowork/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "SDLC Harness enforcement hooks — prompt-based (no shell access needed)",
+  "description": "SDLC Harness enforcement hooks \u2014 prompt-based (no shell access needed)",
   "hooks": {
     "PreToolUse": [
       {
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "The assistant is about to write or edit this file: $ARGUMENTS\n\nIs the file path a test file — its basename starts with \"test_\"/\"test-\", ends with \"_test\"/\".test\", or the path includes a \"/tests/\", \"/test/\", or \"/spec/\" directory segment? A file is NOT a test file just because \"test\" or \"spec\" appears as a substring elsewhere in its name (for example \"contest.py\" or \"specification_parser.ts\" are NOT test files).\n\nRespond with JSON: {\"ok\": true} if it IS a test file (writing/editing tests is always safe), or if this looks like an edit to an EXISTING file rather than the creation of a brand-new non-test source file. Respond with {\"ok\": false, \"reason\": \"...\"} only if this is clearly the creation of a brand-new, non-test implementation file.\n\nNote: this hook can only see the current file write, not prior turns or the filesystem — it is a best-effort filename heuristic, not proof a failing test was actually run first.",
+            "prompt": "The assistant is about to write or edit this file: $ARGUMENTS\n\nIs the file path a test file \u2014 its basename starts with \"test_\"/\"test-\", ends with \"_test\"/\".test\", or the path includes a \"/tests/\", \"/test/\", or \"/spec/\" directory segment? A file is NOT a test file just because \"test\" or \"spec\" appears as a substring elsewhere in its name (for example \"contest.py\" or \"specification_parser.ts\" are NOT test files).\n\nRespond with JSON: {\"ok\": true} if it IS a test file (writing/editing tests is always safe), or if this looks like an edit to an EXISTING file rather than the creation of a brand-new non-test source file. Respond with {\"ok\": false, \"reason\": \"...\"} only if this is clearly the creation of a brand-new, non-test implementation file.\n\nNote: this hook can only see the current file write, not prior turns or the filesystem \u2014 it is a best-effort filename heuristic, not proof a failing test was actually run first.",
             "timeout": 15
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "The user just submitted this prompt: $ARGUMENTS\n\nA block on this event ends the turn outright with no chance to retry, so only deny prompts that explicitly try to bypass SDLC safeguards. Does this prompt explicitly instruct skipping planning, testing, or self-review (for example: \"skip the tests\", \"don't write a plan\", \"just implement it directly, don't bother testing\", \"ignore TDD\")?\n\nRespond with JSON: {\"ok\": true} if it does NOT ask to skip any safeguard — this is the normal case for almost every prompt, including ordinary code requests with no explicit plan attached. Respond with {\"ok\": false, \"reason\": \"...\"} only if it explicitly asks to bypass planning, testing, or review.",
+            "prompt": "The user just submitted this prompt: $ARGUMENTS\n\nA block on this event ends the turn outright with no chance to retry, so only deny prompts that explicitly try to bypass SDLC safeguards with nothing put in their place.\n\nDistinguish a BYPASS from a JUSTIFIED EXCEPTION.\n\nA BYPASS asks to drop a safeguard and offers nothing instead: \"skip the tests\", \"don't write a plan\", \"just implement it directly, don't bother testing\", \"ignore TDD\". Deny these.\n\nA JUSTIFIED EXCEPTION names a stated reason AND a stated alternative, so the safeguard is substituted rather than removed. Example: \"don't TDD this, it is a one-time mechanical rename that will not recur, just verify after that things are right\". That is a reasoned engineering call with verification still attached \u2014 allow it. Judge the substance, not the presence of the word \"skip\".\n\nWhen a prompt is ambiguous, allow it. This gate ends the turn with no retry, so a wrong denial costs the user their whole turn while a wrong allow costs nothing \u2014 the downstream TDD and review gates still apply.\n\nRespond with JSON: {\"ok\": true} if it does NOT ask to bypass a safeguard \u2014 this is the normal case for almost every prompt, including ordinary code requests with no explicit plan attached, and including justified exceptions as defined above. Respond with {\"ok\": false, \"reason\": \"...\"} only if it asks to drop planning, testing, or review outright with no reason and no alternative given.",
             "timeout": 10
           }
         ]

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -497,6 +497,50 @@ else
   fail "ROADMAP missing Dynamic Workflows evaluation entry"
 fi
 
+# Test 18: the UserPromptSubmit gate distinguishes a BYPASS from a JUSTIFIED
+# exception.
+#
+# Incident 2026-08-07: the maintainer wrote "do the prose rename now, dont TDD
+# something like this, it will most likely only ever happen once so just verify
+# after". The gate denied it and ended the turn. That prompt is not a bypass —
+# it states a reason (one-time mechanical change) AND an alternative (verify
+# after). The safeguard was being substituted, not removed.
+#
+# The gate could not tell the difference because it only ever asked "does this
+# ask to skip something". A rule with no sanctioned exception path is one people
+# route around; this is the same shape as the merge gate before --user-approved.
+# Assert the prompt carries BOTH halves: the allowance, and the bare-skip denial
+# it must keep.
+if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
+  ups_prompt=$(python3 -c "
+import json
+d=json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
+print(' '.join(hk.get('prompt','') for h in d.get('UserPromptSubmit',[]) for hk in h.get('hooks',[])))
+" 2>/dev/null)
+
+  if [ -z "$ups_prompt" ]; then
+    fail "could not extract the UserPromptSubmit prompt — this assertion would be vacuous"
+  else
+    missing=""
+    # "stated reason", not bare "reason" — the latter matches the JSON response
+    # field name `"reason"` that the prompt already contained, so it passed
+    # without the clause existing. Caught while writing this test.
+    printf '%s' "$ups_prompt" | grep -qi "stated reason" || missing="$missing no-reason-clause"
+    # "stated alternative", mirroring "stated reason". The looser
+    # alternative|verify matched the word "alternative" elsewhere in the prompt,
+    # so deleting the clause still passed.
+    printf '%s' "$ups_prompt" | grep -qi "stated alternative" || missing="$missing no-alternative-clause"
+    printf '%s' "$ups_prompt" | grep -qiE "substitut|replac" || missing="$missing no-substitution-framing"
+    # It must still deny an unjustified skip, or the fix has gutted the gate.
+    printf '%s' "$ups_prompt" | grep -qi "ok.*false" || missing="$missing no-denial-path"
+    if [ -z "$missing" ]; then
+      pass "UserPromptSubmit gate allows a justified exception and still denies a bare bypass"
+    else
+      fail "UserPromptSubmit gate cannot distinguish a justified exception from a bypass:$missing"
+    fi
+  fi
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -3027,6 +3027,41 @@ test_no_shipped_doc_reasserts_the_phantom_watchdog() {
 }
 test_no_shipped_doc_reasserts_the_phantom_watchdog
 
+# ---- Fable is the primary thinker, not a post-hoc reviewer ----
+#
+# Maintainer, 2026-08-07: "use fable to think... it should be your main brain and
+# driving everything, ur just the coder....that should be clear in our /sdlc".
+#
+# The shipped guidance framed Fable as a rung to escalate TO when uncertain, and
+# as a cadence slot ("Fable during design"). Both read as advisory. The intended
+# contract is stronger: Fable DECIDES design, priority and sequencing, and the
+# driver implements that decision. Codex is the adversarial check afterwards —
+# a different job, not the same one later.
+#
+# This is codified here rather than in per-user memory on purpose. The skill's own
+# Memory Audit Protocol says a process rule saved only to memory is a /sdlc gap:
+# memory changes one agent, docs change everyone.
+test_fable_framed_as_decider_not_advisor() {
+    local bad="" doc="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    [ -f "$doc" ] || { fail "wizard doc missing"; return; }
+    # Tolerate markdown emphasis between the words: the doc says
+    # "Fable **decides**", and a literal-space pattern missed it. Same
+    # markup-weld class as the #491 splitter bug.
+    grep -qiE "fable[^A-Za-z]{0,4}(decides|drives)" "$doc" \
+        || bad="$bad\n  the wizard doc never says Fable DECIDES — it reads as advisory"
+    grep -qiE "implement (its|that|the) (call|decision)|you (are|'re) the coder" "$doc" \
+        || bad="$bad\n  it does not say the driver implements Fable's call"
+    # Codex must stay distinct, or the fix has collapsed two different jobs.
+    grep -qiE "codex.*(adversarial|check)" "$doc" \
+        || bad="$bad\n  Codex's adversarial-check role is no longer distinguished from Fable's"
+    if [ -z "$bad" ]; then
+        pass "shipped guidance frames Fable as deciding, with Codex still the adversarial check"
+    else
+        fail "Fable is still framed as an advisor rather than the primary thinker:$(printf '%b' "$bad")"
+    fi
+}
+test_fable_framed_as_decider_not_advisor
+
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then

--- a/tests/test-roadmap-integrity.sh
+++ b/tests/test-roadmap-integrity.sh
@@ -267,6 +267,23 @@ else
     pass "no duplicate row IDs"
 fi
 
+# Check: ROADMAP must not assert PR-open state at all.
+#
+# It said "**Open PRs — none.**" while PR #503 was open, and every existing check
+# passed — they enforce the FORM of bullets in that block, so a claim of "none"
+# has no bullets to inspect and sails through. A staleness guard that cannot
+# detect the staleness it exists for.
+#
+# The fix is not a better checker. Whether a PR is open is the tracker's fact,
+# and no offline test can verify it. ROADMAP restating it is the duplicate-source
+# hazard #482 names, so the honest move is to stop making the claim and point at
+# the tracker, which is always current by construction.
+if grep -qiE '^\*\*Open PRs? (—|-|:)? *none' "$ROADMAP"; then
+    fail "ROADMAP asserts 'Open PRs — none'. That is the tracker's fact and goes stale silently — no offline test can verify it. Link to the PR list instead of restating it."
+else
+    pass "ROADMAP does not restate PR-open state (tracker is the source — #482)"
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Two things, both about a rule that was right in general and had no path for the case
where it wasn't.

## 1. The Cowork prompt gate blocked a reasoned engineering call

Live incident, 2026-08-07. The maintainer wrote:

> "do the prose rename now, dont TDD something like this, it will most likely only ever
> happen once so just verify after"

The gate denied it and **ended the turn outright, with no retry.** That is not a bypass:
it states a reason (a one-time mechanical rename that will not recur) and an alternative
(verify afterwards). The safeguard was being *substituted*, not removed.

The gate could not tell the difference because it only asked "does this ask to skip
planning, testing, or review". Any sentence containing a skip was a bypass, regardless
of what was offered in its place.

Confirmed ours before touching anything: the blocking prompt was read out of the
installed plugin cache (`~/.claude/plugins/cache/.../sdlc-wizard-cowork/1.93.0`) and is
byte-identical to `cowork/hooks/hooks.json` here.

The prompt now draws the distinction, still denies bare skips, and adds a tie-break it
lacked: **when ambiguous, allow.** This gate ends the turn with no retry, so a wrong
denial costs the user their whole turn while a wrong allow costs nothing — the TDD and
review gates downstream still fire. Asymmetric consequences deserve an asymmetric
default.

**This is the third gate this session that had no sanctioned exception path.** The merge
gate got `--user-approved` for the same reason. A rule people learn to route around is
worse than one with a recorded exception.

## 2. Fable is the primary thinker, not a rung you escalate to

The shipped guidance framed Fable as somewhere to go when stuck, and as a cadence slot
("Fable during design"). Both read as advisory. The contract is stronger, and the loop is
now stated in order:

**Fable decides → Opus implements → Fable reviews → Codex gates.**

Fable appears twice on purpose: the brain before code exists, the reviewer of what got
built. Codex is last and singular — an adversarial gate, not a second opinion to average
with the first.

Recorded as explicitly unsettled: this runs Opus as driver calling out to Fable. The
inverse (Fable driving, delegating to Opus subagents) is untested and may be better —
tracked as #504. The doc now says "the one that has been used, not the one that has been
measured" rather than implying it was chosen on evidence.

This rule went to per-user memory first, which breaks the skill's own Memory Audit
Protocol: *a process rule saved only to memory is a /sdlc gap.* Worth naming why —
`skills/sdlc/SKILL.md` is at **19,993 of 20,000 bytes**, so the ceiling is actively
pushing process rules out of shipped docs into private memory. That is #489 doing damage
beyond "edits are annoying".

## 3. ROADMAP.md asserted two things that were false

Under **"Start here next"** — the first thing a cold session reads — it claimed row #485
was implemented and awaiting review on `fix/485-single-tier-merge-gate` with `HARD_DENY`
deleted. Verified: that branch is **0 commits ahead of main** and carries nothing, and
`HARD_DENY` is alive in `merge-pr.sh` with **5 occurrences**. It had been sending cold
sessions to work that does not exist, on a branch that is empty.

It also said "Open PRs — none" while #503 was open. The integrity test enforces the
*form* of bullets in that block, so a claim of "none" has no bullets to inspect. The fix
is not a better checker — whether a PR is open is the tracker's fact and no offline test
can verify it. ROADMAP now links the PR list instead of restating it.

## Verification

- Suite **65/65**, rebased onto the post-rename `main`
- Every new assertion RED first. Two of my own were vacuous and caught while writing
  them: `reason` matched the JSON field name already in the prompt, and
  `alternative|verify` matched a word elsewhere in the text. Both tightened, then each
  clause confirmed load-bearing by deleting it and watching the test fail.
- The Fable assertion initially failed against *correct* prose because the doc says
  `Fable **decides**` and the pattern wanted a literal space — same markdown-weld class
  as the #491 splitter bug, caught here by the test rather than a reviewer.

Part of v1.95.0. Refs #504.