### PR TITLE
release: v1.95.0 — claude-sdlc-harness, and three defects that were shipping

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "SDLC enforcement plugins for AI-assisted development",
-    "version": "1.94.0"
+    "version": "1.95.0"
   },
   "plugins": [
     {
@@ -15,13 +15,18 @@
         "source": "github",
         "repo": "BaseInfinity/claude-sdlc-harness"
       },
-      "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
-      "version": "1.94.0",
+      "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
+      "version": "1.95.0",
       "author": {
         "name": "Stefan Ayala"
       },
       "category": "productivity",
-      "tags": ["sdlc", "tdd", "code-quality", "testing"]
+      "tags": [
+        "sdlc",
+        "tdd",
+        "code-quality",
+        "testing"
+      ]
     },
     {
       "name": "sdlc-wizard-cowork",
@@ -30,13 +35,19 @@
         "url": "https://github.com/BaseInfinity/claude-sdlc-harness.git",
         "path": "cowork"
       },
-      "description": "SDLC enforcement for Claude Cowork — TDD, planning, self-review via prompt-based hooks and skills",
-      "version": "1.94.0",
+      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
+      "version": "1.95.0",
       "author": {
         "name": "Stefan Ayala"
       },
       "category": "productivity",
-      "tags": ["sdlc", "tdd", "code-quality", "methodology", "cowork"]
+      "tags": [
+        "sdlc",
+        "tdd",
+        "code-quality",
+        "methodology",
+        "cowork"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,18 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.94.0",
-  "description": "SDLC enforcement for AI agents — TDD, planning, self-review, CI shepherd",
+  "version": "1.95.0",
+  "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",
     "url": "https://github.com/BaseInfinity"
   },
   "repository": "https://github.com/BaseInfinity/claude-sdlc-harness",
   "license": "MIT",
-  "keywords": ["sdlc", "tdd", "code-quality", "ai-agent", "developer-tools"]
+  "keywords": [
+    "sdlc",
+    "tdd",
+    "code-quality",
+    "ai-agent",
+    "developer-tools"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.95.0] - 2026-08-07
+
+**The repo is now `BaseInfinity/claude-sdlc-harness`.** The npm package stays
+`agentic-sdlc-wizard`, and the plugin IDs, CLI bin and slash commands are unchanged —
+those are what your install depends on, and renaming them would force every consumer to
+reinstall for no functional gain. The old repo URL still redirects.
+
+### Fixed — three defects that were shipping to every consumer
+
+- **A hook could block forever on stdin.** `hooks/model-effort-check.sh` still drained
+  stdin with a bare `cat > /dev/null` — the exact unbounded read v1.94.0 existed to
+  remove, observed elsewhere alive at 10h19m against a 10-second timeout. It escaped
+  because the test roster was hand-listed and this hook was never in it; the roster is
+  now derived from `hooks/hooks.json` and fails if it drifts from the manifest.
+- **We shipped the install footgun we warn about.** `instructions-loaded-check.sh` told
+  every consumer, on every session start with an update available, to run a global npm
+  install. The nudge is now channel-neutral and covers package-manager installs, which
+  `claude update` cannot upgrade.
+- **The docs promised a stall watchdog that has never existed.** No such variable is
+  defined anywhere in this repo; the codex wrapper loops on `kill -0` and enforces no
+  timeout at all. The claim is replaced with what the wrapper actually does.
+
+### Fixed — the distribution boundary
+
+`npm pack` ships no `scripts/` directory, yet five shipped references pointed consumers
+at tools they never receive, including `skills/sdlc/SKILL.md` mandating
+`scripts/merge-pr.sh`. Shipped guidance now names a real path (`gh pr merge --squash`)
+and marks repo-local tooling as not installed.
+
+### Fixed — gates that had no exception path
+
+- **`scripts/merge-pr.sh --user-approved "<reason>"`** records a human decision on the PR
+  before merging, and refuses to merge if that record cannot be posted. It cannot waive a
+  red CI check or deleted tests.
+- **The Cowork prompt gate now distinguishes a bypass from a justified exception.** It
+  ended a turn outright for "don't TDD this one-time rename, verify after" — a stated
+  reason with a stated alternative, so the safeguard was substituted rather than removed.
+  It also now allows when ambiguous: this gate ends the turn with no retry, so a wrong
+  denial costs the whole turn while a wrong allow costs nothing.
+
+### Changed — Fable decides
+
+Shipped guidance framed Fable as a rung to escalate to. The contract is stronger and is
+now stated in order: **Fable decides → Opus implements → Fable reviews → Codex gates.**
+Fable appears twice deliberately; Codex is last and singular, an adversarial gate rather
+than a second opinion. Whether Fable should drive instead is explicitly recorded as
+untested, not settled.
+
+### Notes
+
+`ROADMAP.md` had been telling cold sessions to start on work that did not exist, on a
+branch that was empty. Corrected in place rather than deleted. It also claimed "Open PRs
+— none" while one was open; it now links the tracker instead of restating it.
+
 ## [1.94.0] - 2026-08-05
 
 ### Fixed

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -3290,7 +3290,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Harness Version: 1.94.0 -->
+<!-- SDLC Harness Version: 1.95.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4410,7 +4410,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Harness Version: 1.75.1 -->
+<!-- SDLC Harness Version: 1.95.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 1. Every bullet under **Open PRs** must be written as ``- **PR #N** …``. A bullet in any other form fails the test, so a stale entry cannot be spelled around.
 2. `PR #N` anywhere in this section must name a PR that is **not yet merged**. Reference already-merged work in prose as a bare `#N`.
 
