### PR TITLE
docs(readme): the E2E scoring pipeline runs here, not in the consumer's repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,15 +221,24 @@ GENERATED FILES (in your repo)
   - .claude/skills/*/SKILL.md
   - .claude/settings.json
   - CLAUDE.md, SDLC.md, TESTING.md, ARCHITECTURE.md
+
+        (that's everything you get — the arrow below leaves your repo)
+
         |
-        | validated by
+        | the harness itself is validated by
         v
-CI/CD PIPELINE
+CI/CD PIPELINE (this repo, NOT yours)
   - E2E: simulate SDLC task -> score 0-10
-  - Before/after: main vs PR wizard
+  - Before/after: main vs PR harness
   - Statistical: 5x trials, 95% CI
   - Model-aware: SDP adjusts for external conditions
 ```
+
+**The bottom box runs here, not in your project.** `tests/e2e/` is not part of the
+published package, so `npm pack` ships none of it. That scoring pipeline is how *this*
+repo proves a change to the harness is an improvement before releasing it — it is not
+something you run, configure, or need an API key for. What lands in your repo is the
+middle box: hooks, skills, settings and docs.
 
 ## Self-Evolving System
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -3062,6 +3062,33 @@ test_fable_framed_as_decider_not_advisor() {
 }
 test_fable_framed_as_decider_not_advisor
 
+# ---- README's architecture diagram must not imply consumers get our CI ----
+#
+# The diagram reads: "GENERATED FILES (in your repo)" -> "validated by" ->
+# "CI/CD PIPELINE / E2E: simulate SDLC task -> score 0-10". With one box
+# labelled "in your repo" and the next unlabelled, the scoring pipeline reads
+# as something that runs in the consumer's repo. It does not: `tests/e2e/` is
+# absent from package.json's files, so `npm pack` ships none of it. That
+# pipeline validates the harness HERE, before a release goes out.
+#
+# Same defect class as GH #491's distribution boundary — a shipped doc implying
+# the consumer has something they never receive.
+test_readme_diagram_scopes_the_ci_pipeline() {
+    local f="$REPO_ROOT/README.md" block
+    [ -f "$f" ] || { fail "README.md missing"; return; }
+    block=$(grep -A4 'CI/CD PIPELINE' "$f" | head -5)
+    if [ -z "$block" ]; then
+        pass "README no longer shows the CI/CD pipeline box (nothing to mis-scope)"
+        return
+    fi
+    if grep -qE 'CI/CD PIPELINE \((this repo|our repo|meta-repo)[^)]*\)' "$f"; then
+        pass "README diagram scopes the CI/CD pipeline to this repo, not the consumer's"
+    else
+        fail "README's CI/CD PIPELINE box is unscoped — it follows a box labelled '(in your repo)', so it reads as running in the consumer's repo. tests/e2e/ does not ship."
+    fi
+}
+test_readme_diagram_scopes_the_ci_pipeline
+
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
See commit message. Rolled into v1.96.0.