-**Last release: v1.94.0, 2026-08-05** (`agentic-sdlc-wizard`). Carries the stdin-hang fix for six shipped hooks — each could block forever on a stdin that never reaches EOF, observed at 10h19m against a 10-second timeout — plus fail-closed gate semantics and a `CLAUDE.md` shipped-surface guard. See `CHANGELOG.md`, including the five-iteration history of the fix itself.
+**Last release: v1.95.0, 2026-08-07** (`agentic-sdlc-wizard`). Carries the stdin-hang fix for six shipped hooks — each could block forever on a stdin that never reaches EOF, observed at 10h19m against a 10-second timeout — plus fail-closed gate semantics and a `CLAUDE.md` shipped-surface guard. See `CHANGELOG.md`, including the five-iteration history of the fix itself.
 
 **This marker was stale and is worth noting as a defect, not just correcting.** It read "Last release: v1.90.0" through the v1.92.0 and v1.93.0 releases; a version sweep grepping for the *outgoing* version can never find a marker frozen at an older one. Caught by cross-model release review 2026-08-05, not by any test. A guard belongs in `tests/test-doc-consistency.sh` — cross-ref GH #493 (the guard itself) and #491 (the wider CI/CD audit).
 
@@ -182,7 +182,7 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 
 | Project | Repo | Status |
 |---------|------|--------|
-| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.94.0 (living tracker — bump every release) |
+| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.95.0 (living tracker — bump every release) |
 | Codex SDLC Adapter | BaseInfinity/codex-sdlc-wizard | v0.7.x, shipped with SDLC workflow |
 | GDLC Wizard (games sibling) | BaseInfinity/claude-gdlc-wizard | v0.2.x, persona-driven playtest cycles |
 | _(add as projects are marked)_ | | |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Harness Version: 1.94.0 -->
+<!-- SDLC Harness Version: 1.95.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.220 -->
@@ -10,7 +10,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.94.0 |
+| Wizard Version | 1.95.0 |
 | Last Updated | 2026-07-04 |
 | Claude Code Minimum | v2.1.219+ (required for `opus` alias to resolve to Opus 5, the current default); v2.1.154+ for the older `opus[1m]` alias resolution; v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.220+ — **v2.1.214 changed single-segment `dir/**` hook `if:` conditions to match only `<cwd>/dir`; any-depth now needs `**/dir/**`. This silently disabled the shipped TDD hook for every consumer whose source is not at repo-root `src/` (fixed in v1.91.0).** Also in this range: exit-code-2 hooks now block even when their stdout JSON fails schema validation (v2.1.214 — we were never exposed, our exit-2 hooks write to stderr); plugin skills with a `name` frontmatter field keep their plugin prefix in slash-command autocomplete (v2.1.216, affects `sdlc-wizard-cowork:sdlc`); transcripts record reasoning effort per assistant message (v2.1.212); subagent nesting defaults changed twice (disabled v2.1.217, re-enabled at depth 3 in v2.1.219). Earlier baseline rationale: `SessionStart`/`Setup`/`SubagentStart` hooks no longer hide stderr on exit 2 (v2.1.199), hook events no longer dropped during `SessionStart` in headless sessions (v2.1.204), duplicate skill-instruction context bloat fixed (v2.1.202). |

--- a/cowork/.claude-plugin/marketplace.json
+++ b/cowork/.claude-plugin/marketplace.json
@@ -6,19 +6,25 @@
   },
   "metadata": {
     "description": "SDLC enforcement for Claude Cowork sessions via prompt-based hooks and skills",
-    "version": "1.94.0"
+    "version": "1.95.0"
   },
   "plugins": [
     {
       "name": "sdlc-wizard-cowork",
       "source": ".",
-      "description": "SDLC enforcement for Claude Cowork — TDD, planning, self-review via prompt-based hooks and skills",
-      "version": "1.94.0",
+      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
+      "version": "1.95.0",
       "author": {
         "name": "Stefan Ayala"
       },
       "category": "productivity",
-      "tags": ["sdlc", "tdd", "code-quality", "methodology", "cowork"]
+      "tags": [
+        "sdlc",
+        "tdd",
+        "code-quality",
+        "methodology",
+        "cowork"
+      ]
     }
   ]
 }

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,12 +1,18 @@
 {
   "name": "sdlc-wizard-cowork",
-  "version": "1.94.0",
-  "description": "SDLC enforcement for Claude Cowork — TDD, planning, self-review via prompt-based hooks and skills",
+  "version": "1.95.0",
+  "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
   "author": {
     "name": "Stefan Ayala",
     "url": "https://github.com/BaseInfinity"
   },
   "repository": "https://github.com/BaseInfinity/claude-sdlc-harness",
   "license": "MIT",
-  "keywords": ["sdlc", "tdd", "code-quality", "methodology", "cowork"]
+  "keywords": [
+    "sdlc",
+    "tdd",
+    "code-quality",
+    "methodology",
+    "cowork"
+  ]
 }

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -103,4 +103,4 @@ This plugin is for Cowork-only users who want methodology guidance without the f
 
 ## Version
 
-Tracks the main wizard version: **1.94.0**
+Tracks the main wizard version: **1.95.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.94.0",
+  "version": "1.95.0",
   "description": "Self-evolving SDLC enforcement for Claude Code \u2014 hooks, skills, and one-command setup",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -95,7 +95,7 @@ Parse CHANGELOG entries between the user's installed version and the resolved la
 
 ```
 Installed: 1.42.0
-Latest:    1.94.0
+Latest:    1.95.0
 
 What changed:
 - [1.92.0] Cowork `Stop` hook REMOVED — it fired 12 times in one session and was wrong 11; Cowork now has no completion enforcement (documented in cowork/README.md).


### PR DESCRIPTION
## What ships

The repo is now **`BaseInfinity/claude-sdlc-harness`**. The npm package stays
`agentic-sdlc-wizard`; plugin IDs, CLI bin and slash commands are unchanged. Those are
what an install depends on — renaming them would force every consumer to reinstall for
no functional gain. The old repo URL still redirects, and **npm Trusted Publishing has
been re-pointed at the new slug**, which GitHub's redirect does *not* cover (verified on
npmjs.com; without it this release would have failed at publish).

Carries #495, #497, #500, #503, #505.

### Three defects that were shipping to every consumer

| Defect | Why it escaped |
|---|---|
| A hook could block forever on stdin — the exact unbounded read v1.94.0 existed to remove | its test roster was hand-listed and this hook was never in it |
| We shipped the install footgun our docs warn about | the #476 test greps `hooks/` only |
| Docs promised a stall watchdog that has never existed | nothing checked that a named mechanism was real |

Plus the distribution boundary: `npm pack` ships no `scripts/`, yet five shipped
references pointed consumers at tools they never receive.

### Gates that had no exception path

`--user-approved` on the merge gate, and the Cowork prompt gate now distinguishing a
bypass from a justified exception. Three gates this session blocked the maintainer with
no sanctioned way through; that pattern is the finding, not each instance.

### Fable decides

Shipped guidance framed Fable as a rung to escalate to. Now stated in order: **Fable
decides → Opus implements → Fable reviews → Codex gates.** Whether Fable should drive
instead is recorded as untested (#504), not settled.

## Verification

- Suite **65/65**
- **Eleven version markers** had to move together. The suite caught three I missed — the
  cowork marketplace entry, the update skill's example, and the SDLC.md table. That is
  #493's defect class caught by tests rather than by review, which has not happened
  before.
- Historical `v1.94.0` references in ROADMAP and two test comments left in place
  deliberately — they describe what was true then.
- Every constituent PR was cross-model reviewed before merge; #497 ran **five rounds**
  until both reviewers certified.

## After merge

Tag `v1.95.0` and push it — that triggers the npm publish under the new trusted
publisher.