### PR TITLE
fix(docs): delete the wizard doc's second install path for the SDLC skill (#513)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ tests/fixtures/community-scanner/
 /.playwright-mcp/
 /anthropic-sonnet-*.png
 /awesome-claude-code-subagents/
-scripts/__pycache__/
+# Unanchored: Python helpers now live in tests/lib/ as well as scripts/
+__pycache__/
 /~/
 
 # tests/e2e/score-history.txt is recreated by test-cusum.sh on each run

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2354,111 +2354,23 @@ chmod +x .claude/hooks/tdd-pretool-check.sh
 
 ---
 
-## Step 6: Create SDLC Skill
+## Step 6: Install the SDLC Skill
 
-Create `.claude/skills/sdlc/SKILL.md`:
+Run the installer. It writes `.claude/skills/sdlc/SKILL.md` for you:
 
-````markdown
----
-name: sdlc
-description: Full SDLC workflow for implementing features, fixing bugs, refactoring code, testing, releasing, publishing, and deploying. Use this skill when implementing, fixing, refactoring, testing, adding features, building new code, or releasing/publishing/deploying.
-argument-hint: "[task description]"
----
-# SDLC Skill - Full Development Workflow
-
-## Task
-$ARGUMENTS
-
-## Full SDLC Checklist
-
-Your FIRST action must be TodoWrite with these steps:
-
-```
-TodoWrite([
-  // PLANNING PHASE (Plan Mode for non-trivial tasks)
-  { content: "Find and read relevant documentation", status: "in_progress", activeForm: "Reading docs" },
-  { content: "Assess doc health - flag issues (ask before cleaning)", status: "pending", activeForm: "Checking doc health" },
-  { content: "DRY scan: What patterns exist to reuse?", status: "pending", activeForm: "Scanning for reusable patterns" },
-  { content: "Prove It Gate: adding new component? Research alternatives, prove quality with tests", status: "pending", activeForm: "Checking prove-it gate" },
-  { content: "Blast radius: What depends on code I'm changing?", status: "pending", activeForm: "Checking dependencies" },
-  { content: "Restate task in own words - verify understanding", status: "pending", activeForm: "Verifying understanding" },
-  { content: "Scrutinize test design - right things tested? Follow TESTING.md?", status: "pending", activeForm: "Reviewing test approach" },
-  { content: "Present approach + STATE CONFIDENCE LEVEL", status: "pending", activeForm: "Presenting approach" },
-  { content: "Signal ready - user exits plan mode", status: "pending", activeForm: "Awaiting plan approval" },
-  // TRANSITION PHASE (After plan mode, before compact)
-  { content: "Doc sync: update or create feature docs — MUST be current before commit", status: "pending", activeForm: "Syncing feature docs" },
-  { content: "Request /compact before TDD", status: "pending", activeForm: "Requesting compact" },
-  // IMPLEMENTATION PHASE (After compact)
-  { content: "TDD RED: Write failing test FIRST", status: "pending", activeForm: "Writing failing test" },
-  { content: "TDD GREEN: Implement, verify test passes", status: "pending", activeForm: "Implementing feature" },
-  { content: "Run lint/typecheck", status: "pending", activeForm: "Running lint and typecheck" },
-  { content: "Run ALL tests", status: "pending", activeForm: "Running all tests" },
-  { content: "Production build check", status: "pending", activeForm: "Verifying production build" },
-  // REVIEW PHASE
-  { content: "DRY check: Is logic duplicated elsewhere?", status: "pending", activeForm: "Checking for duplication" },
-  { content: "Security review (if warranted)", status: "pending", activeForm: "Checking security implications" },
-  { content: "Cross-model review (REQUIRED for high-stakes)", status: "pending", activeForm: "Running cross-model review" },
-  // CI FEEDBACK LOOP (After local tests pass)
-  { content: "Commit and push to remote", status: "pending", activeForm: "Pushing to remote" },
-  { content: "Watch CI - fix failures, iterate until green (max 2x)", status: "pending", activeForm: "Watching CI" },
-  { content: "Read CI review - implement valid suggestions, iterate until clean", status: "pending", activeForm: "Addressing CI review feedback" },
-  // FINAL
-  { content: "Present summary: changes, tests, CI status", status: "pending", activeForm: "Presenting final summary" }
-])
+```bash
+npx -y agentic-sdlc-wizard@latest init
 ```
 
-## New Pattern & Test Design Scrutiny (PLANNING)
+**Do not hand-copy a skill out of this document.** Earlier revisions embedded a
+640-line copy of the skill here, and it diverged from the installed file until the
+two shared only five section topics — 56,284 bytes against the real skill's 19,356,
+moving in opposite directions inside single PRs. One skill, one source: the CLI is
+canonical, and `skills/sdlc/SKILL.md` ships in the same npm package as this document,
+so the real file is already sitting next to these instructions. Read it there (GH #513).
 
-**New design patterns require human approval:**
-1. Search first - do similar patterns exist in codebase?
-2. If YES and they're good - use as building block
-3. If YES but they're bad - propose improvement, get approval
-4. If NO (new pattern) - explain why needed, get explicit approval
-
-**Test design scrutiny during planning:**
-- Are we testing the right things?
-- Does test approach follow TESTING.md philosophies?
-- If introducing new test patterns, same scrutiny as code patterns
-
-## Prove It Gate (REQUIRED for New Additions)
-
-**Adding a new skill, hook, workflow, component — or a new PRACTICE/process step? PROVE IT FIRST:**
-
-1. **Research:** Does something equivalent already exist (native CC, third-party plugin, existing skill)?
-2. **If YES:** Why is yours better? Show evidence (A/B test, quality comparison, gap analysis)
-3. **If NO:** What gap does this fill? Is the gap real or theoretical?
-4. **Quality tests:** New additions MUST have tests that prove OUTPUT QUALITY, not just existence
-5. **Less is more:** Every addition is maintenance burden. Default answer is NO unless proven YES
-
-**Existence tests are NOT quality tests:**
-- BAD: "ci-analyzer skill file exists" — proves nothing about quality
-- GOOD: "ci-analyzer recommends lint-first when test-before-lint detected" — proves behavior
-
-**If you can't write a quality test for it, you can't prove it works, so don't add it.**
-
-## Plan Mode Integration
-
-**Use plan mode for:** Multi-file changes, new features, LOW confidence, bugs needing investigation.
-
-**Workflow:**
-1. **Plan Mode** (editing blocked): Research → Write plan file → Present approach + confidence
-2. **Transition** (after approval): Doc sync (update or create feature docs — MUST be current before commit) → Request /compact
-3. **Implementation** (after compact): TDD RED → GREEN → PASS
-
-**Before TDD, MUST ask:** "Docs updated. Run `/compact` before implementation?"
-
-### Auto-Approval: Skip Plan Approval Step
-
-If ALL of these are true, skip plan approval and go straight to TDD:
-- Confidence is **HIGH (95%+)** — you know exactly what to do
-- Task is **single-file or trivial** (config tweak, small bug fix, string change)
-- No new patterns introduced
-- No architectural decisions
-
-When auto-approving, still announce your approach — just don't wait for approval:
-> "Confidence HIGH (95%). Single-file change. Proceeding directly to TDD."
-
-**When in doubt, wait for approval.** Auto-approval is for clear-cut cases only.
+Policy that used to live only inside that block is now stated at document level under
+**Merging, CI and Release Policy** below.
 
 ## Confidence Check (REQUIRED)
 
@@ -2512,385 +2424,23 @@ Low confidence does **not** mean "ask the user." It means "escalate," and the us
 
 **Honesty rule.** If you fix a reviewer's finding and choose to skip the confirming round, state that plainly. An unconfirmed fix is not a certification, and reporting it as one is exactly the false-green this protocol exists to prevent. Skipping a round can be the right call — silently implying it happened is not.
 
-## Self-Review — demoted from critical (GH #486)
+## Merging, CI and Release Policy
 
-**A same-model read-back is no longer a gate.** It is still scored (1 point) because the
-10-point rubric and every stored baseline depend on the total, but it cannot fail a run on
-its own, and it is no longer injected per-prompt or listed as a checklist step.
+This is reader-facing policy for the human running the harness. The agent-facing
+version ships as `skills/sdlc/SKILL.md` — installed by `npx agentic-sdlc-wizard init`,
+not by hand-copying from this document (GH #513).
 
-**Why:** Anthropic's Opus 5 guidance says explicit verification instructions cause
-over-verification. That advice targets *same-model* self-checking, and this repo's own
-record agrees — in one session `/code-review` reported 64/64 green three times while an
-independent model found real P1s each time, including a shipped hook proven silently dead
-and a guard proven to be reading nothing. Same-model self-review has **zero recorded
-unique catches** here.
+### Explicit Merge Confirmation — and a Narrow, Conditional Exception
 
-**What did NOT change: cross-model review.** The guidance above does not transfer to it,
-and it is the only layer with a record of catching real defects. Where `/code-review`
-still earns its place is as *preflight input* to that review on high-stakes work — run it
-to reduce what the cross-model reviewer has to find, not as a gate of its own.
+**The default: explicit `gh pr merge --squash` always needs the user's confirmation, every PR.** `gh pr merge --auto` (GitHub's own auto-merge-on-green feature) stays permanently, unconditionally banned regardless of anything below — it fires before review feedback can even be read (PR #145 incident: auto-merged unreviewed, shipped a P1 bug).
 
-**If your driver is Sonnet-class rather than Opus 5,** keeping a self-review pass is
-reasonable; the over-verification finding is Opus-5-specific. That conditional lives here
-in the on-demand doc rather than in the always-loaded skill, which ships one file to every
-model.
+**A narrow, conditional exception (2026-07-21)** lets an agent skip that one confirmation click — never the ban above — ONLY if ALL hold: CI's `validate` check is green (verified, not inferred); Codex `high` reached CERTIFIED via a full adversarial dialogue (not a round-1 rubber stamp); a **fresh, diff-only reviewer subagent** (no prior session context) independently found **zero unresolved findings after at least one dialogue round**; and, where the PR touches the **merge-evidence chain** — CI/release workflows, hooks, agent-config directories, or the merge wrapper itself — the higher bar below is met. Those paths are singled out because a PR editing them defines its own CI check, runs its own gate, and posts its own review evidence, so every leg of the evidence stack becomes self-produced at once. Note branch protection matches a required check by NAME, so *any* new workflow file can mint a green one.
 
-### The loop, for reference
+**Dual cross-model certification IS merge authorization, including on the merge-evidence chain (2026-08-08).** Two models that did not write the code, run blind to each other, each able to refuse, is a different evidence class from self-review — so when both reviewers agree the merge proceeds, and the human is the **deadlock-breaker**, not the per-PR approver. This matters for the audit trail as much as for speed: where the only way to say yes was a human-override flag, every such merge recorded a per-PR human decision for what was really one standing policy decision, and an override record that misattributes its own authority is worse than no record. On the merge-evidence chain the bar adds two conditions: the gate that runs must be the **merged** one — byte-identical to the default branch, not this PR's edited copy, or the PR is judged by its own edits — and the review-dialogue evidence stays **required rather than waived**, so a round-1 rubber stamp does not clear it. Three things dual agreement never clears: a red CI check, net-removed test files, and a package-version bump (releases stay human). And state the residual plainly rather than implying it away: both clearances are typically posted by the same token, so this is **attested, not authenticated**, and a new workflow file minting a green required check is a hole nothing local can close — the compensating layer is that both reviewers read that file in the diff. Policy prose that steers behaviour but does not decide whether the current PR may merge (the SDLC policy document, the SDLC skill) may instead be cleared by posted, SHA-bound cross-model evidence. A package-version bump always needs confirmation. **This distinction is not a security boundary** — a local gate never is against a determined agent — it bounds the blast radius of an honest agent that has degraded: a bad docs merge ships one bad doc, a bad control-plane merge silently degrades every later merge's evidence, including the check that would have caught it. Even when it fires, the agent must tell the user immediately afterward what merged and why — this is "skip the click," never a silent merge.
 
-```
-PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Cross-Model Review
-    ↑                                                      │
-    │                                                      ↓
-    │                                            Issues found?
-    │                                            ├── NO → Present to user
-    │                                            └── YES ↓
-    └────────────────────────────────────────────── Ask user: fix in new plan?
-```
+**Be honest with yourself about what's actually enforced.** Some of this repo's own conditions are mechanically verified by local tooling — but that tooling is intentionally repo-local and does **not** ship as part of the wizard install. If you want the same fail-closed guarantee rather than self-certified prose, build the equivalent for your own repo: a wrapper script that independently re-checks CI status against the PR's remote head SHA, scans the diff against your own denylist (including the wrapper and any gate hook themselves — a PR editing the merge policy must not be able to exempt itself from it), and binds the merge atomically to that SHA (e.g. `gh pr merge --match-head-commit <sha>`) to close the race between checking and merging. Absent that, treat every condition above as something your own agent must reason about and self-report against, not something guaranteed.
 
-**The loop goes back to PLANNING, not TDD RED.** When self-review finds issues:
-1. Ask user: "Found issues. Want to create a plan to fix?"
-2. If yes → back to PLANNING phase with new plan doc
-3. Then → docs update → TDD → review (proper SDLC loop)
-
-**How to self-review:**
-1. Optionally run `/code-review` as preflight input, then send the diff to a DIFFERENT model
-2. It launches parallel agents (CLAUDE.md compliance, bug detection, logic & security)
-3. Issues at confidence >= 80 are real findings — go back to PLANNING to fix
-4. Issues below 80 are likely false positives — skip unless obviously valid
-5. Address issues by going back through the proper SDLC loop
-
-## Cross-Model Review (REQUIRED for High-Stakes)
-
-**When to run:** High-stakes changes (auth, payments, data handling), releases/publishes (version bumps, CHANGELOG, npm publish), complex refactors, research-heavy work.
-**When to skip (log justification):** Trivial changes (typo fixes, config tweaks), time-sensitive hotfixes, risk < review cost.
-
-**Prerequisites:** Codex CLI installed (`npm i -g @openai/codex`), OpenAI API key set.
-
-**Before requesting review, run `shellcheck` on any new or modified `.sh` file** (`shellcheck -s bash <files>`). This closes a real gap this repo hit directly (2026-07-21): a merge-safety-gate PR whose own tests had each been watched failing still passed cleanly, yet Codex's own review still caught bugs `shellcheck` would have flagged for free — including the classic `if [ $? -ne 0 ]` anti-pattern (SC2181), which is fragile against a line accidentally inserted between the command and the check. Mutation testing only proves your tests catch *deliberately broken variants you thought to try* — it can't catch a whole class of mechanical bugs a static analyzer finds instantly. Fix findings before submitting to Codex; don't spend a review round on what a free, instant, deterministic tool already tells you.
-
-### Round 1: Initial Review
-
-1. When the change is high-stakes, write `.reviews/handoff.json` (optionally run `/code-review` first as preflight input — it reduces what the reviewer has to find, but is no longer a gate):
-   ```jsonc
-   {
-     "review_id": "feature-xyz-001",
-     "status": "PENDING_REVIEW",
-     "round": 1,
-     "files_changed": ["src/auth.ts", "tests/auth.test.ts"],
-     "review_instructions": "Review for security, edge cases, and correctness",
-     "artifact_path": ".reviews/feature-xyz-001/",
-     "pr_number": 205
-   }
-   ```
-   `pr_number` (optional) is the PreCompact self-heal opt-in (ROADMAP #209). When set, the `precompact-seam-check.sh` hook queries `gh pr view N --json state` on every manual `/compact` and treats MERGED as implicit CERTIFIED — so a forgotten PENDING handoff doesn't block every future compact. Omit for ad-hoc reviews not tied to a PR.
-2. Run the independent reviewer:
-   ```bash
-   codex exec \
-     -c 'model_reasoning_effort="high"' \
-     -s danger-full-access \
-     -o .reviews/latest-review.md \
-     "You are an independent code reviewer. Read .reviews/handoff.json, \
-      review the listed files. Output each finding with: an ID (1, 2, ...), \
-      severity (P0/P1/P2), description, and a 'certify condition' stating \
-      what specific change would resolve it. \
-      End with CERTIFIED or NOT CERTIFIED." \
-     < /dev/null
-   ```
-
-   > **Always append `< /dev/null`** to `codex exec` calls run from background, hooks, CI, or any non-interactive parent. Without it, codex blocks on stdin reads even when the prompt is given as an argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file (the file is only written on completion, so a hang gives zero visibility). Validated on codex-cli 0.130.0 / macOS 14, 2026-05-15. For live progress, wrap the call so it prints heartbeats (maintainer tooling `scripts/codex-review-with-progress.sh` in this repo is NOT installed by the wizard).
-
-   > **Always launch codex via `run_in_background: true` on the Bash tool.** The Bash tool clamps `timeout` to 600000 ms (10 min) regardless of the value passed, and force-kills the foreground process at that wall. Multi-artifact bundle reviews (release reviews per the checklist below, multi-finding rechecks, etc.) routinely run 6–30 minutes — they need background mode to complete. **A progress wrapper does not save you here.** The maintainer tooling `scripts/codex-review-with-progress.sh` in this repo, which is NOT installed by the wizard, prints elapsed-time heartbeats and forwards signals to its child, but it has **no stall watchdog and no timeout** — it loops on `kill -0` until codex exits on its own, however long that takes. This paragraph claimed a 30-minute stall watchdog for months, naming a tunable that has never existed in this repo; the claim survived because nothing checked that a named mechanism was real (GH #491). Nothing bounds a hung review except you noticing and killing it. A foreground call killed mid-review plus the Stop-hook re-invocation loop can burn 60+ minutes of session compute on what should be a single 7-minute run (issue #364, 2026-05-27 incident). The general rule: **any long-running wrapper invoked through the CC Bash tool — codex, slow builds, long test suites — should use `run_in_background: true` unconditionally, then be actively watched — no wrapper in this repo enforces a timeout on your behalf.**
-
-   > **Never also append a trailing `&` inside the command string when using `run_in_background: true`.** These are two different backgrounding mechanisms — the Bash tool's own `run_in_background` flag, and the shell's native job-control `&` — and combining them double-backgrounds the process: the "completed" notification fires for the outer wrapper shell exiting immediately, not for the actual `codex exec` process, which is still running detached and unmonitored. This produces a convincing but false "review complete" signal — the transcript looks done, but no verdict has actually been written yet. Confirm real completion independently (e.g. `ps aux | grep codex`) before trusting a background-task notification that arrived suspiciously fast for a multi-minute review. Use `run_in_background: true` alone; never both.
-
-3. If CERTIFIED → **write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json` before proceeding to CI.** `hooks/codex-gate-check.sh` compares this SHA to current HEAD at commit time and treats a mismatch (or a missing field) as a stale certification (ROADMAP #437) — a CERTIFIED status string alone doesn't prove the certification still covers what's about to be committed. If NOT CERTIFIED → go to Round 2.
-
-### Round 2+: Dialogue Loop
-
-When the reviewer finds issues, respond per-finding instead of silently fixing everything:
-
-1. Write `.reviews/response.json`:
-   ```jsonc
-   {
-     "review_id": "feature-xyz-001",
-     "round": 2,
-     "responding_to": ".reviews/latest-review.md",
-     "responses": [
-       { "finding": "1", "action": "FIXED", "summary": "Added missing validation" },
-       { "finding": "2", "action": "DISPUTED", "justification": "This is intentional — see CODE_REVIEW_EXCEPTIONS.md" },
-       { "finding": "3", "action": "ACCEPTED", "summary": "Will add test coverage" }
-     ]
-   }
-   ```
-   - **FIXED**: "I fixed this. Here is what changed." Reviewer verifies.
-   - **DISPUTED**: "This is intentional/incorrect. Here is why." Reviewer accepts or rejects.
-   - **ACCEPTED**: "You are right. Fixing now." (Same as FIXED, batched.)
-
-2. Update `handoff.json` with `"status": "PENDING_RECHECK"`, increment `round`, add `"response_path"` and `"previous_review"` fields.
-
-3. Run targeted recheck (NOT a full re-review):
-   ```bash
-   codex exec \
-     -c 'model_reasoning_effort="high"' \
-     -s danger-full-access \
-     -o .reviews/latest-review.md \
-     "You are doing a TARGETED RECHECK. First read .reviews/handoff.json \
-      to find the previous_review path — read that file for the original \
-      findings and certify conditions. Then read .reviews/response.json \
-      for the author's responses. For each: \
-      FIXED → verify the fix against the original certify condition. \
-      DISPUTED → evaluate the justification (ACCEPT if sound, REJECT if not). \
-      ACCEPTED → verify it was applied. \
-      Do NOT expand the review surface. A new P0, P1 or P2 must be reported and BLOCKS. Lesser observations go in 'Notes for next review' (non-blocking). \
-      End with CERTIFIED or NOT CERTIFIED." \
-     < /dev/null
-   ```
-
-4. If CERTIFIED → **write/update `"commit_sha"` in `handoff.json` to current HEAD** (same reason as Round 1 step 3 — the gate hook checks it). If NOT CERTIFIED (rejected disputes or failed fixes) → fix rejected items and repeat.
-
-### Convergence
-
-3 recheck rounds (4 total including initial review) is the default budget for a typical change. If still NOT CERTIFIED after round 4, escalate to the user with a summary of open findings rather than spinning indefinitely.
-
-**Exception — known-large migrations:** the round cap is a heuristic against spinning on a shrinking tail of nitpicks, not a hard stop. Judge convergence by the *trend* in finding quality, not the round number: if every round is still surfacing a genuinely new, independently-verified, real issue — especially if severity is flat or increasing (later rounds finding live-code bugs, not just prose) — keep going past round 4. Only stop when a round returns CERTIFIED, or consecutive rounds return nothing but nitpicks/false positives. (Source: v1.84.0 release review — a repo-wide model-recommendation migration ran 11 rounds, each finding something real; round 8 found a mandatory-reading claude-setup-wizard template whose tutorial hook code had silently drifted from the real shipped hook (broken, non-blocking), more consequential than anything in rounds 1-3. Escalating at round 4 per the default heuristic would have shipped that bug. 2026-07-04.)
-
-**CERTIFIED is not the finish line.** A CERTIFIED verdict and a green CI run are different verification layers that catch different bug classes — a CERTIFIED review does not substitute for actually pushing and watching CI. Confirmed on the same v1.84.0 release: after round-11 CERTIFIED and a full local test sweep, real CI still caught 3 more genuine bugs the review never touched — a content regression in an unrelated section silently dropped by an earlier edit (caught by a pre-existing local test that simply hadn't been re-run since), an environment-specific CLI output-format change invisible to any local run against an older tool version, and a new test file committed without the executable bit (passes every local `bash tests/foo.sh` invocation, only fails when CI runs it as `./tests/foo.sh`). Budget for at least one more fix-push-recheck cycle after CERTIFIED, and don't treat CERTIFIED as license to skip reading the actual CI logs — see the CI Feedback Loop section below.
-
-```
-Change ready → handoff.json (round 1, PENDING_REVIEW)
-                            |
-                   Reviewer: FULL REVIEW (structured findings)
-                            |
-                   CERTIFIED? → YES → write commit_sha → CI feedback loop
-                            |
-                            NO (findings with IDs + certify conditions)
-                            |
-                   Claude writes response.json:
-                     FIXED / DISPUTED / ACCEPTED per finding
-                            |
-                   handoff.json (round 2+, PENDING_RECHECK)
-                            |
-                   Reviewer: TARGETED RECHECK
-                   (scoped surface; any new P0/P1/P2 blocks)
-                            |
-                   All resolved? → YES → CERTIFIED (write commit_sha)
-                            |
-                            NO → fix rejected items, repeat
-                            (max 3 rechecks, then escalate to user)
-```
-
-**Tool-agnostic:** The value is adversarial diversity (different model, different blind spots), not the specific tool. Any competing AI reviewer works.
-
-**Full protocol:** See the "Cross-Model Review Loop" section below for key flags and reasoning effort guidance.
-
-### Parallel Blind Dual Review
-
-When two models review the same change, **run them in parallel and blind to each other, then merge the findings**. Do not chain them.
-
-**The rule:** neither reviewer sees the other's output, or your own responses to it, until both have reported. Give each the same diff, the same preflight, and the same instruction to attack. Then merge: treat any finding either one raises as real until disproved.
-
-**Why blindness, not just plurality.** A second reviewer shown the first's findings is *anchored* — it tends to confirm, refine, and extend what it was given rather than look where nobody has looked. You pay for two reviews and get one review plus a proofread. Measured on this repo 2026-07-27, across a four-round review of the merge gate: the **parallel blind** round produced findings that barely overlapped — one model found parsing and encoding defects, the other found a case-sensitivity hole that let a protected path merge clean, plus a policy-document regression neither the author nor the first model noticed. The **sequenced** rounds overlapped heavily by comparison. Both models independently found things that would have shipped otherwise.
-
-**Give both reviewers the SAME contract.** Same diff, same preflight, same severity scale, same fix policy — otherwise you cannot merge their findings or compare their verdicts, and you will not notice when one is grading on a different curve. Measured here 2026-07-29: one reviewer was given P0-P3 and the other HIGH/MEDIUM/LOW on the same change, which made two genuine reviews look like disagreement.
-
-| Severity | Meaning | Action |
-|---|---|---|
-| P0/P1 | Wrong behaviour, security, data loss, or a test that passes against broken code | **Fix before merge. Restarts the cycle.** |
-| P2 | Real defect, bounded blast radius. Inaccurate shipped prose belongs here | **Fix before merge.** Re-gate, no full restart |
-| P3 | Correctness or accuracy nit — a stale comment, an unclear message | Fix if cheap and it is about being *right* |
-| P3 (style) | Preference, naming, formatting with no correctness content | **Not review's job — encode it as a lint rule instead.** |
-
-**Style findings become lint rules, not review findings.** A cross-model round is expensive, slow, and non-deterministic; a linter is free, instant and total. If a reviewer raises a style point worth honouring, the fix is not "change this line" — it is *add the rule so nothing can ever violate it again*, then let the linter enforce it in every repo that installs this. That converts a recurring review cost into a one-time one. Run the linters **before** requesting review (`shellcheck -s bash` on changed `.sh` files, plus whatever your language uses) so no reviewer round is spent on what a deterministic tool already reports. Review exists for **correctness** — behaviour, security, and whether the tests actually test anything. If you find yourself lacking a standard rather than lacking a fix, the deliverable is the rule.
-
-Tell both reviewers this in the prompt, and tell them explicitly: **do not manufacture findings to appear thorough — "I found nothing real" is a valid and useful answer.** Without that instruction a reviewer under pressure to produce will generate P3s indefinitely, and you will mistake its output for unfinished work.
-
-**Diminishing returns — how to actually tell.** Judge by the *maximum severity per round*, never by finding count: count rises when a reviewer looks somewhere new, which is the opposite of a stopping signal (the round that found the most here also found the most serious bugs). You are converged when two consecutive rounds produce nothing above P3 **from reviewers that had not already cleared this code**. A single reviewer's own trend flattening means only that it has run out of defects *it* can see — one reviewer certified at high confidence here immediately before a fresh reviewer found six P1s in the same code.
-
-**Merging findings.** Combine, do not intersect. Two independent reviewers agreeing is a strong signal, but a finding raised by only one is the *common* case and is usually the valuable one — that is the entire point of using two. Respond to each reviewer's findings separately, and run the recheck round with each still blind to the other.
-
-**Cost control.** This is not free — each round costs wall-clock and, for a paid API reviewer, real money. Scale it to blast radius:
-
-| Change | Review |
-|---|---|
-| Live enforcement: CI config, hooks, agent config, the merge mechanism itself | Parallel blind dual review |
-| Ordinary application code | One reviewer at the pre-commit gate |
-| Docs, roadmap entries, comments | Neither |
-
-**Iterating vs. gating.** Looping with one reviewer while you build is cheap and effective — use the model that does not bill per token if you have one. But that reviewer is no longer independent by the end: it is reading code shaped by its own earlier feedback. So iterate with it freely, then run the **final** gate as a parallel blind round with a *fresh* instance of each model.
-
-**The loop, stated explicitly.** Reviewers returning findings is the normal case, not a setback, and the agent must not stop to ask permission each time. Run this until it terminates:
-
-```
-implement  →  fix every finding  →  re-review with the ITERATION model
-                    ↑                            ↓
-                    │                    findings? ──yes──┐
-                    │                            │        │
-                    └────────────────────────────┼────────┘
-                                                 no
-                                                 ↓
-                                    GATE: fresh parallel blind round
-                                                 ↓
-                                    findings? ──yes──→ back to the top
-                                                 ↓ no
-                                            ship it
-```
-
-**Rules that make it terminate rather than spin:**
-
-1. **Every finding gets a response before the next round** — FIXED, DISPUTED with reasoning, or ACCEPTED. Never silently drop one.
-2. **A dispute is a claim you owe evidence for.** If the reviewer rejects it and offers a concrete alternative, implement the alternative — you asked for an adversary, not an audience.
-3. **Any P0/P1 finding restarts the cycle from the top.** A gate round that surfaces a real defect was not a gate round, it was an iteration round. P2/P3-only findings do not need a full restart: fix them and re-run the gate. Either way the gate must eventually return *nothing new* — "findings?" in the diagram means any finding, and what differs is only whether you re-enter at iteration or at the gate.
-4. **Fixes need their own verification.** A fix shipped on the strength of "the reviewer suggested it" is unverified code — the reviewer proposed it, nobody has yet shown it works. A test that passes against broken code was never a test.
-
-   **TDD, applied to the fix: RED → GREEN.** Write the assertion, run it, watch **that specific assertion** fail, then implement and watch it pass. The common miss is observing red at the *suite* level — one assertion fails, the suite is red, you implement, the suite goes green, and any assertion that was green from birth is never noticed.
-
-   **Editing an existing test is the hard case, and the honest answer depends on what it guards.** If it guards a bug you are about to fix, RED is free — the bug exists, so the test fails for the right reason. If it guards behaviour that is **already correct**, **you cannot get RED**: correct code does not fail, and rewriting does not change that. Say so plainly rather than calling the assertion verified — an unverified regression test is exactly how this repo shipped eight that passed against broken code. When an assertion is load-bearing enough to justify it, breaking the behaviour once to watch the test go red is the only mechanism that validates that class; treat it as a deliberate exception, not the routine.
-
-   **Either way, prefer rewriting a suspect test over patching it.** Patching guesses which missing piece mattered; a rewrite from a known-good fixture with exactly one deliberate defect does not have to guess. Measured 2026-07-29/30: one test was found ineffective three separate times and patched twice — the rewrite worked first try.
-
-   **Rewrite rather than patch when:** the test passes where you would expect failure; its fixture is broken in more than one way, so you cannot tell which defect it detects; or it asserts on a substring present in both the pass and the fail message.
-
-   **Prefer executing the real thing over asserting on its source text.** A test that greps a script for the *words* proves the words are present, not that the behaviour works — the failure mode that produced every ineffective test in this repo's history. Run the script against a stub and check the exit code.
-
-5. **Verdict disagreement is expected — take the lower one.** Two reviewers can both be right and score differently: one weights a single unfixed P1 as disqualifying, the other weights overall structure. Do not average them, do not pick the friendlier one, and do not treat the gap as a reason to dismiss either. Ship only when *both* clear your bar.
-6. **Two stop conditions, and they are not the same — do not collapse them.** You are **done** when a fresh blind round returns **zero unresolved findings** — not merely "nothing new", because the same unfixed finding raised again is still an open finding. That is the only condition that permits shipping, and it is not reached on a schedule. You are **stuck** when rounds keep producing findings without converging; after 3 rechecks that is a non-convergence alarm, and it ends in escalation to the human with a summary of open findings — never in shipping. **Exception — a large migration may legitimately run past round 4** when each round is still surfacing real, previously-uninventoried surfaces (v1.84.0 ran 11 that way). Judge by whether the finding trend is genuinely converging, and state which of the two you are claiming. An agent that ships because it ran out of rounds has declared victory on a timer.
-
-**Anti-pattern: asking the human to adjudicate each round.** The human sets the bar and decides scope; the models find defects and you fix them. An agent that surfaces every finding for approval has converted an automated gate back into manual review, which is the cost the gate existed to remove.
-
-**If you only have one model available**, run it twice with genuinely different framings — for example once asked to find correctness defects and once asked to prove a specific safety property false — and treat the result as a single review, not two. It is meaningfully better than one pass and meaningfully worse than two models. Do not report it as dual review.
-
-**Do not show reviewers each other's work to "save a round."** That optimisation removes the only property this technique has.
-
-### Release Review Focus
-
-Before any release/publish, add these to `review_instructions`:
-- **CHANGELOG consistency** — all sections present, no lost entries during consolidation
-- **Version parity** — package.json, SDLC.md, CHANGELOG, wizard metadata all match
-- **Stale examples** — hardcoded version strings in docs match current release
-- **Docs accuracy** — README, ARCHITECTURE.md reflect current feature set
-- **CLI-distributed file parity** — live skills, hooks, settings match CLI templates
-- **Policy Migration Inventory** — for a repo-wide blanket-recommendation migration (e.g. changing a default model, effort level, or policy referenced in many places), enumerate every surface it could touch *before* the first review round: skill frontmatter, setup/update wizard menus, live hooks, tutorial doc templates, CHANGELOG. Discovering surfaces one review round at a time is what turns a 4-5 round review into an 11-round one.
-
-Evidence: v1.20.0 cross-model review caught CHANGELOG section loss and stale wizard version examples that passed all tests and self-review. v1.84.0's Sonnet-5-default migration ran 11 rounds because each round surfaced a new, previously-uninventoried surface (skill frontmatter, then setup wizard, then a live hook, then tutorial templates) rather than catching them all upfront.
-
-### Multiple Reviewers (N-Reviewer Pipeline)
-
-When multiple reviewers comment on a PR (Claude, Codex, human reviewers), address each reviewer independently:
-
-1. **Read all reviews** — collect feedback from every active reviewer
-2. **Respond per-reviewer** — each reviewer has different blind spots. Address each one's findings separately
-3. **Resolve conflicts** — if reviewers disagree, pick the stronger argument, note why
-4. **Iterate until all approve** — don't merge until every active reviewer is satisfied
-5. **Max 3 iterations per reviewer** — escalate to user if a reviewer keeps finding new things
-
-The value of multiple reviewers: different models/humans catch different issues. No single reviewer is sufficient for high-stakes changes.
-
-### Custom Subagents (`.claude/agents/`)
-
-Claude Code supports custom subagents in `.claude/agents/`. These run as independent subprocesses focused on a single task:
-
-- **`sdlc-reviewer`** — SDLC compliance review (planning, TDD, self-review checks)
-- **`ci-debug`** — CI failure diagnosis (reads logs, identifies root cause)
-- **`test-writer`** — Quality test writing following TESTING.md philosophies
-
-**Skills vs agents:** Skills guide Claude's behavior for a task type. Agents are independent subprocesses that run autonomously and return results. Use agents when you want parallel work or a fresh context window.
-
-## Test Review (Harder Than Implementation)
-
-During self-review, critique tests HARDER than app code:
-1. **Testing the right things?** - Not just that tests pass
-2. **Tests prove correctness?** - Or just verify current behavior?
-3. **Follow our philosophies (TESTING.md)?**
-   - Testing Diamond (integration-heavy)?
-   - Minimal mocking (real DB, mock external APIs only)?
-   - Real fixtures from captured data?
-
-**Tests are the foundation.** Bad tests = false confidence = production bugs.
-
-## Scope Guard (Stay in Your Lane)
-
-**Only make changes directly related to the task.**
-
-If you notice something else that should be fixed:
-- ✅ NOTE it in your summary ("I noticed X could be improved")
-- ❌ DON'T fix it unless asked
-
-**Why this matters:** AI agents can drift into "helpful" changes that weren't requested. This creates unexpected diffs, breaks unrelated things, and makes code review harder.
-
-## Test Failure Recovery (SDET Philosophy)
-
-**🛑 ALL TESTS MUST PASS BEFORE COMMIT**
-
-**Treat test code like app code.** Test failures are bugs. Investigate them the way a 15-year SDET would - with thought and care, not by brushing them aside.
-
-If tests fail:
-1. Identify which test(s) failed
-2. Diagnose WHY - this is the important part:
-   - Your code broke it? Fix your code (regression)
-   - Test is for deleted code? Delete the test
-   - Test has wrong assertions? Fix the test
-   - Test is "flaky"? Investigate - flakiness is just another word for bug
-3. Fix appropriately (fix code, fix test, or delete dead test)
-4. Run specific test individually first
-5. Then run ALL tests
-6. Still failing? Escalate to Fable, then Codex `high` — ask the user only if they still can't resolve it
-
-**Flaky tests are bugs, not mysteries:**
-- Sometimes the bug is in app code (race condition, timing issue)
-- Sometimes the bug is in test code (shared state, not parallel-safe)
-- Sometimes the bug is in test environment (cleanup not proper)
-
-Debug it. Find root cause. Fix it properly. Tests ARE code.
-
-## Flaky Test Prevention
-
-**Flaky tests are bugs. Period.** They erode trust in the test suite, slow down teams, and mask real regressions. For a deep dive, see: [How do you Address and Prevent Flaky Tests?](https://softwareautomation.notion.site/How-do-you-Address-and-Prevent-Flaky-Tests-23c539e19b3c46eeb655642b95237dc0)
-
-### Principles
-
-1. **Treat test code like app code** — same code review standards, same quality bar. Tests are first-class citizens, not afterthoughts.
-
-2. **Investigate every flaky failure** — never ignore a flaky test. It's a bug somewhere in one of three layers:
-   - **Test code** — shared state, not parallel-safe, timing assumptions, missing cleanup
-   - **App code** — race condition, unhandled edge case, non-deterministic behavior
-   - **Environment/infra** — CI runner flakiness, resource contention, external service instability
-
-3. **Stress-test new tests** — run new or modified tests N times before merge to sniff out flakiness early. A test that passes 1x but fails on run 50 has a bug.
-
-4. **Isolate testing environments** — sanitize state between tests. Don't share databases. Clean up properly. Each test should be independently runnable.
-
-5. **Address flakiness immediately** — momentum matters. The longer a flaky test lives, the more trust erodes and the harder root cause becomes to find.
-
-6. **Quarantine only if actively fixing** — quarantine is a temporary holding pen, not a permanent ignore. If a test is quarantined for more than a sprint, it needs attention or deletion.
-
-7. **Track flaky rates** — you can't fix what you don't measure. Know which tests are flaky and how often.
-
-### When the Bug Is in CI Infrastructure
-
-Sometimes the flakiness is genuinely in CI infrastructure (runner environment, GitHub Actions internals, third-party action bugs). When this happens:
-- **Make cosmetic steps non-blocking** — PR comments, notifications, and reports should use `continue-on-error: true`
-- **Keep quality gates strict** — the actual pass/fail decision must NOT have `continue-on-error`
-- **Separate "fail the build" from "nice to have"** — a missing PR comment is not a regression
-
-## Debugging Workflow (Systematic Investigation)
-
-When something breaks and the cause isn't obvious, follow this systematic debugging workflow:
-
-```
-Reproduce → Isolate → Root Cause → Fix → Regression Test
-```
-
-1. **Reproduce** — Can you make it fail consistently? If intermittent, stress-test (run N times). If you can't reproduce it, you can't fix it
-2. **Isolate** — Narrow the scope. Which file? Which function? Which input? Use binary search: comment out half the code, does it still fail?
-3. **Root cause** — Don't fix symptoms. Ask "why?" until you hit the actual cause. "It crashes on line 42" is a symptom. "Null pointer because the API returns undefined when rate-limited" is a root cause
-4. **Fix** — Fix the root cause, not the symptom
-5. **Regression test** — Write a test that fails without your fix and passes with it (TDD GREEN)
-
-**For regressions** (it worked before, now it doesn't): Use `git bisect` to find the exact breaking commit. `git bisect start`, `git bisect bad` (current), `git bisect good <known-good-commit>`. Narrows to the breaking commit in O(log n) steps.
-
-**Environment-specific bugs** (works locally, fails in CI/staging/prod): Check environment differences (env vars, OS version, dependency versions, file permissions). Reproduce the environment locally if possible. Add logging at the failure point — don't guess, observe.
-
-## CI Feedback Loop — Local Shepherd (After Commit)
+### CI Feedback Loop — Local Shepherd (After Commit)
 
 **This is the "local shepherd" — your CI fix mechanism.** It runs in your active session with full context.
 
@@ -2940,7 +2490,7 @@ Local tests pass -> Commit -> Push -> Watch CI
 - Flaky? Investigate - flakiness is a bug
 - Stuck? Escalate — Fable, then Codex `high`; the user last
 
-## CI Review Feedback Loop — Local Shepherd (After CI Passes)
+### CI Review Feedback Loop — Local Shepherd (After CI Passes)
 
 **CI passing isn't the end.** If CI includes a code reviewer, read and address its suggestions.
 
@@ -2972,33 +2522,89 @@ CI passes -> Read review suggestions
 - **Ask first**: Present suggestions to user, let them decide which to implement
 - **Skip review feedback**: Ignore CI review suggestions, only fix CI failures
 
-## Explicit Merge Confirmation — and a Narrow, Conditional Exception
+## Self-Review — demoted from critical (GH #486)
 
-**The default: explicit `gh pr merge --squash` always needs the user's confirmation, every PR.** `gh pr merge --auto` (GitHub's own auto-merge-on-green feature) stays permanently, unconditionally banned regardless of anything below — it fires before review feedback can even be read (PR #145 incident: auto-merged unreviewed, shipped a P1 bug).
+**A same-model read-back is no longer a gate.** It is still scored (1 point) because the
+10-point rubric and every stored baseline depend on the total, but it cannot fail a run on
+its own, and it is no longer injected per-prompt or listed as a checklist step.
 
-**A narrow, conditional exception (2026-07-21)** lets an agent skip that one confirmation click — never the ban above — ONLY if ALL hold: CI's `validate` check is green (verified, not inferred); Codex `high` reached CERTIFIED via a full adversarial dialogue (not a round-1 rubber stamp); a **fresh, diff-only reviewer subagent** (no prior session context) independently found **zero unresolved findings after at least one dialogue round**; and, where the PR touches the **merge-evidence chain** — CI/release workflows, hooks, agent-config directories, or the merge wrapper itself — the higher bar below is met. Those paths are singled out because a PR editing them defines its own CI check, runs its own gate, and posts its own review evidence, so every leg of the evidence stack becomes self-produced at once. Note branch protection matches a required check by NAME, so *any* new workflow file can mint a green one.
+**Why:** Anthropic's Opus 5 guidance says explicit verification instructions cause
+over-verification. That advice targets *same-model* self-checking, and this repo's own
+record agrees — in one session `/code-review` reported 64/64 green three times while an
+independent model found real P1s each time, including a shipped hook proven silently dead
+and a guard proven to be reading nothing. Same-model self-review has **zero recorded
+unique catches** here.
 
-**Dual cross-model certification IS merge authorization, including on the merge-evidence chain (2026-08-08).** Two models that did not write the code, run blind to each other, each able to refuse, is a different evidence class from self-review — so when both reviewers agree the merge proceeds, and the human is the **deadlock-breaker**, not the per-PR approver. This matters for the audit trail as much as for speed: where the only way to say yes was a human-override flag, every such merge recorded a per-PR human decision for what was really one standing policy decision, and an override record that misattributes its own authority is worse than no record. On the merge-evidence chain the bar adds two conditions: the gate that runs must be the **merged** one — byte-identical to the default branch, not this PR's edited copy, or the PR is judged by its own edits — and the review-dialogue evidence stays **required rather than waived**, so a round-1 rubber stamp does not clear it. Three things dual agreement never clears: a red CI check, net-removed test files, and a package-version bump (releases stay human). And state the residual plainly rather than implying it away: both clearances are typically posted by the same token, so this is **attested, not authenticated**, and a new workflow file minting a green required check is a hole nothing local can close — the compensating layer is that both reviewers read that file in the diff. Policy prose that steers behaviour but does not decide whether the current PR may merge (the SDLC policy document, the SDLC skill) may instead be cleared by posted, SHA-bound cross-model evidence. A package-version bump always needs confirmation. **This distinction is not a security boundary** — a local gate never is against a determined agent — it bounds the blast radius of an honest agent that has degraded: a bad docs merge ships one bad doc, a bad control-plane merge silently degrades every later merge's evidence, including the check that would have caught it. Even when it fires, the agent must tell the user immediately afterward what merged and why — this is "skip the click," never a silent merge.
+**What did NOT change: cross-model review.** The guidance above does not transfer to it,
+and it is the only layer with a record of catching real defects. Where `/code-review`
+still earns its place is as *preflight input* to that review on high-stakes work — run it
+to reduce what the cross-model reviewer has to find, not as a gate of its own.
 
-**Be honest with yourself about what's actually enforced.** Some of this repo's own conditions are mechanically verified by local tooling — but that tooling is intentionally repo-local and does **not** ship as part of the wizard install. If you want the same fail-closed guarantee rather than self-certified prose, build the equivalent for your own repo: a wrapper script that independently re-checks CI status against the PR's remote head SHA, scans the diff against your own denylist (including the wrapper and any gate hook themselves — a PR editing the merge policy must not be able to exempt itself from it), and binds the merge atomically to that SHA (e.g. `gh pr merge --match-head-commit <sha>`) to close the race between checking and merging. Absent that, treat every condition above as something your own agent must reason about and self-report against, not something guaranteed.
+**If your driver is Sonnet-class rather than Opus 5,** keeping a self-review pass is
+reasonable; the over-verification finding is Opus-5-specific. That conditional lives here
+in the on-demand doc rather than in the always-loaded skill, which ships one file to every
+model.
 
-## DRY Principle
+### The loop, for reference
 
-**Before coding:** "What patterns exist I can reuse?"
-**After coding:** "Did I accidentally duplicate anything?"
+```
+PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Cross-Model Review
+    ↑                                                      │
+    │                                                      ↓
+    │                                            Issues found?
+    │                                            ├── NO → Present to user
+    │                                            └── YES ↓
+    └────────────────────────────────────────────── Ask user: fix in new plan?
+```
 
-## DELETE Legacy Code
+**The loop goes back to PLANNING, not TDD RED.** When self-review finds issues:
+1. Ask user: "Found issues. Want to create a plan to fix?"
+2. If yes → back to PLANNING phase with new plan doc
+3. Then → docs update → TDD → review (proper SDLC loop)
 
-- Legacy code? DELETE IT
-- Backwards compatibility? NO - DELETE IT
-- "Just in case" fallbacks? DELETE IT
-
-**THE RULE:** Delete old code first. If it breaks, fix it properly.
+**How to self-review:**
+1. Optionally run `/code-review` as preflight input, then send the diff to a DIFFERENT model
+2. It launches parallel agents (CLAUDE.md compliance, bug detection, logic & security)
+3. Issues at confidence >= 80 are real findings — go back to PLANNING to fix
+4. Issues below 80 are likely false positives — skip unless obviously valid
+5. Address issues by going back through the proper SDLC loop
 
 ---
 
-**Full reference:** SDLC.md
-````
+## Testing and Debugging Practices
+
+Practices that outlive any one task: keeping the suite trustworthy, and finding a cause
+instead of guessing at one.
+
+### Flaky Test Prevention
+
+**Flaky tests are bugs. Period.** They erode trust in the test suite, slow down teams, and mask real regressions. For a deep dive, see: [How do you Address and Prevent Flaky Tests?](https://softwareautomation.notion.site/How-do-you-Address-and-Prevent-Flaky-Tests-23c539e19b3c46eeb655642b95237dc0)
+
+#### Principles
+
+1. **Treat test code like app code** — same code review standards, same quality bar. Tests are first-class citizens, not afterthoughts.
+
+2. **Investigate every flaky failure** — never ignore a flaky test. It's a bug somewhere in one of three layers:
+   - **Test code** — shared state, not parallel-safe, timing assumptions, missing cleanup
+   - **App code** — race condition, unhandled edge case, non-deterministic behavior
+   - **Environment/infra** — CI runner flakiness, resource contention, external service instability
+
+3. **Stress-test new tests** — run new or modified tests N times before merge to sniff out flakiness early. A test that passes 1x but fails on run 50 has a bug.
+
+4. **Isolate testing environments** — sanitize state between tests. Don't share databases. Clean up properly. Each test should be independently runnable.
+
+5. **Address flakiness immediately** — momentum matters. The longer a flaky test lives, the more trust erodes and the harder root cause becomes to find.
+
+6. **Quarantine only if actively fixing** — quarantine is a temporary holding pen, not a permanent ignore. If a test is quarantined for more than a sprint, it needs attention or deletion.
+
+7. **Track flaky rates** — you can't fix what you don't measure. Know which tests are flaky and how often.
+
+#### When the Bug Is in CI Infrastructure
+
+Sometimes the flakiness is genuinely in CI infrastructure (runner environment, GitHub Actions internals, third-party action bugs). When this happens:
+- **Make cosmetic steps non-blocking** — PR comments, notifications, and reports should use `continue-on-error: true`
+- **Keep quality gates strict** — the actual pass/fail decision must NOT have `continue-on-error`
+- **Separate "fail the build" from "nice to have"** — a missing PR comment is not a regression
 
 ---
 
@@ -3109,6 +2715,25 @@ This rule is per-workflow, not global. Setup wizard does NOT auto-configure isol
 - **Setting Playwright MCP `--isolated` globally as a default** — breaks single-agent flows that rely on the persistent managed profile for session continuity across debug interactions. Upstream Playwright rejected this for the same reason. Make it explicit per-workflow when concurrent agents are running.
 
 ---
+
+
+### Debugging Workflow (Systematic Investigation)
+
+When something breaks and the cause isn't obvious, follow this systematic debugging workflow:
+
+```
+Reproduce → Isolate → Root Cause → Fix → Regression Test
+```
+
+1. **Reproduce** — Can you make it fail consistently? If intermittent, stress-test (run N times). If you can't reproduce it, you can't fix it
+2. **Isolate** — Narrow the scope. Which file? Which function? Which input? Use binary search: comment out half the code, does it still fail?
+3. **Root cause** — Don't fix symptoms. Ask "why?" until you hit the actual cause. "It crashes on line 42" is a symptom. "Null pointer because the API returns undefined when rate-limited" is a root cause
+4. **Fix** — Fix the root cause, not the symptom
+5. **Regression test** — Write a test that fails without your fix and passes with it (TDD GREEN)
+
+**For regressions** (it worked before, now it doesn't): Use `git bisect` to find the exact breaking commit. `git bisect start`, `git bisect bad` (current), `git bisect good <known-good-commit>`. Narrows to the breaking commit in O(log n) steps.
+
+**Environment-specific bugs** (works locally, fails in CI/staging/prod): Check environment differences (env vars, OS version, dependency versions, file permissions). Reproduce the environment locally if possible. Add logging at the failure point — don't guess, observe.
 
 ## Step 8: Create CLAUDE.md
 
@@ -4135,6 +3760,8 @@ Use an independent AI model from a different company as a code reviewer. The aut
 
 **Prompt the reviewer for everything, then filter yourself.** Asking a reviewer to "only report high-severity issues" makes it report less, including real defects. Ask for the full list and triage it: act on P0/P1, batch the rest into a note. Getting cosmetic findings back is a signal to filter harder, not to reduce reasoning effort.
 
+**Before requesting review, run `shellcheck` on any new or modified `.sh` file** (`shellcheck -s bash <files>`). This closes a real gap this repo hit directly (2026-07-21): a merge-safety-gate PR whose own tests had each been watched failing still passed cleanly, yet Codex's own review still caught bugs `shellcheck` would have flagged for free — including the classic `if [ $? -ne 0 ]` anti-pattern (SC2181), which is fragile against a line accidentally inserted between the command and the check. Mutation testing only proves your tests catch *deliberately broken variants you thought to try* — it can't catch a whole class of mechanical bugs a static analyzer finds instantly. Fix findings before submitting to Codex; don't spend a review round on what a free, instant, deterministic tool already tells you.
+
 **Prerequisites:**
 - Codex CLI installed: `npm i -g @openai/codex`
 - OpenAI API key configured: `export OPENAI_API_KEY=...`
@@ -4188,7 +3815,9 @@ codex exec \
 
 > **Always append `< /dev/null`** to `codex exec` calls run from background, hooks, CI, or any non-interactive parent. Without it, codex blocks on stdin reads even when the prompt is given as an argument — the process sits at S/0% CPU indefinitely with a 0-byte `-o` output file. Validated on codex-cli 0.130.0 / macOS 14, 2026-05-15. For live progress visibility, wrap the call so it prints heartbeats (maintainer tooling `scripts/codex-review-with-progress.sh` in this repo is NOT installed by the wizard).
 
-> **Always launch via `run_in_background: true` on the Bash tool.** Same reason as the parallel callout in the Cross-Model Review Loop section above — Bash tool clamps `timeout` to 600000 ms (10 min) regardless of the value passed and force-kills foreground at the wall. Multi-artifact bundle reviews need background mode to complete. See issue #364 (2026-05-27 incident: 70 min session compute on a 7-min review).
+> **Always launch codex via `run_in_background: true` on the Bash tool.** The Bash tool clamps `timeout` to 600000 ms (10 min) regardless of the value passed, and force-kills the foreground process at that wall. Multi-artifact bundle reviews (release reviews per the checklist below, multi-finding rechecks, etc.) routinely run 6–30 minutes — they need background mode to complete. **A progress wrapper does not save you here.** The maintainer tooling `scripts/codex-review-with-progress.sh` in this repo, which is NOT installed by the wizard, prints elapsed-time heartbeats and forwards signals to its child, but it has **no stall watchdog and no timeout** — it loops on `kill -0` until codex exits on its own, however long that takes. This paragraph claimed a 30-minute stall watchdog for months, naming a tunable that has never existed in this repo; the claim survived because nothing checked that a named mechanism was real (GH #491). Nothing bounds a hung review except you noticing and killing it. A foreground call killed mid-review plus the Stop-hook re-invocation loop can burn 60+ minutes of session compute on what should be a single 7-minute run (issue #364, 2026-05-27 incident). The general rule: **any long-running wrapper invoked through the CC Bash tool — codex, slow builds, long test suites — should use `run_in_background: true` unconditionally, then be actively watched — no wrapper in this repo enforces a timeout on your behalf.**
+
+> **Never also append a trailing `&` inside the command string when using `run_in_background: true`.** These are two different backgrounding mechanisms — the Bash tool's own `run_in_background` flag, and the shell's native job-control `&` — and combining them double-backgrounds the process: the "completed" notification fires for the outer wrapper shell exiting immediately, not for the actual `codex exec` process, which is still running detached and unmonitored. This produces a convincing but false "review complete" signal — the transcript looks done, but no verdict has actually been written yet. Confirm real completion independently (e.g. `ps aux | grep codex`) before trusting a background-task notification that arrived suspiciously fast for a multi-minute review. Use `run_in_background: true` alone; never both.
 
 4. If CERTIFIED → **write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — `hooks/codex-gate-check.sh` (ROADMAP #437) blocks a commit if this is missing or doesn't match current HEAD, so a bare `CERTIFIED` status isn't enough. Then done. If NOT CERTIFIED → enter the dialogue loop.
 
@@ -4252,7 +3881,11 @@ codex exec \
 
 **But scoped does not mean muzzled.** A recheck that uncovers a genuine P0, P1 or P2 reports it and it blocks — see the severity contract in "Parallel Blind Dual Review". Certification means *zero unresolved findings*, not *zero findings raised after round 1*. An earlier revision of this paragraph said new P2s could never block certification; that let a real defect through on the grounds of what round it was found in, which is not a property of the defect. What the scoping rule actually forbids is expanding the review's *surface*, not silencing what the reviewer sees.
 
-**Convergence:** Max 3 recheck rounds (4 total including initial review) as the default. If still NOT CERTIFIED after round 4, escalate to the user with a summary of all open findings — escalate, never ship. Don't spin indefinitely. **Exception:** a large migration may legitimately run longer when each round is still surfacing real, previously-uninventoried surfaces (v1.84.0 ran 11 that way). Judge by whether the finding trend is genuinely converging, and say which case you are claiming.
+**Convergence:** Max 3 recheck rounds (4 total including initial review) as the default. If still NOT CERTIFIED after round 4, escalate to the user with a summary of all open findings — escalate, never ship. Don't spin indefinitely. Judge by whether the finding trend is genuinely converging, and say which case you are claiming.
+
+**Exception — known-large migrations:** the round cap is a heuristic against spinning on a shrinking tail of nitpicks, not a hard stop. Judge convergence by the *trend* in finding quality, not the round number: if every round is still surfacing a genuinely new, independently-verified, real issue — especially if severity is flat or increasing (later rounds finding live-code bugs, not just prose) — keep going past round 4. Only stop when a round returns CERTIFIED, or consecutive rounds return nothing but nitpicks/false positives. (Source: v1.84.0 release review — a repo-wide model-recommendation migration ran 11 rounds, each finding something real; round 8 found a mandatory-reading claude-setup-wizard template whose tutorial hook code had silently drifted from the real shipped hook (broken, non-blocking), more consequential than anything in rounds 1-3. Escalating at round 4 per the default heuristic would have shipped that bug. 2026-07-04.)
+
+**CERTIFIED is not the finish line.** A CERTIFIED verdict and a green CI run are different verification layers that catch different bug classes — a CERTIFIED review does not substitute for actually pushing and watching CI. Confirmed on the same v1.84.0 release: after round-11 CERTIFIED and a full local test sweep, real CI still caught 3 more genuine bugs the review never touched — a content regression in an unrelated section silently dropped by an earlier edit (caught by a pre-existing local test that simply hadn't been re-run since), an environment-specific CLI output-format change invisible to any local run against an older tool version, and a new test file committed without the executable bit (passes every local `bash tests/foo.sh` invocation, only fails when CI runs it as `./tests/foo.sh`). Budget for at least one more fix-push-recheck cycle after CERTIFIED, and don't treat CERTIFIED as license to skip reading the actual CI logs — see the CI Feedback Loop section below.
 
 ```
 Claude writes code → handoff.json (round 1)
@@ -4289,7 +3922,7 @@ Claude writes code → handoff.json (round 1)
 
 **When to use this:**
 - High-stakes changes (auth, payments, data handling)
-- **Releases and publishes** (version bumps, CHANGELOG, npm publish) — see Release Review Checklist below
+- **Releases and publishes** (version bumps, CHANGELOG, npm publish) — see Release Review Focus below
 - Research-heavy work where accuracy matters more than speed
 - Complex refactors touching many files
 - Any time you want higher confidence before merging
@@ -4299,7 +3932,7 @@ Claude writes code → handoff.json (round 1)
 - Time-sensitive hotfixes
 - Changes where the review cost exceeds the risk
 
-#### Release Review Checklist
+#### Release Review Focus
 
 Before any release or npm publish, add these focus areas to the cross-model `review_instructions`:
 
@@ -4312,6 +3945,7 @@ Before any release or npm publish, add these focus areas to the cross-model `rev
 | Stale examples | Hardcoded version strings in docs/wizard match current release | Wizard examples showing v1.15.0 when publishing v1.20.0 |
 | Docs accuracy | README, ARCHITECTURE.md reflect current feature set | "8 workflows" when there are actually 7 |
 | CLI-distributed file parity | Live skills, hooks, settings match CLI templates | SKILL.md edited but cli/templates/ not updated |
+| Policy Migration Inventory | A repo-wide blanket-recommendation migration (changing a default model, effort, or policy) — enumerate EVERY surface stating the old value before round 1 | v1.84.0 ran 11 rounds because each round surfaced a new uninventoried surface: skill frontmatter, then setup wizard, then a live hook, then tutorial templates |
 
 **Example `review_instructions` for releases:**
 ```
@@ -4338,7 +3972,105 @@ Run them in parallel; collect feedback via `gh api repos/OWNER/REPO/pulls/PR/com
 
 Same handoff format. Adapt `review_instructions` (e.g. "verify each cited claim links to a primary source") and `verification_checklist` (specific claim → specific source). Add `"audience"` and `"stakes"` keys to the JSON so the reviewer knows what reading level / risk profile to apply.
 
----
+#### Parallel Blind Dual Review
+
+When two models review the same change, **run them in parallel and blind to each other, then merge the findings**. Do not chain them.
+
+**The rule:** neither reviewer sees the other's output, or your own responses to it, until both have reported. Give each the same diff, the same preflight, and the same instruction to attack. Then merge: treat any finding either one raises as real until disproved.
+
+**Why blindness, not just plurality.** A second reviewer shown the first's findings is *anchored* — it tends to confirm, refine, and extend what it was given rather than look where nobody has looked. You pay for two reviews and get one review plus a proofread. Measured on this repo 2026-07-27, across a four-round review of the merge gate: the **parallel blind** round produced findings that barely overlapped — one model found parsing and encoding defects, the other found a case-sensitivity hole that let a protected path merge clean, plus a policy-document regression neither the author nor the first model noticed. The **sequenced** rounds overlapped heavily by comparison. Both models independently found things that would have shipped otherwise.
+
+**Give both reviewers the SAME contract.** Same diff, same preflight, same severity scale, same fix policy — otherwise you cannot merge their findings or compare their verdicts, and you will not notice when one is grading on a different curve. Measured here 2026-07-29: one reviewer was given P0-P3 and the other HIGH/MEDIUM/LOW on the same change, which made two genuine reviews look like disagreement.
+
+| Severity | Meaning | Action |
+|---|---|---|
+| P0/P1 | Wrong behaviour, security, data loss, or a test that passes against broken code | **Fix before merge. Restarts the cycle.** |
+| P2 | Real defect, bounded blast radius. Inaccurate shipped prose belongs here | **Fix before merge.** Re-gate, no full restart |
+| P3 | Correctness or accuracy nit — a stale comment, an unclear message | Fix if cheap and it is about being *right* |
+| P3 (style) | Preference, naming, formatting with no correctness content | **Not review's job — encode it as a lint rule instead.** |
+
+**Style findings become lint rules, not review findings.** A cross-model round is expensive, slow, and non-deterministic; a linter is free, instant and total. If a reviewer raises a style point worth honouring, the fix is not "change this line" — it is *add the rule so nothing can ever violate it again*, then let the linter enforce it in every repo that installs this. That converts a recurring review cost into a one-time one. Run the linters **before** requesting review (`shellcheck -s bash` on changed `.sh` files, plus whatever your language uses) so no reviewer round is spent on what a deterministic tool already reports. Review exists for **correctness** — behaviour, security, and whether the tests actually test anything. If you find yourself lacking a standard rather than lacking a fix, the deliverable is the rule.
+
+Tell both reviewers this in the prompt, and tell them explicitly: **do not manufacture findings to appear thorough — "I found nothing real" is a valid and useful answer.** Without that instruction a reviewer under pressure to produce will generate P3s indefinitely, and you will mistake its output for unfinished work.
+
+**Diminishing returns — how to actually tell.** Judge by the *maximum severity per round*, never by finding count: count rises when a reviewer looks somewhere new, which is the opposite of a stopping signal (the round that found the most here also found the most serious bugs). You are converged when two consecutive rounds produce nothing above P3 **from reviewers that had not already cleared this code**. A single reviewer's own trend flattening means only that it has run out of defects *it* can see — one reviewer certified at high confidence here immediately before a fresh reviewer found six P1s in the same code.
+
+**Merging findings.** Combine, do not intersect. Two independent reviewers agreeing is a strong signal, but a finding raised by only one is the *common* case and is usually the valuable one — that is the entire point of using two. Respond to each reviewer's findings separately, and run the recheck round with each still blind to the other.
+
+**Cost control.** This is not free — each round costs wall-clock and, for a paid API reviewer, real money. Scale it to blast radius:
+
+| Change | Review |
+|---|---|
+| Live enforcement: CI config, hooks, agent config, the merge mechanism itself | Parallel blind dual review |
+| Ordinary application code | One reviewer at the pre-commit gate |
+| Docs, roadmap entries, comments | Neither |
+
+**Iterating vs. gating.** Looping with one reviewer while you build is cheap and effective — use the model that does not bill per token if you have one. But that reviewer is no longer independent by the end: it is reading code shaped by its own earlier feedback. So iterate with it freely, then run the **final** gate as a parallel blind round with a *fresh* instance of each model.
+
+**The loop, stated explicitly.** Reviewers returning findings is the normal case, not a setback, and the agent must not stop to ask permission each time. Run this until it terminates:
+
+```
+implement  →  fix every finding  →  re-review with the ITERATION model
+                    ↑                            ↓
+                    │                    findings? ──yes──┐
+                    │                            │        │
+                    └────────────────────────────┼────────┘
+                                                 no
+                                                 ↓
+                                    GATE: fresh parallel blind round
+                                                 ↓
+                                    findings? ──yes──→ back to the top
+                                                 ↓ no
+                                            ship it
+```
+
+**Rules that make it terminate rather than spin:**
+
+1. **Every finding gets a response before the next round** — FIXED, DISPUTED with reasoning, or ACCEPTED. Never silently drop one.
+2. **A dispute is a claim you owe evidence for.** If the reviewer rejects it and offers a concrete alternative, implement the alternative — you asked for an adversary, not an audience.
+3. **Any P0/P1 finding restarts the cycle from the top.** A gate round that surfaces a real defect was not a gate round, it was an iteration round. P2/P3-only findings do not need a full restart: fix them and re-run the gate. Either way the gate must eventually return *nothing new* — "findings?" in the diagram means any finding, and what differs is only whether you re-enter at iteration or at the gate.
+4. **Fixes need their own verification.** A fix shipped on the strength of "the reviewer suggested it" is unverified code — the reviewer proposed it, nobody has yet shown it works. A test that passes against broken code was never a test.
+
+   **TDD, applied to the fix: RED → GREEN.** Write the assertion, run it, watch **that specific assertion** fail, then implement and watch it pass. The common miss is observing red at the *suite* level — one assertion fails, the suite is red, you implement, the suite goes green, and any assertion that was green from birth is never noticed.
+
+   **Editing an existing test is the hard case, and the honest answer depends on what it guards.** If it guards a bug you are about to fix, RED is free — the bug exists, so the test fails for the right reason. If it guards behaviour that is **already correct**, **you cannot get RED**: correct code does not fail, and rewriting does not change that. Say so plainly rather than calling the assertion verified — an unverified regression test is exactly how this repo shipped eight that passed against broken code. When an assertion is load-bearing enough to justify it, breaking the behaviour once to watch the test go red is the only mechanism that validates that class; treat it as a deliberate exception, not the routine.
+
+   **Either way, prefer rewriting a suspect test over patching it.** Patching guesses which missing piece mattered; a rewrite from a known-good fixture with exactly one deliberate defect does not have to guess. Measured 2026-07-29/30: one test was found ineffective three separate times and patched twice — the rewrite worked first try.
+
+   **Rewrite rather than patch when:** the test passes where you would expect failure; its fixture is broken in more than one way, so you cannot tell which defect it detects; or it asserts on a substring present in both the pass and the fail message.
+
+   **Prefer executing the real thing over asserting on its source text.** A test that greps a script for the *words* proves the words are present, not that the behaviour works — the failure mode that produced every ineffective test in this repo's history. Run the script against a stub and check the exit code.
+
+5. **Verdict disagreement is expected — take the lower one.** Two reviewers can both be right and score differently: one weights a single unfixed P1 as disqualifying, the other weights overall structure. Do not average them, do not pick the friendlier one, and do not treat the gap as a reason to dismiss either. Ship only when *both* clear your bar.
+6. **Two stop conditions, and they are not the same — do not collapse them.** You are **done** when a fresh blind round returns **zero unresolved findings** — not merely "nothing new", because the same unfixed finding raised again is still an open finding. That is the only condition that permits shipping, and it is not reached on a schedule. You are **stuck** when rounds keep producing findings without converging; after 3 rechecks that is a non-convergence alarm, and it ends in escalation to the human with a summary of open findings — never in shipping. **Exception — a large migration may legitimately run past round 4** when each round is still surfacing real, previously-uninventoried surfaces (v1.84.0 ran 11 that way). Judge by whether the finding trend is genuinely converging, and state which of the two you are claiming. An agent that ships because it ran out of rounds has declared victory on a timer.
+
+**Anti-pattern: asking the human to adjudicate each round.** The human sets the bar and decides scope; the models find defects and you fix them. An agent that surfaces every finding for approval has converted an automated gate back into manual review, which is the cost the gate existed to remove.
+
+**If you only have one model available**, run it twice with genuinely different framings — for example once asked to find correctness defects and once asked to prove a specific safety property false — and treat the result as a single review, not two. It is meaningfully better than one pass and meaningfully worse than two models. Do not report it as dual review.
+
+**Do not show reviewers each other's work to "save a round."** That optimisation removes the only property this technique has.
+
+#### Multiple Reviewers (N-Reviewer Pipeline)
+
+When multiple reviewers comment on a PR (Claude, Codex, human reviewers), address each reviewer independently:
+
+1. **Read all reviews** — collect feedback from every active reviewer
+2. **Respond per-reviewer** — each reviewer has different blind spots. Address each one's findings separately
+3. **Resolve conflicts** — if reviewers disagree, pick the stronger argument, note why
+4. **Iterate until all approve** — don't merge until every active reviewer is satisfied
+5. **Max 3 iterations per reviewer** — escalate to user if a reviewer keeps finding new things
+
+The value of multiple reviewers: different models/humans catch different issues. No single reviewer is sufficient for high-stakes changes.
+
+#### Custom Subagents (`.claude/agents/`)
+
+Claude Code supports custom subagents in `.claude/agents/`. These run as independent subprocesses focused on a single task:
+
+- **`sdlc-reviewer`** — SDLC compliance review (planning, TDD, self-review checks)
+- **`ci-debug`** — CI failure diagnosis (reads logs, identifies root cause)
+- **`test-writer`** — Quality test writing following TESTING.md philosophies
+
+**Skills vs agents:** Skills guide Claude's behavior for a task type. Agents are independent subprocesses that run autonomously and return results. Use agents when you want parallel work or a fresh context window.
 
 ## User Understanding and Periodic Feedback
 

--- a/tests/lib/fence-only-assertions.py
+++ b/tests/lib/fence-only-assertions.py
@@ -1,0 +1,880 @@
+#!/usr/bin/env python3
+"""GH #513 — find assertions that verify a QUOTATION instead of the document.
+
+CLAUDE_CODE_SDLC_WIZARD.md carried a 639-line ````markdown fence introduced by
+"Step 6: Create SDLC Skill" — a second install path for the file the CLI already
+writes. Assertions were grepping the DOCUMENT for strings that exist only inside
+that fence (`### Release Review Focus`, `gh pr merge --auto`, `no stall watchdog
+and no timeout`), so they were verifying a copy of a draft the CLI does not
+install, cowork/ does not byte-check, and the #489 ceiling does not cover.
+
+Same defect class as PR #517's fixture, which committed dummy files as the
+"pristine gate" while executing the real script: a check that appears to verify
+X and actually verifies Y.
+
+MATCHING THE TARGET IS THE WHOLE POINT. The first version matched on the search
+STRING alone and flagged `grep -q "CODE_REVIEW_EXCEPTIONS.md" "$WORKFLOW"` — a
+test of pr-review.yml that never touches the wizard doc. A guard that cries wolf
+gets muted, which is worse than no guard, so a finding requires BOTH that the
+needle is fence-only AND that the grep actually targets the wizard document.
+
+WHAT COUNTS AS "INSIDE A FENCE" — TWO WRONG ANSWERS BEFORE THIS ONE.
+
+The first version tracked only lines starting with four backticks, because that
+is the fence the #513 copy happened to use. Deleting those fences made the guard
+silently vacuous: with zero four-backtick fences left, `outside` came out
+byte-identical to `doc`, so `needle in doc and needle not in outside` could never
+be true again. (An earlier note gave a byte count for that state; it was measured
+mid-development against a document neither `main` nor this branch now has, and no
+reachable tree reproduces it, so it is gone rather than left looking checkable.) A guard for the "appears to verify X,
+actually verifies Y" defect class had quietly become an instance of it.
+
+The obvious repair — strip EVERY fenced block — overshoots. Measured against the
+tree this ships in, it flags 19 live assertions across three suites
+(test-doc-consistency.sh, test-hooks.sh, test-self-update.sh), pinning `"verification_checklist"`,
+`"You are doing a TARGETED RECHECK`, `CHANGELOG completeness`, `SDLC Harness
+Version`, `SDLC Harness Update Check`, `gh issue create`, `issues: write` and
+`sparse-checkout` across test-self-update.sh and test-hooks.sh. Those live in a
+handoff.json schema example, a recheck-prompt template and workflow examples:
+legitimate document content a test SHOULD be able to pin. (An earlier version of
+this paragraph said four, counted before the promotion added document-level
+content — the argument got stronger and the stated number went stale.)
+
+So the scope is neither "four-backtick blocks" nor "all blocks" but the property
+that made the original assertions worthless: the block was a COPY OF THE SKILL.
+`skillcopy.copy_blocks` is the single definition of that, shared with the guard
+that forbids such blocks outright.
+
+That makes this guard DORMANT while the document is healthy and live the moment a
+copy reappears. Dormant-by-precondition is not vacuous-by-accident, and the
+difference is demonstrable: `--selftest` runs it against a synthetic document
+that HAS a copy, so the detector is exercised on every run rather than only when
+the repo is already broken.
+
+HOW IT READS SHELL — six ways the previous version silently missed real
+assertions (Codex round 2, all four confirmed by behavioural fixture):
+
+1. A HARD-CODED list of target variable names (WIZARD/WIZARD_DOC/WIZARD_FILE/DOC)
+   missed `$MANUAL`. It also missed `$SKILL`, which in
+   tests/test-memory-audit-protocol.sh:27 is assigned the WIZARD DOC despite its
+   name. Variable names are now RESOLVED
+   PER FILE from assignments, so the guard cannot fall behind a rename.
+2. Backslash-continued commands were invisible, and `grep ... \` chained with
+   `&&` is the dominant multi-condition idiom in this corpus. Continuations are
+   joined before matching.
+3. `grep -f patterns.txt target` takes its needles from a FILE, so no literal is
+   present to check. Skipping it silently is how a whole assertion form
+   disappears; it is now REPORTED as unverifiable, which is a true statement
+   about the guard's reach rather than a false claim of coverage. Zero instances
+   exist in the corpus today, so this cannot cry wolf on arrival.
+4. tests/test-doc-consistency.sh was excluded WHOLESALE because it contains
+   extractor machinery. Excluding a file to avoid parsing its heredocs discards
+   its real assertions too. Heredoc BODIES are now stripped everywhere — the
+   machinery is what lives in them — and no file is excluded.
+5. Three needle shapes were dropped with NO report: a case-insensitive `grep -i`,
+   a needle containing regex metacharacters, and any needle under 12 characters.
+   All three were mechanically resolvable from text already in hand, and one of
+   them — `grep -A 500 ... | grep -i 'content:.*cross-model review'` — was the
+   EXACT assertion this PR deletes, i.e. the shape the guard most exists to keep
+   out was invisible to it. Case is now folded, patterns are compiled in the
+   dialect grep would use, and the floor is 4 characters (the old 12 did no
+   false-positive work: a short needle that also appears OUTSIDE a copy is
+   legitimate on the `not in outside` test alone, which is the real
+   discriminator).
+6. `SECTION=$(awk '...' "$WIZARD")` — the corpus's dominant extraction idiom —
+   never resolved, because the assignment pattern stops at the first space and
+   captured `$(awk`. Every content check on the extract then passed silently.
+   Resolution is by TAINT, not parsing: a variable holding text extracted from
+   the wizard doc IS wizard-doc content, so line-level containment is the whole
+   rule. Rounds 2 through 8 of this file are all shell-parser patches; taint is
+   the last increment that pays.
+
+ACCEPTED LIMITS OF THE SHELL READING, and the decision to stop extending it.
+Rounds 2 through 9 of this module are all shell-parser repairs: shell has a rule
+this file did not model, a reviewer finds it, the rule gets modelled, the next
+round finds the next one. These are known-open and deliberately NOT patched:
+
+- `cat <<E"OF"` is delimiter `EOF` in bash. This reads tag `E`, finds no
+  terminator, and consumes to end of file, hiding any assertion after it.
+- A quoted string SPANNING LINES that contains `<<EOF` swallows the same way;
+  operand blanking is per line by design, because cross-line quote tracking
+  mis-syncs on one stray apostrophe and would blank the rest of a file.
+- `MANUAL=doc.md some_command` is a TEMPORARY assignment — `MANUAL` is empty
+  afterwards — but this treats it as persistent, so a later grep on `$MANUAL`
+  can be falsely condemned.
+- `2>/dev/null MANUAL=doc.md` IS a persistent assignment, but a leading
+  redirection ends prefix position here, so it is missed.
+
+They are open because the FIX IS NOT MORE PARSING. Narrowing to a closed grammar
+does not work either: `<<E"OF"` does not look out-of-grammar, it aliases silently
+INTO the grammar as tag `E`, so "report what you cannot parse" is unreachable
+without parsing shell well enough to know you cannot. GH #527 carries the ruling —
+replace all of this with a containment scan on the raw filename plus a sanctioned
+helper vocabulary, which is invariant under everything shell can do to disguise a
+line. That is a 27-file migration and belongs in its own PR.
+
+Living with them is bounded by the other guard: every one of these requires a
+SKILL COPY to be present in the wizard document, and skillcopy.py detects that
+markup-blind and fails the build. This module is defense-in-depth for an event
+that guard has already rejected, which is why its gaps degrade coverage rather
+than open a hole.
+
+WHERE THE UNVERIFIABLE REPORT IS AND IS NOT APPROPRIATE. It is for needles whose
+CONTENT this guard cannot know — `grep -f` reads them from another file, and an
+interpolated `$VAR` needle is unknown at scan time. Weakness in this guard's own
+matcher is NEVER grounds for it: reporting a shape the guard could resolve trades
+a silent miss for a noisy one and trains the reader to ignore the channel. The
+current tree produces zero offenders AND zero unverifiable reports, which is the
+bar any change here has to clear.
+
+Usage:
+    fence-only-assertions.py <repo-root>   check the real suites; exit 1 on offenders
+    fence-only-assertions.py --selftest    run the behavioural fixtures
+"""
+import glob
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import skillcopy                    # noqa: E402  (path set above)
+
+WIZARD_DOC = "CLAUDE_CODE_SDLC_WIZARD.md"
+
+# grep [flags] [--] "needle" <target>. The target is required and is what makes
+# this a wizard-doc assertion rather than some other file's.
+FLAGS = r"(?:-[a-zA-Z]+(?:\s+\d+)?\s+)*"
+GREP = re.compile(r"""grep\s+(%s)(?:--\s+)?(["'])(.{4,}?)\2\s+(\S+)""" % FLAGS)
+# The 90-char ceiling is NOT cosmetic here and must not be removed: this pattern
+# has no target to anchor against, so an unbounded needle span walks straight
+# through the closing quote and the file argument of an ORDINARY grep, capturing
+# `AGENTS\.md" "$WIZARD` as one needle. Removing it produced ~100 false reports
+# across the corpus (round 9, self-inflicted while fixing the 12-char floor).
+# A grep with NO file argument reads stdin — its target is whatever piped into
+# it. `grep -A 500 "## Heading" "$WIZARD" | grep -q "<needle>"` is the exact
+# shape of the two bogus assertions this PR deletes; matching only greps that
+# carry their own target makes the guard silent on the form most likely to
+# come back (Fable round 2, reproduced against the HEAD document).
+# The needle span must EXCLUDE its own delimiter. `.{4,90}?` walked straight
+# through the closing quote and the file argument of an ordinary grep, so
+# `grep -q "HIL" "$WIZARD"` captured `HIL" "$WIZARD` as a stdin needle. It was
+# invisible while `_judge` silently dropped anything containing `$`; making
+# interpolation reportable surfaced ~100 of them at once (round 9).
+GREP_STDIN = re.compile(
+    r"""grep\s+(%s)(?:--\s+)?(?:"([^"]{4,90})"|'([^']{4,90})')\s*(?=\||;|&&|\)|$)"""
+    % FLAGS, re.M)
+# grep -f/-F-with-f style: needles come from a file, so there is no literal here.
+GREP_PATTERN_FILE = re.compile(r"""grep\s+((?:-[a-zA-Z]+(?:\s+\d+)?\s+)*)-[a-zA-Z]*f[a-zA-Z]*\s+(\S+)\s+(\S+)""")
+# Assignments are found as TOKENS rather than anchored to the start of a line.
+# A line-anchored `KEYWORD? NAME=VALUE` regex kept losing real forms one variant
+# at a time: first bare-only (missed `local F=`), then keyword-only (missed
+# `local -r MANUAL=` and `declare -r`, and misresolved the multi-assignment
+# `local OTHER=x MANUAL=...` to OTHER while dropping MANUAL). Scanning for every
+# NAME=VALUE token handles flags, keywords and multi-assignment without
+# enumerating them, which is the enumeration that kept coming up short.
+# The VALUE may concatenate quoted and unquoted pieces: `"$ROOT"/CLAUDE_...md`
+# is one path, and a regex that stops at the closing quote captured only "$ROOT"
+# and lost the filename (Codex round 5). One-or-more alternating segments.
+ASSIGN = re.compile(
+    r"""(?:^|[\s;])([A-Za-z_][A-Za-z0-9_]*)="""
+    r"""((?:"[^"]*"|'[^']*'|[^\s;|&)]+)+)""", re.M)
+
+
+def strip_comments(text):
+    """Drop `#` comments so `# MANUAL=...` is not read as an assignment. A `#`
+    only starts a comment at the start of a line or after whitespace, and never
+    inside quotes — `grep "a#b"` and `${VAR#prefix}` must survive."""
+    out = []
+    for line in text.split("\n"):
+        q, i = None, 0
+        while i < len(line):
+            c = line[i]
+            if q:
+                # Same escape rule mask_argument_strings() uses: `\` escapes inside
+                # double quotes only. Without it an escaped `\"` closed the string
+                # early and a later `#` truncated a live line.
+                if c == "\\" and q == '"':
+                    i += 2
+                    continue
+                if c == q:
+                    q = None
+            elif c in "\"'":
+                q = c
+            elif c == "#" and (i == 0 or line[i - 1].isspace()):
+                line = line[:i]
+                break
+            i += 1
+        out.append(line)
+    return "\n".join(out)
+# `<<<word` is a here-STRING, so `(?!<)` excludes it outright. This pattern is
+# deliberately loose otherwise: `x << y` (a shift) and a quoted `'<<EOF'` both
+# match it, and no amount of regex tightening reliably tells them from a real
+# opener. The pattern is not asked to: strip_heredocs() runs it against a line
+# whose quoted spans and `$((...))` arithmetic have been blanked, so neither
+# shape is present to match by the time it is applied.
+# A heredoc DELIMITER is an arbitrary word, not an identifier. `cat <<'END-AWK'`
+# is valid shell, and an identifier-only pattern read that tag as `END`, failed to
+# find a terminator, and exposed the whole body (Codex round 9).
+HEREDOC = re.compile(r"""(?<!<)<<-?(?!<)\s*(['"]?)([A-Za-z_][-A-Za-z0-9_.]*)\1""")
+
+
+def join_continuations(text):
+    """Join backslash-continued lines so a multi-line `grep ... \\` is one unit."""
+    return re.sub(r"\\\n\s*", " ", text)
+
+
+def _blank_operand_spans(line):
+    """`line` with quoted spans and `$((...))` contents blanked to equal-length
+    runs of spaces. Used ONLY to locate shell OPERATORS, never to produce text.
+
+    Terminator-existence used to be the heredoc discriminator. It is not one, and
+    Codex round 8 broke it three ways: a quoted `'<<EOF'` STEALS a later real
+    `cat <<EOF`'s terminator and swallows everything between, an unterminated
+    heredoc leaves its body in scan as a false positive, and `cat <<A <<B` exposes
+    the second body. All three come from asking "does a terminator exist?" instead
+    of "is this text an operator at all?". Blanking operands answers the second
+    question directly, and a quoted or arithmetic `<<` simply is not there to match.
+
+    Per line, not across lines: a quoted string spanning a newline is not resolved
+    here. That bound is deliberate — cross-line quote tracking mis-syncs on a
+    single stray apostrophe and would silently blank the rest of a file.
+    """
+    out, i, n = list(line), 0, len(line)
+    while i < n:
+        c = line[i]
+        if c in "\"'":
+            # `cat <<'AWK'` quotes the TAG to suppress expansion. That quoted span
+            # IS the operator's operand, so blanking it erased the tag and the
+            # heredoc stopped being recognised at all.
+            head = line[:i].rstrip(" \t")
+            if head.endswith("<<") or head.endswith("<<-"):
+                close = line.find(c, i + 1)
+                i = (close + 1) if close != -1 else i + 1
+                continue
+            k = i + 1
+            while k < n:
+                if c == '"' and line[k] == "\\":
+                    k += 2
+                    continue
+                if line[k] == c:
+                    break
+                k += 1
+            if k >= n:                       # unterminated on this line
+                for j in range(i, n):
+                    out[j] = " "
+                break
+            for j in range(i, k + 1):
+                out[j] = " "
+            i = k + 1
+            continue
+        if line.startswith("$((", i):
+            k = line.find("))", i + 3)
+            k = (k + 2) if k != -1 else n
+            for j in range(i, k):
+                out[j] = " "
+            i = k
+            continue
+        i += 1
+    return "".join(out)
+
+
+def strip_heredocs(text):
+    """Remove heredoc BODIES. Extractor machinery (awk/python) lives in them, and
+    excluding whole files to dodge that machinery loses their real assertions.
+
+    Openers are located on the operand-blanked line, and EVERY opener on that line
+    is honoured in order, so `cat <<A <<B` consumes both bodies rather than leaving
+    the second one in scan. An opener with no terminator consumes to end of file,
+    which is what a real shell does — the alternative, keeping its body, put
+    assertion-shaped lines back into the scan as false positives.
+    """
+    lines = text.split("\n")
+    out, i = [], 0
+    while i < len(lines):
+        out.append(lines[i])
+        i += 1
+        for m in HEREDOC.finditer(_blank_operand_spans(lines[i - 1])):
+            tag = m.group(2)
+            end = next((k for k in range(i, len(lines))
+                        if lines[k].strip() == tag), None)
+            i = len(lines) if end is None else end + 1
+    return "\n".join(out)
+
+
+# A new simple command begins after these, so assignment-prefix position resumes.
+_KEYWORDS = {"if", "then", "else", "elif", "while", "until", "do", "done",
+             "for", "case", "esac", "time", "!", "{", "}"}
+# These take assignments as ordinary ARGUMENTS, not just as a command prefix.
+_DECLARING = {"local", "declare", "export", "readonly", "typeset"}
+_CMD_BREAK = set(";|&()")
+_SPACE = set(" \t")
+
+
+def mask_argument_strings(text):
+    """Blank the contents of quoted strings that are ARGUMENTS, keep those that
+    are assignment VALUES, and neutralise `NAME=` where shell would not read an
+    assignment at all. Consumed only by doc_vars().
+
+    POSITION is what decides, per POSIX 2.9.1: a simple command is a prefix of
+    assignments, then the command word, then arguments. So `MANUAL=doc.md cmd` is
+    an assignment and `echo MANUAL=doc.md` is not, and no amount of quote analysis
+    distinguishes them — round 8's false positive. Prefix position resumes after a
+    command separator or a shell keyword, and `local`/`declare`/`export`/
+    `readonly`/`typeset` accept assignments in argument position too. Outside those
+    positions the `=` is blanked, because ASSIGN scans for NAME=VALUE tokens with
+    no sense of position and would otherwise disagree with this function.
+
+    Within a value, quote DELIMITERS are dropped and backslash escapes resolved,
+    exactly as shell does. Preserving the delimiters kept `MANUAL=CLAUDE_CODE_
+    "SDLC"_WIZARD.md` from ever matching the document name (round 8), since the
+    quotes sat inside the value string. A value is any run of quoted and unquoted
+    segments in one word: once a word has passed `NAME=`, the rest of it is value.
+    """
+    out = []
+    for line in text.split("\n"):
+        buf, i, n = [], 0, len(line)
+        in_value = False                # this word already passed `NAME=`
+        word = []                       # the current word, quotes resolved
+        prefix, declaring = True, False
+
+        def end_word(assigned):
+            nonlocal prefix, declaring, word, in_value
+            w = "".join(word)
+            if not assigned:
+                if declaring and w.startswith("-"):
+                    pass                        # a flag, e.g. `local -r`
+                elif w in _DECLARING:
+                    declaring, prefix = True, False
+                elif w in _KEYWORDS:
+                    prefix, declaring = True, False
+                elif w:
+                    prefix, declaring = False, False
+            word, in_value = [], False
+
+        while i < n:
+            c = line[i]
+            if c in "\"'":
+                j, k = -1, i + 1
+                while k < n:
+                    if c == '"' and line[k] == "\\":
+                        k += 2
+                        continue
+                    if line[k] == c:
+                        j = k
+                        break
+                    k += 1
+                if j == -1:                     # unterminated on this line
+                    buf.append(line[i:])
+                    break
+                span = line[i + 1:j]
+                if in_value:
+                    buf.append(span)            # delimiters dropped, as shell does
+                    word.append(span)
+                else:
+                    # A masked span must be CONSUMED whole, delimiters included:
+                    # emitting only the opening quote left the closing one to be
+                    # read as an opener and masked across the newline.
+                    buf.append(c + " " * len(span) + c)
+                i = j + 1
+                continue
+            if in_value and c == "\\" and i + 1 < n:
+                buf.append(line[i + 1])
+                word.append(line[i + 1])
+                i += 2
+                continue
+            if c in _CMD_BREAK:
+                end_word(in_value)
+                prefix, declaring = True, False
+            elif c in _SPACE:
+                end_word(in_value)
+            elif c == "=" and not in_value:
+                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", "".join(word)):
+                    if prefix or declaring:
+                        in_value = True
+                    else:
+                        buf.append(" ")         # not an assignment; see docstring
+                        i += 1
+                        continue
+            else:
+                word.append(c)
+            buf.append(c)
+            i += 1
+        out.append("".join(buf))
+    return "\n".join(out)
+
+
+# `SECTION=$(awk '...' "$WIZARD")`. ASSIGN's value stops at the first space, so
+# it captured `$(awk` and SECTION never resolved — yet the corpus's dominant
+# extraction idiom is exactly this, and every content check on the extract then
+# passed silently (Fable round 8). Taint, not parsing: a variable holding text
+# EXTRACTED from the wizard doc is wizard-doc content, so greps against it are
+# assertions about the document. Line-level containment is the whole rule; the
+# module's history says the next increment of shell-parsing fidelity is where it
+# goes to die.
+SUBST_ASSIGN = re.compile(r"(?:^|[\s;])([A-Za-z_][A-Za-z0-9_]*)=\$\(")
+
+
+def doc_vars(text):
+    """Shell variables in this file that resolve to the wizard document.
+    Resolved from assignments rather than a hard-coded name list — that list is
+    what missed $MANUAL, and it would equally have missed $SKILL, which this
+    corpus really does assign to the wizard doc."""
+    raw = text
+    text = mask_argument_strings(text)
+    names = set()
+    for name, value in ASSIGN.findall(text):
+        if WIZARD_DOC in value:
+            names.add(name)
+    # One indirection: FOO="$WIZARD" where WIZARD already resolves.
+    for _ in range(3):
+        grew = False
+        for name, value in ASSIGN.findall(text):
+            if name in names:
+                continue
+            if any(re.search(r"\$\{?%s\}?\b" % re.escape(n), value) for n in names):
+                names.add(name)
+                grew = True
+        if not grew:
+            break
+    # Taint runs on the UNMASKED source: inside `$( ... )` the doc reference is a
+    # command ARGUMENT, which masking has already blanked by design.
+    for _ in range(3):
+        grew = False
+        for line in raw.split("\n"):
+            for name in SUBST_ASSIGN.findall(line):
+                if name in names:
+                    continue
+                if WIZARD_DOC in line or any(
+                        re.search(r"\$\{?%s\}?\b" % re.escape(n), line) for n in names):
+                    names.add(name)
+                    grew = True
+        if not grew:
+            break
+    return names
+
+
+def targets_doc(target, names):
+    if WIZARD_DOC in target:
+        return True
+    m = re.search(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", target)
+    return bool(m and m.group(1) in names)
+
+
+def scan_source(body, doc, outside, label):
+    """Offenders in one shell source. `doc`/`outside` are the wizard document and
+    the same document with skill-copy blocks removed.
+
+    Scanned per logical line, because a pipeline's target is established by its
+    FIRST command and inherited by everything downstream of the pipe."""
+    # Comments FIRST: a `<<EOF` mentioned inside a comment was opening a heredoc
+    # and swallowing everything to the next matching tag — 80 lines of
+    # tests/test-workflow-triggers.sh, 20 of tests/test-evaluate-bugs.sh. Any
+    # assertion added in a swallowed region would be invisible with no warning,
+    # which is this guard's own named enemy (Fable round 6).
+    body = strip_heredocs(strip_comments(join_continuations(body)))
+    names = doc_vars(body)
+    found = []
+    for line in body.split("\n"):
+        explicit = [(f, q, n, t) for f, q, n, t in GREP.findall(line)]
+        # Any token in the line that resolves to the wizard doc establishes the
+        # pipeline's subject — `sed -n '1,100p' "$WIZARD" | grep -q ...` has no
+        # grep target at all, so checking only grep targets misses it.
+        line_targets_doc = (WIZARD_DOC in line
+                            or any(v in names
+                                   for v in re.findall(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?", line)))
+        seen = set()
+        for flags, quote, needle, target in explicit:
+            seen.add(needle)
+            if "f" in flags.replace("-", "").replace(" ", ""):
+                continue                # handled by GREP_PATTERN_FILE
+            if not targets_doc(target, names):
+                continue
+            found += _judge(needle, doc, outside, label, f"target {target}", flags, quote)
+        # Greps with no file argument read stdin. If anything upstream in this
+        # pipeline resolves to the wizard doc, the needle is being asserted
+        # against the document just as surely as a direct grep.
+        if line_targets_doc:
+            for flags, dq, sq in GREP_STDIN.findall(line):
+                needle, quote = (dq, '"') if dq else (sq, "'")
+                if needle in seen:
+                    continue
+                found += _judge(needle, doc, outside, label,
+                                "piped from a wizard-doc command", flags, quote)
+        for _, patfile, target in GREP_PATTERN_FILE.findall(line):
+            if targets_doc(target, names):
+                found.append(f"    {label}: grep -f {patfile} (target {target}) "
+                             f"— needles come from a file; this guard cannot verify "
+                             f"them. Inline the literals or assert outside a fence.")
+    return found
+
+
+# grep's DIALECT decides what is a metacharacter, and getting this wrong is not a
+# detail: `(` is LITERAL in BRE, so treating the needle
+# `### Cross-Model Review Loop (REQUIRED` as a pattern reported a plain literal as
+# unverifiable — noise in the one channel that must stay trustworthy.
+_META_BRE = re.compile(r"[.*\[\]^$\\]")
+_META_ERE = re.compile(r"[.*+?\[\]^$(){}|\\]")
+_POSIX_CLASS = {"alpha": "a-zA-Z", "digit": "0-9", "alnum": "a-zA-Z0-9",
+                "space": " \\t\\n\\r\\f\\v", "blank": " \\t", "upper": "A-Z",
+                "lower": "a-z", "xdigit": "0-9A-Fa-f", "word": "a-zA-Z0-9_",
+                "punct": "!-/:-@\\[-`{-~", "graph": "!-~", "print": " -~",
+                "cntrl": "\\x00-\\x1f\\x7f"}
+
+
+def _to_python_re(pat, ere):
+    """A grep pattern as a Python one. POSIX classes have no Python equivalent,
+    and in BRE the characters `(){}+?|` are literal — Python treats every one of
+    them as syntax, so they must be escaped rather than passed through."""
+    pat = re.sub(r"\[:(\w+):\]",
+                 lambda m: _POSIX_CLASS.get(m.group(1), re.escape(m.group(0))), pat)
+    if ere:
+        return pat
+    out, i = [], 0
+    while i < len(pat):
+        c = pat[i]
+        if c == "\\" and i + 1 < len(pat):
+            nxt = pat[i + 1]
+            # In BRE the ESCAPED form is the operator: `\(` groups, `\+` repeats.
+            out.append(nxt if nxt in "(){}+?|" else c + nxt)
+            i += 2
+            continue
+        out.append("\\" + c if c in "(){}+?|" else c)
+        i += 1
+    return "".join(out)
+
+
+def _judge(needle, doc, outside, label, how, flags="", quote='"'):
+    """Does this needle exist ONLY inside a skill copy?
+
+    "Unverifiable" is reserved for needles whose CONTENT this guard cannot know —
+    `grep -f` reads them from another file. Weakness in this matcher is never
+    grounds for it, and treating it as such is how three shapes went silently
+    missing: a case-insensitive grep, a regex needle, and a short one. Each was
+    mechanically resolvable from text already in hand, and one of them —
+    `grep -A 500 ... | grep -i 'content:.*cross-model review'` — was the exact
+    deleted assertion this guard exists to keep out (Fable round 8).
+    """
+    # `$` is only INTERPOLATION in a double-quoted or unquoted needle, and only
+    # before a name, `{` or `(`. Inside single quotes shell expands nothing, so
+    # `'^### Heading[[:space:]]*$'` is a regex ANCHOR — and treating it as
+    # interpolation silently skipped four real doc-targeting assertions in this
+    # corpus (round 9). Genuine interpolation IS unknowable content, so it earns
+    # the unverifiable report rather than a silent skip.
+    if quote != "'" and re.search(r"\$[A-Za-z_{(]", needle):
+        return [f"    {label}: {needle!r} ({how}) — needle interpolates a shell "
+                f"variable, so its content is unknown at scan time; inline the "
+                f"literal or assert outside a fence"]
+    f = flags.replace("-", "").replace(" ", "")
+    ci = "i" in f
+    if "F" in f:                        # fixed-string: nothing is a metacharacter
+        meta = False
+    else:
+        meta = bool((_META_ERE if "E" in f else _META_BRE).search(needle))
+    if meta:
+        try:
+            # grep is LINE-oriented: `^` and `$` anchor to a line, not to the file.
+            # Without re.M they anchored to the whole document and every
+            # anchored pattern silently matched nothing (Codex round 10).
+            rx = re.compile(_to_python_re(needle, "E" in f),
+                            re.M | (re.I if ci else 0))
+        except re.error:
+            return [f"    {label}: {needle!r} ({how}) — needle is not a pattern "
+                    f"this guard can compile; verify by hand or inline a literal"]
+        inside = bool(rx.search(doc)) and not rx.search(outside)
+    elif ci:
+        inside = needle.lower() in doc.lower() and needle.lower() not in outside.lower()
+    else:
+        inside = needle in doc and needle not in outside
+    if inside:
+        return [f"    {label}: {needle!r} ({how}) "
+                f"— exists ONLY inside a skill-copy block"]
+    return []
+
+
+def run(root):
+    doc = open(os.path.join(root, WIZARD_DOC), encoding="utf-8").read()
+    skill = open(os.path.join(root, "skills", "sdlc", "SKILL.md"), encoding="utf-8").read()
+    outside = skillcopy.without_copies(doc, skill)
+    suites = (glob.glob(os.path.join(root, "tests", "*.sh"))
+              + glob.glob(os.path.join(root, "tests", "e2e", "*.sh")))
+    found = []
+    for path in suites:
+        body = open(path, errors="ignore", encoding="utf-8").read()
+        found += scan_source(body, doc, outside, os.path.basename(path))
+    return sorted(set(found))
+
+
+# --- selftest -------------------------------------------------------------
+# Every fixture is a form a reviewer proved the previous version missed, across
+# rounds 2 through 8. The round is named on each one.
+_FENCE_ONLY = "### Release Review Focus for the embedded copy"
+_DOC = ("real prose\n"
+        "````markdown\n"
+        "name: sdlc\n"
+        "## Full SDLC Checklist\n"
+        "## Confidence Check (REQUIRED)\n"
+        "## Cross-Model Review (REQUIRED for High-Stakes)\n"
+        + _FENCE_ONLY + "\n"
+        "tag: r8only\n"          # 9-char needle, under the retired 12 floor
+        "````\n"
+        "tail prose\n")
+_SKILL = skillcopy.SKILL_FIXTURE
+
+_CASES = [
+    ("hard-coded name list missed $MANUAL",
+     'MANUAL="$REPO/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("a variable named $SKILL that is really the wizard doc",
+     'SKILL="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$SKILL"\n' % _FENCE_ONLY, True),
+    # Codex round 3: `local VAR=...` is ordinary shell and the bare-assignment
+    # regex missed it, hiding the real `local F=...` assertion at
+    # tests/test-doc-consistency.sh:1817.
+    ("local VAR= declaration resolves",
+     'local MANUAL="$REPO/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    # Codex round 4: flags after the keyword, and multi-assignment where the
+    # FIRST name is not the document variable.
+    # Codex round 5: quoted+unquoted concatenation, and two false-positive shapes.
+    ("value concatenating a quoted var and an unquoted path resolves",
+     'MANUAL="$ROOT"/CLAUDE_CODE_SDLC_WIZARD.md\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("a commented-out assignment is not an assignment",
+     '# MANUAL="$R/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, False),
+    ("an assignment-looking string inside a command argument is not one",
+     'printf "MANUAL=CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, False),
+    # Self-attack on the quoted-span masker before handing it to reviewers. It is
+    # new and subtle, and one bug in it (not consuming a kept span, so the closing
+    # quote read as an opening one) already masked across a newline.
+    ("apostrophe inside a comment does not desync the scan",
+     "# don't do this\n"
+     'WIZ="CLAUDE_CODE_SDLC_WIZARD.md"\ngrep -q "%s" "$WIZ"\n' % _FENCE_ONLY, True),
+    ("a hash inside ${...} is not a comment",
+     'X="${P#pre}" WIZ="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$WIZ"\n' % _FENCE_ONLY, True),
+    ("an unterminated quote does not swallow the next line",
+     'echo "oops\nWIZ="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$WIZ"\n' % _FENCE_ONLY, True),
+    ("single quotes nested inside double quotes",
+     'echo "it\'s fine"\nWIZ="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$WIZ"\n' % _FENCE_ONLY, True),
+    ("local -r with a flag resolves",
+     'local -r MANUAL="$R/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("declare -r with a flag resolves",
+     'declare -r MANUAL="$R/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("multi-assignment resolves the RIGHT name, not the first",
+     'local OTHER=x MANUAL="$R/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("export/readonly declarations resolve",
+     'readonly WIZ="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$WIZ"\n' % _FENCE_ONLY, True),
+    ("backslash-continued command",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'if grep -q "other" "$WIZARD" \\\n'
+     '   && grep -q "%s" "$WIZARD"; then :; fi\n' % _FENCE_ONLY, True),
+    ("grep -qf reported as unverifiable rather than skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -qf "$EXPECT" "$WIZARD"\n', True),
+    ("assertion in a heredoc body is machinery, not an assertion",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'awk_prog=$(cat <<\'AWK\'\ngrep -q "%s" "$WIZARD"\nAWK\n)\n' % _FENCE_ONLY, False),
+    # Codex round 7: `<<` inside a quoted string, and the left-shift operator.
+    # Neither has a terminator, so the old stripper swallowed the whole rest of
+    # the file — every assertion after it invisible, with no warning.
+    ("a quoted <<EOF is not a heredoc opener",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'printf \'%%s\\n\' \'<<EOF\'\n'
+     'grep -q "%s" "$WIZARD"\n' % _FENCE_ONLY, True),
+    ("a left shift is not a heredoc opener",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'n=$((x << y))\n'
+     'grep -q "%s" "$WIZARD"\n' % _FENCE_ONLY, True),
+    # Codex round 7: shell concatenation. A quoted span belongs to an assignment
+    # VALUE when it is part of the same word as the `=`, not only when it sits
+    # immediately after it.
+    ("unquoted prefix before the quoted span resolves",
+     'MANUAL=prefix"$ROOT/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("quoted, unquoted, quoted concatenation resolves",
+     'MANUAL="$ROOT"/middle"/CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    # ...and the other direction: an escaped quote must not end the argument span
+    # and expose the text after it as an assignment.
+    ("an escaped quote does not expose a false assignment",
+     'printf "x \\" MANUAL=CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, False),
+    ("needle that also exists OUTSIDE the copy is legitimate",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "real prose and more text here" "$WIZARD"\n', False),
+    # Fable round 2, both reproduced against the HEAD document: the numeric flag
+    # argument broke the flag regex, and a piped grep carries no target token.
+    # These are the exact shape of the two bogus assertions this PR deletes, so
+    # they are the likeliest form for the defect to return in.
+    ("grep -A 500 on the doc piped into grep (numeric flag arg + pipe)",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -q "%s"\n' % _FENCE_ONLY, True),
+    ("sed on the doc piped into grep (no grep target at all)",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'sed -n \'1,100p\' "$WIZARD" | grep -q "%s"\n' % _FENCE_ONLY, True),
+    ("piped grep on an UNRELATED file stays clean",
+     'WORKFLOW=".github/workflows/pr-review.yml"\n'
+     'sed -n \'1,100p\' "$WORKFLOW" | grep -q "%s"\n' % _FENCE_ONLY, False),
+    ("assertion about a different file is not ours",
+     'WORKFLOW=".github/workflows/pr-review.yml"\n'
+     'grep -q "%s" "$WORKFLOW"\n' % _FENCE_ONLY, False),
+]
+
+
+# --- Codex round 8 -------------------------------------------------------
+# Heredoc openers are now located on the operand-blanked line, so neither a
+# quoted `<<TAG` nor an arithmetic shift is present to match. Terminator
+# existence is no longer consulted, which is what made all three of these fail.
+_CASES += [
+    ("a quoted '<<EOF' does not steal a later real terminator",
+     "WIZ=\"$REPO/CLAUDE_CODE_SDLC_WIZARD.md\"\n"
+     "printf '%%s\\n' '<<EOF'\n"
+     'grep -q "%s" "$WIZ"\n'
+     "cat <<EOF\nbody\nEOF\n" % _FENCE_ONLY, True),
+    ("an arithmetic shift does not steal a later real terminator",
+     "WIZ=\"$REPO/CLAUDE_CODE_SDLC_WIZARD.md\"\n"
+     "x=$(( 1 << 4 ))\n"
+     'grep -q "%s" "$WIZ"\n'
+     "cat <<4\nbody\n4\n" % _FENCE_ONLY, True),
+    ("two heredocs on one command consume BOTH bodies",
+     "WIZ=\"$REPO/CLAUDE_CODE_SDLC_WIZARD.md\"\n"
+     "cat <<A <<B\nalpha\nA\n"
+     'grep -q "%s" "$WIZ"\n'
+     "B\n" % _FENCE_ONLY, False),
+    ("an unterminated heredoc consumes to EOF rather than leaving a false one",
+     "WIZ=\"$REPO/CLAUDE_CODE_SDLC_WIZARD.md\"\n"
+     "cat <<EOF\n"
+     'grep -q "%s" "$WIZ"\n' % _FENCE_ONLY, False),
+]
+
+# A value concatenated out of quoted and unquoted pieces is ONE token, and shell
+# drops the delimiters. Preserving them kept the document name from ever matching.
+_CASES += [
+    ("a double-quoted segment inside an unquoted value still resolves",
+     'MANUAL=CLAUDE_CODE_"SDLC"_WIZARD.md\n'
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("a single-quoted segment inside an unquoted value still resolves",
+     "MANUAL=CLAUDE_CODE_'SDLC'_WIZARD.md\n"
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("a backslash-escaped character in a value still resolves",
+     "MANUAL=CLAUDE_CODE_SDLC_WIZARD\\.md\n"
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+]
+
+# POSIX 2.9.1: assignments live in the command PREFIX. Outside it, `NAME=` is an
+# ordinary argument, and reading it as an assignment fabricated a variable that
+# then falsely condemned a later grep on an unrelated `$MANUAL`.
+_CASES += [
+    ("a NAME= argument after the command word is NOT an assignment",
+     "echo MANUAL=CLAUDE_CODE_SDLC_WIZARD.md\n"
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, False),
+    ("an env-style assignment PREFIXING a command still resolves",
+     "MANUAL=CLAUDE_CODE_SDLC_WIZARD.md run_it\n"
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+    ("assignment position resumes after a shell keyword",
+     "if true; then MANUAL=CLAUDE_CODE_SDLC_WIZARD.md; fi\n"
+     'grep -q "%s" "$MANUAL"\n' % _FENCE_ONLY, True),
+]
+
+
+# --- Fable round 8: shapes that were SILENTLY skipped ---------------------
+# Each was mechanically resolvable from text the guard already had, so each was a
+# miss, not an unknowable. The first is the exact deleted assertion this whole
+# guard exists to keep out, which had been invisible to it the entire time.
+_CASES += [
+    ("a case-insensitive grep is folded, not skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -qi "%s" "$WIZARD"\n' % _FENCE_ONLY.upper(), True),
+    ("a BRE regex needle is compiled, not skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "### Release Review Focus.*embedded copy" "$WIZARD"\n', True),
+    ("an ERE regex needle is compiled, not skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -qE "Release (Review) Focus.+embedded" "$WIZARD"\n', True),
+    # `(` is LITERAL in BRE. Reading it as a group reported a plain literal as
+    # unverifiable, which is noise in the channel that must stay trustworthy.
+    ("an unbalanced paren in a BRE needle is a literal, not a bad pattern",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "### Release Review Focus (unmatched" "$WIZARD"\n', False),
+    # Expectation FLIPPED in round 10, and the old one encoded a bug: without
+    # re.M this anchored pattern could never match, so it "passed" by matching
+    # nothing at all. Per line it correctly finds the copy-only heading.
+    ("a POSIX character class resolves, and anchors per line",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -qE "^#+[[:space:]]+Release Review Focus" "$WIZARD"\n', True),
+    # The old floor was 12 characters and did no false-positive work: a short
+    # needle that also exists outside a copy is legitimate on the `not in outside`
+    # test alone, which is the real discriminator.
+    ("a short needle below the old 12-char floor is judged, not skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "r8only" "$WIZARD"\n', True),
+    # Command substitution: the corpus's dominant extraction idiom. ASSIGN stops
+    # at the first space, so SECTION never resolved and every content check on
+    # the extract passed silently.
+    ("a variable holding text extracted from the doc is tainted",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'SECTION=$(awk \'/^## /{p=1} p\' "$WIZARD")\n'
+     'echo "$SECTION" | grep -q "%s"\n' % _FENCE_ONLY, True),
+    ("a variable extracted from an UNRELATED file is not tainted",
+     'OTHER="README.md"\n'
+     'SECTION=$(awk \'/^## /{p=1} p\' "$OTHER")\n'
+     'echo "$SECTION" | grep -q "%s"\n' % _FENCE_ONLY, False),
+]
+
+
+# --- Codex round 10: repairs that had NO fixture protecting them -------------
+# Every one of these was verified by an ad-hoc script and then left unguarded, so
+# reverting the fix left the selftest green. A repair without a fixture is a
+# repair that regresses silently, which is this module's own named enemy.
+_CASES += [
+    # grep is LINE-oriented. Without re.M, `^`/`$` anchored to the whole document
+    # and every anchored needle silently matched nothing.
+    ("an anchored needle matches per LINE, not per document",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     "grep -q '^%s$' \"$WIZARD\"\n" % _FENCE_ONLY, True),
+    ("an anchored ERE needle with a POSIX class matches per line",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -qE \'^[[:punct:]]{3}[[:space:]]Release Review Focus\' "$WIZARD"\n', True),
+    # A heredoc DELIMITER is an arbitrary word; the identifier-only pattern read
+    # `END-AWK` as `END`, found no terminator, and exposed the body.
+    ("a hyphenated heredoc tag is a real opener",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     "cat <<'END-AWK'\n"
+     'grep -q "%s" "$WIZARD"\n'
+     "END-AWK\n" % _FENCE_ONLY, False),
+    # Genuine interpolation is unknowable content and EARNS the report; a
+    # single-quoted `$` is a regex anchor and must not be mistaken for it.
+    ("a double-quoted interpolated needle is reported, not skipped",
+     'WIZARD="CLAUDE_CODE_SDLC_WIZARD.md"\n'
+     'grep -q "$some_area" "$WIZARD"\n', True),
+]
+
+
+def selftest():
+    outside = skillcopy.without_copies(_DOC, _SKILL)
+    assert _FENCE_ONLY in _DOC and _FENCE_ONLY not in outside, \
+        "fixture document is not exercising the detector — the copy was not stripped"
+    bad = 0
+    for name, src, want in _CASES:
+        got = bool(scan_source(src, _DOC, outside, "fixture.sh"))
+        print(("PASS: " if got == want else "FAIL: ") + name)
+        bad += got != want
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
+    offenders = run(sys.argv[1] if len(sys.argv) > 1 else ".")
+    if offenders:
+        print("\n".join(offenders))
+        sys.exit(1)
+    sys.exit(0)

--- a/tests/lib/mdfence.py
+++ b/tests/lib/mdfence.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Markdown fence parsing shared by the GH #513 guards.
+
+Both guards need the same question answered — "is this line inside a fenced
+block?" — and they got it wrong in the same way for the same reason: they
+special-cased ```` because that was the fence the #513 defect happened to use.
+`fence-only-assertions.py` matched only lines starting with four backticks,
+which made it silently vacuous the moment those fences were deleted (`outside`
+became byte-identical to the document, so its `needle not in outside` test could
+never be true). Fence type is incidental; being fenced is the property.
+
+A fence opens on a run of >= 3 backticks or tildes and closes on a run of the
+SAME character at least as long, CARRYING NO INFO STRING. That asymmetry is
+what lets a ````-block legally contain ```-blocks, and it is why a parser that
+just toggles a boolean on every fence line mis-tracks nested examples.
+
+The info-string half is not decoration. Codex round 2 found this parser treating
+an inner ````markdown line as a close: the block ended early, the text after it
+was published as prose, and the scan desynced so badly that trailing prose was
+reported as a block body. Both #513 guards sit on top of this function, so that
+one omission could defeat both. `misnumbered_ordered_items` in
+tests/test-doc-consistency.sh already carried the rule ("A CLOSING fence carries
+no info string") — this file diverged from a solved problem instead of matching
+it, which is the DRY failure underneath the bug.
+
+Indentation follows the same source: CommonMark allows 0-3 leading spaces before
+a fence; 4 makes it an indented code block, not a fence.
+
+    blocks(text)   -> list of block bodies, each a list of lines
+    outside(text)  -> the document with every fenced block removed
+"""
+import re
+
+FENCE = re.compile(r"^( {0,3})(`{3,}|~{3,})(.*)$")
+
+
+def _scan(text):
+    """Yield (line, body_lines_or_None). body is None for lines outside any
+    fence and for the fence delimiters themselves."""
+    open_fence, body = None, []
+    for line in text.split("\n"):
+        m = FENCE.match(line)
+        if open_fence is None:
+            if m:
+                open_fence = (m.group(2)[0], len(m.group(2)))
+                body = []
+            else:
+                yield line, None
+            continue
+        if (m and m.group(2)[0] == open_fence[0]
+                and len(m.group(2)) >= open_fence[1]
+                and not m.group(3).strip()):        # a close carries no info string
+            yield None, body
+            open_fence, body = None, []
+            continue
+        body.append(line)
+    if open_fence is not None:      # unterminated fence — still a fenced region
+        yield None, body
+
+
+def blocks(text):
+    """Every fenced block's body, in document order."""
+    return [b for line, b in _scan(text) if b is not None]
+
+
+def outside(text):
+    """The document with every fenced block (and its delimiters) removed."""
+    return "\n".join(line for line, b in _scan(text) if b is None)
+
+
+# --- selftest -------------------------------------------------------------
+# Run directly: python3 tests/lib/mdfence.py
+# Each fixture is a bug that actually shipped or was caught in review, not a
+# hypothetical. Fixture names cite where they came from.
+_FIXTURES = [
+    # Codex round 2, P1. An inner fence with an info string is CONTENT.
+    ("info-string line cannot close",
+     "before\n````markdown\ninner1\n````markdown\ninner2\n````\nafter\n",
+     [["inner1", "````markdown", "inner2"]], ["before", "after"]),
+    # The asymmetry that makes a ````-block able to hold ```-blocks.
+    ("shorter run cannot close a longer fence",
+     "````\na\n```\nb\n````\nc\n", [["a", "```", "b"]], ["c"]),
+    # A ~~~ inside a ``` fence is content; a blind toggle swallows the document.
+    ("other fence char is content",
+     "```\na\n~~~\nb\n```\nc\n", [["a", "~~~", "b"]], ["c"]),
+    # 4 spaces is an indented code block, not a fence.
+    ("indent > 3 is not a fence", "before\n    ```\nplain\n", [], ["plain"]),
+    ("indent <= 3 is a fence", "before\n   ```\nx\n   ```\nafter\n",
+     [["x"]], ["before", "after"]),
+    # An unterminated fence must not publish the tail as prose.
+    # Guarding the info-string fix against OVERCORRECTION: a close whose only
+    # trailing content is whitespace is still a close. Tightening "no info
+    # string" into "nothing at all after the run" would silently stop closing
+    # real fences, which is the same class of failure in the other direction.
+    ("trailing whitespace still closes", "a\n```\nx\n```   \nb\n", [["x"]], ["b"]),
+    ("trailing tab still closes", "a\n```\nx\n```\t\nb\n", [["x"]], ["b"]),
+    ("a 0-3 space indented close works", "a\n```\nx\n   ```\nb\n", [["x"]], ["b"]),
+    # An unterminated fence must not publish the tail as prose. The trailing ""
+    # is the final newline's empty split element, not a parser artifact.
+    ("unterminated fence swallows the tail",
+     "before\n```\ntail\n", [["tail", ""]], ["before"]),
+]
+
+if __name__ == "__main__":
+    import sys
+    failed = 0
+    for name, doc, want_blocks, must_be_outside in _FIXTURES:
+        got = blocks(doc)
+        out = outside(doc)
+        if got != want_blocks:
+            print("FAIL %s: blocks %r != %r" % (name, got, want_blocks)); failed += 1
+        elif any(t not in out.split("\n") for t in must_be_outside):
+            print("FAIL %s: %r missing from outside %r" % (name, must_be_outside, out)); failed += 1
+        else:
+            print("ok   %s" % name)
+    sys.exit(1 if failed else 0)

--- a/tests/lib/skillcopy.py
+++ b/tests/lib/skillcopy.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""GH #513 — the wizard doc must not carry a second install path for the skill.
+
+CLAUDE_CODE_SDLC_WIZARD.md carried a 639-line ````markdown fence under "Step 6:
+Create SDLC Skill" telling the reader to hand-copy it into
+`.claude/skills/sdlc/SKILL.md` — the exact file `npx agentic-sdlc-wizard init`
+already writes from `skills/sdlc/SKILL.md`. Two install paths, one file: they
+diverged to 56,284 bytes against the live skill's 19,356, moving in opposite
+directions inside single PRs (#509 shrank the live skill 856 bytes while growing
+the fence 1,470).
+
+WHY THIS IS STRUCTURAL AND NOT A LENGTH THRESHOLD. The first version of this
+guard measured the longest four-backtick fence and failed above 100 lines. That
+check is wrong in both directions, and a reviewer proved all four cases: a
+legitimate unrelated 120-line example fails it, a 99-line second install path
+passes it, a 639-line copy in an ordinary ```-fence passes with a measured
+length of zero, and a copy split across two 80-line blocks passes. Length is not
+the property. The property is "this document IS a copy of the skill", so the
+guard asks that directly.
+
+THREE RULES, and they do NOT share a unit of analysis. That split is the whole
+design, arrived at only after eight rounds of the alternative.
+
+A. One REGION carrying >= HEADING_HITS of the skill's own headings (frontmatter
+   worth one hit). Quoting a section or two stays legal; reproducing does not.
+B. One REGION carrying the skill's frontmatter AND >= FRONTMATTER_MIN_LINES.
+   Rule A keys on heading TEXT, so renaming every heading evades it while the
+   file stays a perfectly usable second install path. Frontmatter plus real file
+   size does not care what the headings are called.
+C. The RAW DOCUMENT reproducing >= max(SPLIT_BODY_FLOOR, SPLIT_BODY_FRACTION of
+   the skill's substantive body lines) of that body prose. Markup-blind: no
+   fences, no blocks, no regions.
+
+WHY C IS MARKUP-BLIND AND A/B ARE NOT. C used to be block-scoped, and every
+block model it wore was itself an attack surface:
+
+  - A verbatim copy INDENTED FOUR SPACES carries no fence at all. `mdfence` sees
+    nothing, `copy_blocks` returned nothing, and the copy is byte-identical,
+    copyable from source, and a completely usable install path. The escape
+    required no obfuscation whatsoever (Fable round 8).
+  - The SAME complete renamed copy measured 105 or 131 reproduced body lines
+    purely by the attacker's choice of 3- vs 4-backtick wrapper, because the
+    skill contains four of its own ``` fences and a 3-backtick wrapper leaks
+    content out of the block model. A detection number that moves with the
+    attacker's formatting is a design smell, not a tuning problem.
+  - A copy in ONE region with renamed headings and no frontmatter had no rule
+    left: A keys on heading text, B on frontmatter, and C required two
+    body-contributing BLOCKS (Fable round 8).
+
+Raw text kills all three at once, because the property was never "rendered as a
+code block" — it is "present in the file the reader has open". A fence, a
+four-space indent and plain prose are equally copyable from source.
+
+A and B cannot follow C global. The live document legitimately carries 3 of the
+skill's 23 headings at document level (`## Confidence Check (REQUIRED)`,
+`## Task`, `### Memory Audit Protocol`) — exactly HEADING_HITS, so a global rule
+A fires on a healthy document. B needs a region to size at all. Both are also
+load-bearing and not redundant with C: A is the only rule that catches a DRIFTED
+copy (the historical fence shares just 4 body lines with today's skill, far under
+any C threshold, but 5 heading markers), and B is the only one that catches a
+renamed, paraphrased, still-loadable copy.
+
+So A and B keep regions, and `regions()` takes fenced blocks PLUS any run of
+blank-or-indented lines, with no CommonMark list-context analysis. That is
+deliberately over-inclusive, and safe only because of this asymmetry:
+
+    DETECTION MAY BE CRUDE AND AGGRESSIVE.
+    STRIPPING MUST BE PRECISE AND CONSERVATIVE.
+
+A false region costs a loud CI red that a human adjudicates. The same crudeness
+inside `without_copies()` would silently strip real prose and turn the assertions
+guard into a false-positive machine, which that guard names as worse than no
+guard at all. `mdfence` therefore stays a strict fence grammar and feeds only the
+stripping path.
+
+MEASURED, on the real files, 2026-08-08. The skill is 19,356 bytes, 254 lines,
+23 headings. Of its substantive body, 71 lines are DISTINCTIVE PROSE — template
+shapes are subtracted, because 29 of the rest are TodoWrite entries and more are
+table rows, boilerplate any document about this workflow legitimately carries.
+C's trigger is a preponderance of that corpus: 35. The live document reproduces
+1. A complete copy reproduces essentially all 71 whether it is fenced at three
+backticks, four, chopped into fragments, or indented four spaces — that
+invariance is what markup-blindness buys. `baseline_drift()` reports at half, so
+a closing margin surfaces at 18 rather than at 35.
+
+WHAT THIS GUARD IS FOR, which is the question four rule-C redesigns never asked.
+These are LINTS in a first-party repo where every author has commit rights and
+can edit the guard itself. No payload analysis was ever a security boundary. The
+contract:
+
+    EVERY ARTIFACT PRODUCIBLE BY PLAUSIBLE ACCIDENT MUST FIRE LOUDLY, ON SEVERAL
+    RULES AT ONCE. ARTIFACTS REQUIRING MULTIPLE DELIBERATE EVASION STEPS ARE THE
+    REVIEW PROCESS'S JOB, NOT THIS FILE'S.
+
+Measured against that bar the suite is complete. The realistic recurrence — a
+verbatim copy with frontmatter and headings intact, introduced by an instruction
+line — trips A, B, C and destination containment simultaneously. The artifact
+that beat A, B and C took four deliberate steps: rename every signature heading,
+split the frontmatter below rule B's size test, delete 54 of 71 distinctive prose
+lines while keeping every operational one, and write an install instruction that
+contradicts the do-not-hand-copy paragraph in the same document. That is not an
+accident this lint missed; it is sabotage, and it is still caught — by
+destination containment, because it had to name where to put the file.
+
+RULE C IS NOT REDESIGNED AGAIN. Four redesigns each answered the newest
+counterexample and lost to the next. The exhaustion argument in
+destination_mentions() says a fifth cannot succeed, not merely that four did not:
+payload-overlap counterexamples above the accident tier are answered by
+destination containment and by review, never by a new constant.
+
+RESIDUAL LIMITS, stated rather than papered over. A guard that claims
+completeness it does not have is the same defect class as one that silently
+cannot fire, so:
+
+- Destination containment is a SUBSTRING scan, so a COMPOSITIONAL path evades it:
+  "copy into `.claude/skills/sdlc/` as `SKILL.md`" names the destination without
+  ever spelling it as one string. Adjacent prose can also repurpose an allowlisted
+  line into an install instruction. Both are review-tier: they need the already
+  four-step A/B/C-evasive payload to matter, and neither is producible by accident.
+- The allowlist is keyed on normalised line text, so REFORMATTING an allowlisted
+  line fails the build loudly, and a legitimate instruction to repair the installed
+  file is flagged. Both resolve by editing the allowlist, where a reviewer sees the
+  reason. Failing loudly on a legitimate edit is the correct direction here; failing
+  silently on an install instruction is not.
+- A partial copy reproducing under HALF the skill's distinctive prose escapes
+  rules A, B and C. It does NOT escape destination containment if it tells the
+  reader where to install it, which is what makes it an install path at all.
+  An earlier version of this note claimed every such artifact was "quotation";
+  that was false and a reviewer disproved it with a 200-of-254-line usable skill.
+- Rule C is bounded by REWRITING. A copy that paraphrases the skill's prose
+  reproduces few exact lines and escapes. That is a genuinely different artifact
+  from the accidental divergence this guard exists to catch, and no structural
+  check distinguishes a paraphrase from independent writing.
+- Rule B fires on ANY region of >= FRONTMATTER_MIN_LINES containing a valid
+  `name: sdlc` line, with no corroborating skill content required. A long
+  troubleshooting block quoting that one line would be flagged. This is a loud,
+  human-adjudicated false positive accepted knowingly in exchange for
+  rename-proofness — B is the only rule a renamed copy cannot shed.
+- A copy that exists ONLY as an unfenced or indented region is detected by A/B/C
+  but never STRIPPED by `without_copies()`, so `fence-only-assertions.py` cannot
+  see needles inside it. Accepted: any tree containing such a copy is already a
+  failing build here, and the assertions guard is defense-in-depth for the same
+  event. It never needs to resolve a state this guard has already rejected.
+
+HISTORY OF RULE C, because the same mistake was made four times in different
+clothes and the record is worth more than the current design:
+  1. Union of markers across >= 2 blocks reaching 3. Fired on two legitimate
+     separated examples.
+  2. Union >= 6 across CONSECUTIVE blocks. Bought a FALSE NEGATIVE: the real
+     skill split into fragments separated by unrelated example blocks rejoins
+     byte-identical and scored ZERO. Adjacency was never the property.
+  3. Two arms — breadth (>= 2 markers per block, union 6) or a frontmatter
+     anchor (union 3). Wrong at both ends again.
+  4. Body-prose reproduction, still scoped to blocks and still requiring two
+     contributing blocks. Beat every heading attack, then lost to an indented
+     copy, a single-region copy, and its own wrapper-width sensitivity.
+  5. Markup-blind body prose over the raw document. Fixed all of the above, then
+     a 15% threshold fired on ordinary TodoWrite examples; subtracting the
+     boilerplate fixed THAT and opened the reverse hole, because in this skill
+     the boilerplate is the operational content, so an artifact can keep all of
+     it, drop the prose, and still install.
+Repairs 1-4 were each fitted to the last counterexample and each trusted a block
+model; dropping the block model ended that series. Repair 5 ended a different
+one: the remaining counterexample and a legitimate document differ by about 15
+lines OF THE SAME KIND, so no payload rule can separate them at all. That is why
+there is no repair 6 — see destination_mentions() for the argument, and note it
+is a claim that a fifth constant CANNOT work, not that four happened to fail.
+
+`fence-only-assertions.py` imports `copy_blocks` from here so that both #513
+guards agree on what "a copy of the skill" means, rather than each carrying its
+own approximation of it.
+
+Usage:
+    skillcopy.py <repo-root>   check the real files; exit 1 on offenders
+    skillcopy.py --selftest    run the behavioral fixtures
+"""
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mdfence import _scan, blocks   # noqa: E402  (path set above)
+
+HEADING_HITS = 3
+# The live document's legitimate frontmatter stub is 11 lines and elides its body
+# as `...rest of skill...`; a real SKILL.md is 250+. 25 clears both by a wide
+# margin, so the bound is not sitting on top of either case.
+FRONTMATTER_MIN_LINES = 25
+# Rule C keys on BODY REPRODUCTION of the RAW DOCUMENT — see the module docstring
+# for why four successive block-scoped designs each failed. The threshold is
+# max(SPLIT_BODY_FLOOR, floor(SPLIT_BODY_FRACTION x body lines)); on the current
+# 128-line body that is floor(19.2) = 19, i.e. 14.8% and not exactly 15%.
+#
+# MEASURED 2026-08-08: the live document reproduces 5 body lines against that 19.
+# A complete copy reproduces all 128 regardless of how it is wrapped. Body overlap
+# was CONSIDERED AND REJECTED in an earlier round on the grounds that the
+# historical 639-line fence shares only a handful of lines with the current skill.
+# That reasoning conflated two objects: the old fence had DRIFTED over months, and
+# rule A catches it anyway on 5 heading markers. What rule C must catch is a NEW
+# copy of the CURRENT skill, and such a copy shares body text by construction.
+# A PREPONDERANCE of the distinctive corpus, not "significant sharing". 15% was
+# never a statement about what a copy IS — it operationalised overlap, and genre
+# overlap disproved overlap as a signal. What makes an embedded artifact a second
+# INSTALL PATH is that it is most of the skill; anything less is quotation, which
+# this guard's own philosophy already calls legal. Pinned by acceptance test and
+# measured 2026-08-08, not asserted: live overlap 1 of 71 (2.9% of the trigger of
+# 35), while every reproduced attack carries ~100% of the corpus by construction.
+SPLIT_BODY_FRACTION = 0.5
+SPLIT_BODY_FLOOR = 12
+BODY_MIN_LEN = 24
+
+
+def _norm(line):
+    """A line reduced to its token stream: stripped, internal whitespace collapsed.
+    Comparing raw stripped lines let a complete copy escape by adding ONE extra
+    internal space per line — identical tokens, zero matches (Codex round 7).
+    Whitespace is formatting, and reformatting is not the paraphrase bound rule C
+    documents as its limit."""
+    return re.sub(r"\s+", " ", line.strip())
+
+
+# Shapes that are TEMPLATE, not prose. Enumerated deliberately rather than
+# classified: a "distinctiveness classifier" is another thing to be wrong about.
+_TEMPLATE = (
+    re.compile(r"^\|"),                       # table rows
+    re.compile(r"^\{\s*content:"),            # TodoWrite checklist entries
+    re.compile(r"^[A-Za-z_-]+:\s"),           # frontmatter / key: value lines
+)
+
+
+def _is_scaffolding(n):
+    """A line that is not distinctive PROSE — table rules and rows, TodoWrite
+    template entries, `key: value` lines, pure punctuation.
+
+    This is subtraction, and it is load-bearing rather than cosmetic. Rule C
+    assumed the skill's body was prose. Measured, 29 of 128 "body" lines were
+    TodoWrite entries and more were table rows — boilerplate that ANY document
+    about the same workflow legitimately contains, because they are the same
+    genre by design. Codex round 9 turned that into a live false positive:
+    adding five ordinary TodoWrite entries to the wizard doc raised overlap from
+    5 to 10 and failed the guard, and fourteen reached the trigger and branded
+    three unrelated regions a split copy. The headroom was never a property of
+    the document; it was a property of the document's current contents, and
+    ordinary documentation work moved it.
+
+    Subtracting these leaves 71 lines of actual prose, and live overlap falls
+    from 5 to 1 — which is what makes "body prose is what a copy IS" true rather
+    than merely stated."""
+    if any(p.match(n) for p in _TEMPLATE):
+        return True
+    return not re.search(r"[A-Za-z]", re.sub(r"[|\-:+=*_~\s]", "", n))
+
+
+def skill_body(skill_text):
+    """The skill's substantive prose lines — long enough to be distinctive, not
+    headings (rule A already keys on those), and not structural scaffolding."""
+    return {n for n in (_norm(l) for l in skill_text.split("\n"))
+            if len(n) >= BODY_MIN_LEN and not n.startswith("#")
+            and not _is_scaffolding(n)}
+
+
+def skill_signature(skill_text):
+    heads = {n for n in (_norm(l) for l in skill_text.split("\n"))
+             if re.match(r"^#{2,3} \S", n)}
+    m = re.search(r"""^name:\s*["\']?([^"\'\s#]+)""", skill_text, re.M)
+    return heads, (m.group(1) if m else None)
+
+
+# YAML quotes the value or not, interchangeably: `name: sdlc`, `name: "sdlc"`,
+# `name: \'sdlc\'` all load identically. Matching only the bare form let a
+# complete, loadable 30-line skill with renamed headings through rule B
+# untouched (Codex round 3).
+def _has_frontmatter(body, fm):
+    if not fm:
+        return False
+    # Quotes must BALANCE. Making each side independently optional accepted
+    # `name: "sdlc'` and `name: 'sdlc"` as valid skill frontmatter (Codex round 4)
+    # — forms YAML rejects, so treating them as a loadable skill is wrong in both
+    # directions.
+    e = re.escape(fm)
+    # A trailing `# comment` is valid YAML: `name: sdlc # canonical` parses to
+    # {"name": "sdlc"}. Rejecting it let a complete 254-line copy with renamed
+    # headings through rule B untouched (Codex round 5).
+    #
+    # But `#` only OPENS a comment after whitespace. `name: sdlc#canonical` loads
+    # as the value "sdlc#canonical" — a different skill — and accepting it fired
+    # rule B on an unrelated 31-line block (Codex rounds 6 and 7).
+    pat = re.compile(
+        r"""^name:\s*(?:%s|"%s"|'%s')(?:\s+#.*)?\s*$""" % (e, e, e))
+    return any(pat.match(_norm(l)) for l in body)
+
+
+def _block_marks(body, heads, fm):
+    marks = sorted({_norm(l) for l in body} & heads)
+    if _has_frontmatter(body, fm):
+        marks.append(f"frontmatter `name: {fm}`")
+    return marks
+
+
+def regions(doc_text):
+    """Candidate copy REGIONS for the per-region rules A and B: every fenced block
+    first (same order and indices `blocks()` yields, so `without_copies()` can keep
+    using those indices unchanged), then every maximal run of blank-or-indented
+    lines outside any fence.
+
+    An indented run is included with no CommonMark list-context analysis at all.
+    That is deliberately over-inclusive: nested list continuations get swept in
+    alongside genuine indented code blocks. It is safe HERE and only here, because
+    regions feed threshold rules whose failure is a loud CI red a human
+    adjudicates. The same crudeness inside `without_copies()` would silently strip
+    real prose and turn the assertions guard into a false-positive machine, which
+    is why `mdfence` stays a strict fence grammar and this lives here instead.
+
+    DETECTION MAY BE CRUDE AND AGGRESSIVE; STRIPPING MUST BE PRECISE AND
+    CONSERVATIVE. That asymmetry is the design rule, and it is what ends the
+    patch-toward-the-last-counterexample cycle rules A/B/C each went through.
+    """
+    out = list(blocks(doc_text))
+    run = []
+    for line, body in _scan(doc_text):
+        if body is not None:                 # inside a fence; blocks() has it
+            # A fence ENDS the pending run. Without this, three separate indented
+            # examples divided by unrelated fenced blocks merged into one region
+            # and falsely tripped rule A (Codex round 9).
+            if any(l.strip() for l in run):
+                out.append(run)
+            run = []
+            continue
+        if not line.strip() or line.startswith("    ") or line.startswith("\t"):
+            run.append(line)
+            continue
+        if any(l.strip() for l in run):
+            out.append(run)
+        run = []
+    if any(l.strip() for l in run):
+        out.append(run)
+    return out
+
+
+def copy_blocks(doc_text, skill_text):
+    """Every region that reproduces the shipped skill, as
+    (1-based region index, region lines, matched markers, rule).
+
+    Rules A and B are per-region. Rule C is evaluated on the RAW DOCUMENT TEXT,
+    markup-blind: it asks how much of the skill's body prose the file contains,
+    not how that content is packaged. A copy is equally usable fenced, indented
+    four spaces, or sitting in plain text, and the reader has the source file
+    open either way. Two independent escapes died with that change — a verbatim
+    4-space-indented copy, which no fence grammar can see at all, and a
+    single-region renamed copy, which no split-copy rule can see.
+
+    The measurement that forced it: block-scoped rule C scored the SAME complete
+    renamed copy at 105 or 131 body lines purely by the attacker's choice of
+    3- vs 4-backtick wrapper, because the skill contains four of its own ```
+    fences and a 3-backtick wrapper leaks content out of the block model. A
+    detection number that moves with the attacker's formatting is a design smell,
+    not a tuning problem. Raw text is wrapper-blind, chop-blind and indent-blind
+    in one move.
+
+    Rule A cannot follow it global: the document legitimately carries three of
+    the skill's headings at document level (`## Confidence Check (REQUIRED)`,
+    `## Task`, `### Memory Audit Protocol`), which equals HEADING_HITS, so a
+    global rule A fires on a healthy document. Rule B needs a region to size at
+    all. Both keep regions; only C goes global.
+    """
+    heads, fm = skill_signature(skill_text)
+    body_lines = skill_body(skill_text)
+    threshold = max(SPLIT_BODY_FLOOR, int(len(body_lines) * SPLIT_BODY_FRACTION))
+    found = []
+    regs = regions(doc_text)
+    for i, body in enumerate(regs, 1):
+        marks = _block_marks(body, heads, fm)
+        if len(marks) >= HEADING_HITS:
+            found.append((i, body, marks, "A"))
+        elif _has_frontmatter(body, fm) and len(body) >= FRONTMATTER_MIN_LINES:
+            found.append((i, body, marks, "B"))
+    already = {j for j, _, _, _ in found}
+    reproduced = {_norm(l) for l in doc_text.split("\n")} & body_lines
+    if len(reproduced) >= threshold:
+        # Attribution stays region-scoped even though detection is global: a
+        # region carrying skill body prose or a skill marker is part of the copy.
+        # A global breach with no such region attributes nothing, and strips
+        # nothing — see the residual limit in the module docstring.
+        for i, body in enumerate(regs, 1):
+            if i in already:
+                continue
+            hit = {_norm(l) for l in body} & body_lines
+            if hit or _block_marks(body, heads, fm):
+                found.append((i, body, sorted(hit)[:4], "C"))
+    return sorted(found)
+
+
+def without_copies(doc_text, skill_text):
+    """The document with skill-copy blocks removed and every other block's body
+    kept. Positional, so a line appearing both inside a copy and in real prose
+    survives — a line-identity filter would strip both."""
+    drop = {i for i, _, _, _ in copy_blocks(doc_text, skill_text)}
+    kept, n = [], 0
+    for line, body in _scan(doc_text):
+        if body is None:
+            kept.append(line)
+            continue
+        n += 1
+        if n not in drop:
+            kept.extend(body)
+    return "\n".join(kept)
+
+
+def _why(rule, marks):
+    if rule == "A":
+        return "reproduces %d of the shipped skill's headings" % len(marks)
+    if rule == "B":
+        return "carries the skill's frontmatter at real-file size (rename-proof rule)"
+    # Rule C attributes two kinds of block, and reporting both as body-line counts
+    # printed "reproduces 1+ body lines" for a block that reproduced none at all
+    # (Codex round 7). `marks` is a truncated SAMPLE for rule C, never a count.
+    return ("reproduces shipped skill body prose as part of a split copy" if marks
+            else "carries a shipped skill marker inside a split copy")
+
+
+def baseline_drift(doc_text, skill_text):
+    """Rule C fires at the threshold; this reports well BEFORE it, at half.
+
+    A guard whose only signal is its own failure gives no warning that the margin
+    is closing. The live document reproduces 1 of the skill's 71 DISTINCTIVE prose
+    lines against a trigger of 35 (measured 2026-08-08). If ordinary editing walks
+    that toward 35, the first anyone hears of it is a red build. Reporting at half
+    means growth surfaces at 18 with real room to respond, and it is a claim about
+    THIS repo's documents, so it lives in the live check and not in the fixtures."""
+    body_lines = skill_body(skill_text)
+    threshold = max(SPLIT_BODY_FLOOR, int(len(body_lines) * SPLIT_BODY_FRACTION))
+    n = len({_norm(l) for l in doc_text.split("\n")} & body_lines)
+    if n * 2 < threshold:
+        return []
+    return [f"document reproduces {n} of the skill's {len(body_lines)} body "
+            f"lines — past half of rule C's threshold of {threshold}. Not a copy "
+            f"yet; the margin is closing. Move the shared prose to one home."]
+
+
+# The install DESTINATION. Rules A/B/C all analyse the payload — which lines the
+# document shares with the skill. This does not: it asks whether the document
+# tells a reader WHERE TO PUT one.
+INSTALL_DESTINATIONS = (".claude/skills/sdlc/SKILL.md", "skills/sdlc/SKILL.md")
+
+# Sites where naming the destination is legitimate, each with its reason. A line
+# not on this list is a finding, resolved in review by removing it or adding it
+# here — where a reviewer sees it.
+DESTINATION_ALLOWLIST = {
+    "Run the installer. It writes `.claude/skills/sdlc/SKILL.md` for you:":
+        "tells the reader the CLI writes it — the opposite of a hand-copy instruction",
+    "canonical, and `skills/sdlc/SKILL.md` ships in the same npm package as this document,":
+        "names the canonical source to explain why hand-copying is wrong",
+    "version ships as `skills/sdlc/SKILL.md` — installed by `npx agentic-sdlc-wizard init`,":
+        "same, in the update path",
+    "See `.claude/skills/sdlc/SKILL.md` for the enforced checklist.":
+        "a pointer to the installed file, carrying no content to copy",
+    "├── .claude/skills/sdlc/SKILL.md          ✓ frontmatter OK":
+        "a line of illustrative CLI output, not an instruction",
+}
+
+
+def destination_mentions(doc_text):
+    """Lines naming the skill's install destination outside the allowlist.
+
+    WHY THIS EXISTS, and why it is not a fourth payload rule. Rules A, B and C
+    all ask which LINES the document shares with the skill. A reviewer built an
+    artifact — valid frontmatter, all 29 TodoWrite entries, all tables, headings
+    renamed, split across two blocks, 200 of the skill's 254 lines — that is a
+    usable install path and shares almost nothing with rule C's distinctive
+    corpus. It differs from a document that legitimately quotes the skill heavily
+    by about 15 lines OF THE SAME KIND OF CONTENT.
+
+    That is a proof obligation, and it fails. Any payload rule must put a
+    separating surface inside those 15 lines. Every candidate is spent: headings
+    lose to renaming, frontmatter-plus-mass to splitting, document overlap needs
+    a constant fitted in a 15-line window, region density cannot separate (a
+    legitimate 30-line excerpt block is 100% skill lines), and order cannot
+    (legitimate template reuse arrives in canonical order). Identity, structure,
+    mass, density, locality, order — that is the whole space. So:
+
+        WHEN THE LEGITIMATE DOCUMENT AND THE ATTACK ARTIFACT ARE BUILT FROM THE
+        SAME LINES, NO FUNCTION OF LINE-SHARING SEPARATES THEM.
+
+    The separating property is therefore not in the payload. What Codex's
+    artifact needs, and what heavy quotation never has, is the sentence "Copy
+    these blocks into `.claude/skills/sdlc/SKILL.md`". Documentation quotes the
+    skill to explain it; an install path must also say where to put it. The
+    destination survives every obfuscation the artifact does — rename it and the
+    reader cannot follow the instruction, so it stops being an install path. Same
+    primitive-selection principle as GH #527: pick the signal that is invariant
+    under every disguise the thing can wear and still work.
+
+    The record supports it: the original #513 defect announced itself as
+    "Create `.claude/skills/sdlc/SKILL.md`:". Accidents name their destination
+    plainly, because accidents are not hiding.
+    """
+    out = []
+    for i, line in enumerate(doc_text.split("\n"), 1):
+        if not any(d in line for d in INSTALL_DESTINATIONS):
+            continue
+        if _norm(line) in {_norm(k) for k in DESTINATION_ALLOWLIST}:
+            continue
+        out.append(f"line {i} names the skill's install destination outside the "
+                   f"allowlist — if this is not a hand-copy instruction, add it to "
+                   f"DESTINATION_ALLOWLIST with its reason: {line.strip()[:90]}")
+    return out
+
+
+def offenders(doc_text, skill_text):
+    return [
+        f"block {i} ({len(body)} lines) [rule {rule}] " + _why(rule, marks)
+        + (f": {', '.join(marks[:4])}" if marks else "")
+        for i, body, marks, rule in copy_blocks(doc_text, skill_text)
+    ]
+
+
+BODY = "\n".join("distinctive skill prose line number %02d here" % i
+                 for i in range(20))
+
+# The fixture skill needs SUBSTANTIVE body lines (>= BODY_MIN_LEN, not headings),
+# because rule C keys on body reproduction. An earlier fixture skill used the
+# literal word "body", which is 4 characters — so skill_body() was empty and no
+# fixture could exercise rule C at all. A fixture corpus that cannot reach the
+# rule it names is the vacuity this whole module exists to prevent.
+_PROSE = ["This is a distinctive line of shipped skill prose, number %02d." % i
+          for i in range(24)]
+
+SKILL_FIXTURE = "---\nname: sdlc\ndescription: full workflow\n---\n" + "\n".join(
+    "%s\n%s" % (h, _PROSE[n])
+    for n, h in enumerate([
+        "## Full SDLC Checklist", "## Confidence Check (REQUIRED)",
+        "## Cross-Model Review (REQUIRED for High-Stakes)",
+        "## Scope, DRY, Patterns, Legacy", "## Task", "## Plan Mode",
+        "## Prove It Gate (New Additions Only)"])) + "\n" + "\n".join(_PROSE[7:])
+
+
+def _split_copy(n, rename=False, decoy=False, respace=False):
+    """SKILL_FIXTURE chopped into n-line fenced fragments — the shape every
+    reviewer used to attack rule C."""
+    lines = [l for l in SKILL_FIXTURE.split("\n") if l != "---"]
+    if rename:
+        lines = [re.sub(r"^(#{1,6})\s+.*", r"\1 Renamed", l) for l in lines]
+    if respace:
+        # One extra internal space per line. The token stream is untouched, so
+        # this is reformatting, not the paraphrase rule C's stated bound allows
+        # to escape (Codex round 7).
+        lines = [l.replace(" ", "  ", 1) for l in lines]
+    out = []
+    for i in range(0, len(lines), n):
+        out.append("```markdown\n%s\n```\n" % "\n".join(lines[i:i + n]))
+        out.append("```bash\necho unrelated\n```\n" if decoy else "prose\n")
+    return "".join(out)
+
+
+def _bodyonly_copy():
+    """The fixture skill with its frontmatter removed and every heading renamed:
+    no heading text for rule A, no `name:` line for rule B. Only rule C is left,
+    so any fixture built on this isolates C — which is the point, since the
+    escapes Fable found were precisely copies that had shed A's and B's signals."""
+    lines = SKILL_FIXTURE.split("\n")
+    if lines and lines[0].strip() == "---":
+        lines = lines[lines.index("---", 1) + 1:]
+    return "\n".join(re.sub(r"^(#{1,6})\s+.*", r"\1 Step", l) for l in lines)
+
+
+def selftest():
+    copy = "\n".join(l for l in SKILL_FIXTURE.split("\n") if l != "---")
+    cases = [
+        ("four-backtick copy caught",
+         "intro\n````markdown\n" + copy + "\n````\n", True),
+        ("triple-backtick copy caught",
+         "intro\n```markdown\n" + copy + "\n```\n", True),
+        # Codex round 2: the previous version of this fixture was INEFFECTIVE —
+        # its first block already reached three markers on its own, so rule A
+        # caught it and rule C was never exercised. Fragments must each stay under
+        # rule A's heading bar for these to test what they claim to test.
+        # Rule C: the skill chopped into fragments. MEASURED, so the comment
+        # cannot drift from it: of the 6 regions flagged, the first two fire
+        # rule A (3 markers each) and the remaining four fire C. The fixture
+        # therefore exercises the MIXED A+C path, which is the one that hid a
+        # tail from without_copies() in round 8 — not a pure-C path.
+        ("copy split into fragments, caught by rule C", _split_copy(6), True),
+        ("copy split with every heading RENAMED still caught by rule C",
+         _split_copy(6, rename=True), True),
+        ("copy split with fragments separated by unrelated examples",
+         _split_copy(6, decoy=True), True),
+        # Codex round 7: renamed headings plus ONE extra internal space per line
+        # reproduced the token stream exactly and scored 3 body hits, because both
+        # sides compared raw stripped lines. Whitespace is formatting.
+        ("copy split with headings renamed AND every line re-spaced",
+         _split_copy(6, rename=True, respace=True), True),
+        # Codex round 2: rule A keys on heading TEXT, so a full copy with every
+        # heading renamed sails through it while remaining a usable install path.
+        ("full copy with every heading renamed, caught by rule B",
+         "```markdown\nname: sdlc\n## Step One\n## Step Two\n## Step Three\n"
+         + "prose line\n" * 25 + "```\n", True),
+        # Codex round 2 raised "a two-signature-heading copy". Mutation-testing
+        # showed rule A already catches it, because the frontmatter line is the
+        # third marker — so this fixture documents rule A, not rule B. Labelling
+        # it "rule B" would be a test asserting something it does not prove.
+        ("real-size copy, frontmatter + two headings, caught by rule A",
+         "```markdown\nname: sdlc\n## Full SDLC Checklist\n"
+         "## Confidence Check (REQUIRED)\n" + "prose line\n" * 25 + "```\n", True),
+        # The live doc carries a legitimate 11-line stub that opens `name: sdlc`
+        # and elides the body as `...rest of skill...`. Failing on frontmatter
+        # alone would flag it, so frontmatter is one hit, not a verdict.
+        # Codex round 3: a complete, loadable 30-line skill using valid quoted
+        # YAML and renamed headings returned ZERO offenders — rule B matched only
+        # the bare `name: sdlc` line.
+        ("quoted YAML frontmatter + renamed headings, caught by rule B",
+         '```markdown\nname: "sdlc"\n## Alpha\n## Beta\n'
+         + "prose line\n" * 30 + "```\n", True),
+        ("single-quoted YAML frontmatter also counts",
+         "```markdown\nname: \'sdlc\'\n## Alpha\n"
+         + "prose line\n" * 30 + "```\n", True),
+        # Codex round 3 REPRODUCED the rule-C false positive: two legitimate,
+        # separated examples quoting 2 headings and 1 heading summed to 3.
+        ("two separated legitimate examples do NOT trip rule C",
+         "```\n## Full SDLC Checklist\n## Confidence Check (REQUIRED)\n```\n"
+         + "prose\n" * 40
+         + "```\n## Cross-Model Review (REQUIRED for High-Stakes)\n```\n", False),
+        # Codex round 4: adjacency was the wrong axis. The real skill split into
+        # ordered fragments SEPARATED BY UNRELATED EXAMPLES rejoins byte-identical
+        # to the skill, and the consecutive-blocks rule reported zero.
+        # Codex round 5, both sides of the old single threshold.
+        ("seven independent ONE-heading examples do NOT fire",
+         "".join("prose\n```markdown\n%s\n```\n" % h for h in
+                 ["## Full SDLC Checklist", "## Confidence Check (REQUIRED)",
+                  "## Cross-Model Review (REQUIRED for High-Stakes)",
+                  "## Scope, DRY, Patterns, Legacy", "## Task", "## Plan Mode",
+                  "## Prove It Gate (New Additions Only)"]), False),
+        ("valid YAML inline comment is still frontmatter",
+         '```markdown\nname: sdlc # canonical skill name\n## Alpha\n'
+         + "prose\n" * 30 + "```\n", True),
+        # Codex rounds 6 AND 7: `#` only starts a YAML comment after whitespace, so
+        # this line loads as {"name": "sdlc#canonical"} — a different skill. Letting
+        # it count as frontmatter fired rule B on an unrelated 31-line block.
+        ("name: sdlc#canonical is a different value, not a comment",
+         '```markdown\nname: sdlc#canonical\n## Alpha\n'
+         + "prose\n" * 30 + "```\n", False),
+        # Codex round 4: independently-optional quotes accepted forms YAML rejects.
+        ("unbalanced frontmatter quotes are NOT valid frontmatter",
+         '```markdown\nname: "sdlc\'\n## Alpha\n' + "prose\n" * 30 + "```\n", False),
+        ("frontmatter-only stub passes",
+         "```yaml\nname: sdlc\ndescription: x\n...rest of skill...\n```\n", False),
+        ("frontmatter plus two headings caught",
+         "```yaml\nname: sdlc\n## Full SDLC Checklist\n"
+         "## Confidence Check (REQUIRED)\n```\n", True),
+        ("legitimate 200-line unrelated example passes",
+         "```bash\n" + "echo hi\n" * 200 + "```\n", False),
+        ("quoting two skill headings passes",
+         "```\n## Full SDLC Checklist\n## Confidence Check (REQUIRED)\n```\n", False),
+        # Fable round 8, finding 1. A verbatim copy indented four spaces renders
+        # as a code block, is copyable from source, and is a fully usable second
+        # install path. It carries NO fence, so no fence grammar can see it — the
+        # escape needed zero obfuscation and defeated both #513 guards outright.
+        ("a VERBATIM copy indented four spaces is caught",
+         "Copy this into `.claude/skills/sdlc/SKILL.md`:\n\n"
+         + "\n".join("    " + l for l in SKILL_FIXTURE.split("\n")) + "\n", True),
+        ("ordinary indented prose is not a copy",
+         "Notes:\n\n" + "\n".join("    a plain indented continuation line %d" % i
+                                   for i in range(40)) + "\n", False),
+        # Fable round 8, finding 5. Rule A keys on heading TEXT and B on
+        # frontmatter, so a single region that renames every heading and drops the
+        # frontmatter had no rule left: the old rule C required TWO body-
+        # contributing blocks and this is one. Global C has no block count to game.
+        ("a single-region copy with every heading renamed is caught",
+         "````markdown\n" + _bodyonly_copy() + "\n````\n", True),
+        # The same copy chopped into small blocks. A BLOCK-scoped rule C scored
+        # the identical copy differently depending on the attacker's wrapper
+        # width, because a skill containing its own ``` fences leaks content out
+        # of the block model. Global C measures raw text and scores both alike.
+        ("the same copy chopped into many small blocks is caught",
+         "".join("```markdown\n" + "\n".join(_bodyonly_copy().split("\n")[i:i + 6])
+                 + "\n```\n\nprose\n\n"
+                 for i in range(0, len(_bodyonly_copy().split("\n")), 6)), True),
+        ("the same copy indented four spaces, headings renamed, is caught",
+         "\n".join("    " + l for l in _bodyonly_copy().split("\n")) + "\n", True),
+        # Codex round 10: regions() must FLUSH a pending indented run when a fence
+        # interrupts it. Without the flush these three separated one-heading
+        # examples merge into a single four-line region and trip rule A.
+        # DISTINCT headings on purpose: _block_marks() is a SET, so three copies
+        # of one heading count once and the fixture could never discriminate.
+        ("separate indented examples divided by fences do NOT merge",
+         "".join("    %s\n\n```bash\necho x\n```\n\n" % h for h in _HEADS3), False),
+    ]
+    bad = 0
+    # Destination containment. The artifact that beat rules A, B and C is caught
+    # here, and heavy quotation WITHOUT an install instruction stays legal —
+    # which is the whole distinction, since the two share most of their lines.
+    _SKILLCOPY = _bodyonly_copy()
+    for name, doc, want in [
+        ("an install instruction naming the destination is caught",
+         "Copy these blocks in order into `.claude/skills/sdlc/SKILL.md`\n\n"
+         "````markdown\n" + _SKILLCOPY + "\n````\n", True),
+        ("the same blocks WITHOUT an install instruction are not a destination finding",
+         "````markdown\n" + _SKILLCOPY + "\n````\n", False),
+        ("the historical `Create .claude/skills/sdlc/SKILL.md:` header is caught",
+         "Create `.claude/skills/sdlc/SKILL.md`:\n\n```markdown\nname: sdlc\n```\n", True),
+        ("the canonical source path is caught when it is a NEW mention",
+         "Paste this into `skills/sdlc/SKILL.md` to install it.\n", True),
+        ("an allowlisted site is legal",
+         "See `.claude/skills/sdlc/SKILL.md` for the enforced checklist.\n", False),
+    ]:
+        got = bool(destination_mentions(doc))
+        print(("PASS: " if got == want else "FAIL: ") + name)
+        bad += got != want
+    # Template subtraction is a CORPUS decision, not a document one, so it needs
+    # direct assertions — reverting it left every document fixture green while
+    # the live false positive came straight back (Codex round 10).
+    for line, want, why in [
+        ("| External APIs | YES | Real calls = flaky + expensive |", True, "table row"),
+        ("|--------|--------|--------|", True, "table rule"),
+        ('{ content: "Run lint/typecheck", status: "pending" },', True, "TodoWrite entry"),
+        ("argument-hint: \"[task description]\"", True, "key: value line"),
+        ("This is a distinctive line of shipped skill prose, number 01.", False,
+         "actual prose"),
+    ]:
+        got = _is_scaffolding(_norm(line))
+        print(("PASS: " if got == want else "FAIL: ")
+              + "%s is %sscaffolding" % (why, "" if want else "NOT "))
+        bad += got != want
+    for name, doc, want in cases:
+        got = bool(offenders(doc, SKILL_FIXTURE))
+        print(("PASS: " if got == want else "FAIL: ") + name)
+        bad += got != want
+    bad += _attribution_cases()
+    return 1 if bad else 0
+
+
+# Codex round 7: a mixed construction where rule A absorbs most of the copy. The
+# table above only asks "did anything fire", which cannot see this — rule A fires
+# on block 1 either way. What matters is whether block 2 is ATTRIBUTED, because
+# without_copies() strips only attributed blocks and an unstripped fragment is
+# exactly where a fence-only needle survives.
+_HEADS3 = ["## Full SDLC Checklist", "## Confidence Check (REQUIRED)",
+           "## Cross-Model Review (REQUIRED for High-Stakes)"]
+
+
+def _mixed(n_in_first):
+    return ("```markdown\n" + "\n".join(_HEADS3 + _PROSE[:n_in_first]) + "\n```\n"
+            "prose\n"
+            "```markdown\n" + _PROSE[11] + "\n```\n")
+
+
+def _attribution_cases():
+    body = len(skill_body(SKILL_FIXTURE))
+    threshold = max(SPLIT_BODY_FLOOR, int(body * SPLIT_BODY_FRACTION))
+    assert threshold == 12, "fixture skill no longer sits at the floor: %d" % threshold
+    bad = 0
+    for name, doc, want in [
+        # 11 body lines inside the rule-A block + 1 outside == the threshold.
+        ("rule-A block's body lines count toward rule C's threshold",
+         _mixed(11), True),
+        # 10 + 1 is under it, so block 2 must stay unattributed — proves the
+        # threshold is doing the work and attribution is not unconditional.
+        ("under the threshold, the trailing fragment is NOT attributed",
+         _mixed(10), False),
+    ]:
+        blocks_found = {i for i, _, _, _ in copy_blocks(doc, SKILL_FIXTURE)}
+        assert 1 in blocks_found, "%s: rule A should always catch block 1" % name
+        got = 2 in blocks_found
+        print(("PASS: " if got == want else "FAIL: ") + name)
+        bad += got != want
+    return bad
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    doc = open(f"{root}/CLAUDE_CODE_SDLC_WIZARD.md", encoding="utf-8").read()
+    skill = open(f"{root}/skills/sdlc/SKILL.md", encoding="utf-8").read()
+    found = (offenders(doc, skill) + destination_mentions(doc)
+             + baseline_drift(doc, skill))
+    if found:
+        print("\n".join("    " + f for f in found))
+        sys.exit(1)
+    sys.exit(0)

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -205,6 +205,31 @@ else
   fail "cowork/skills/sdlc/SKILL.md or canonical skills/sdlc/SKILL.md missing"
 fi
 
+# Test 5b: this repo's own dogfooded skill matches canonical (GH #513)
+#
+# `.claude/skills/sdlc` is a TRACKED SYMLINK (mode 120000 -> ../../skills/sdlc),
+# so this diffs the canonical file against itself and cannot fail on a normal
+# checkout. That is not a defect and not a vacuous test: it is a regression guard
+# for someone replacing the symlink with a real, driftable copy — exactly the
+# second-source problem #513 is about. Stated plainly because a test whose
+# comment oversells what it detects is the defect class this suite polices
+# (Fable round 6).
+#
+# cowork/ was byte-checked and .claude/ was not, so .claude/skills/sdlc/SKILL.md
+# could drift from the file consumers actually receive while every suite stayed
+# green — and this repo dogfoods that copy, so drift there means we run a
+# different skill than we ship. #513 removed a second install path in the wizard
+# doc for exactly this destination; this closes the same gap on disk.
+if [ -f "$PROJECT_ROOT/.claude/skills/sdlc/SKILL.md" ] && [ -f "$PROJECT_ROOT/skills/sdlc/SKILL.md" ]; then
+  if diff -q "$PROJECT_ROOT/.claude/skills/sdlc/SKILL.md" "$PROJECT_ROOT/skills/sdlc/SKILL.md" >/dev/null 2>&1; then
+    pass "repo-local .claude sdlc skill matches canonical"
+  else
+    fail "repo-local .claude/skills/sdlc/SKILL.md DRIFTED from canonical (run: cp skills/sdlc/SKILL.md .claude/skills/sdlc/SKILL.md)"
+  fi
+else
+  fail ".claude/skills/sdlc/SKILL.md or canonical skills/sdlc/SKILL.md missing"
+fi
+
 # Test 6: feedback skill matches canonical
 if [ -f "$PROJECT_ROOT/cowork/skills/feedback/SKILL.md" ] && [ -f "$PROJECT_ROOT/skills/feedback/SKILL.md" ]; then
   if diff -q "$PROJECT_ROOT/cowork/skills/feedback/SKILL.md" "$PROJECT_ROOT/skills/feedback/SKILL.md" >/dev/null 2>&1; then
@@ -545,8 +570,9 @@ fi
 #
 # Cowork consumers receive SIX files — README, hooks.json, two plugin manifests,
 # and the two SKILL.md copies. They never receive CLAUDE_CODE_SDLC_WIZARD.md,
-# and there is no mechanism to give it to them: it is 291 KB against a 44 KB
-# plugin, written for a CLI Cowork does not have.
+# and there is no mechanism to give it to them: it is 271 KB (277,908 bytes)
+# against a 35 KB plugin (35,627 bytes across those six files, measured
+# 2026-08-08), written for a CLI Cowork does not have.
 #
 # So every "full protocol: wizard doc" pointer in the skill is a dangling
 # reference for those users, and GH #489 is adding more of them as content moves

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1967,7 +1967,24 @@ test_escalation_ladder_order_and_threshold
 test_parallel_blind_dual_review() {
     local WIZARD="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
     local SECTION
-    SECTION=$(awk '/^### Parallel Blind Dual Review/{f=1; next} /^### /{f=0} f' "$WIZARD")
+    # Heading DEPTH is not the contract; the section's existence and content are.
+    # GH #513 promoted this out of the Step 6 skill template into document-level
+    # policy, which nested it one level deeper (### -> ####). Matching a fixed
+    # depth would have failed on a change that strictly improved the doc, so the
+    # pin now accepts either and terminates on a sibling-or-shallower heading.
+    # The title is anchored end-to-end and the terminator depth is DERIVED from
+    # whatever depth actually matched, not hardcoded. Without the end anchor a
+    # future "### Parallel Blind Dual Review — deprecated" section would satisfy
+    # the pin; with a hardcoded `^#{1,4} ` terminator a ##### subsection inside
+    # the section would truncate it and the content checks below would pass on a
+    # fragment.
+    SECTION=$(awk '
+        !f && /^#+ Parallel Blind Dual Review[[:space:]]*$/ {
+            match($0, /^#+/); depth = RLENGTH; f = 1; next
+        }
+        f && /^#+ / { match($0, /^#+/); if (RLENGTH <= depth) { f = 0 } }
+        f
+    ' "$WIZARD")
 
     if [ -n "$SECTION" ]; then
         pass "wizard doc has a Parallel Blind Dual Review section"
@@ -3306,6 +3323,105 @@ test_skill_states_loop_autonomy_rule() {
     fi
 }
 test_skill_states_loop_autonomy_rule
+
+# --- GH #513 ---------------------------------------------------------------
+#
+# The wizard doc CARRIED a 639-line ````markdown fence introduced by "Step 6:
+# Create SDLC Skill / Create `.claude/skills/sdlc/SKILL.md`:". That MADE it a
+# SECOND INSTALL PATH for the same destination the CLI writes, and the two had
+# diverged: 56,284 bytes against the live skill's 19,356, moving in opposite
+# directions inside single PRs (#509 shrank the live skill 856 bytes while
+# growing the fence 1,470).
+#
+# One skill, one install path. The CLI is canonical, and `skills/sdlc/SKILL.md`
+# ships in the same npm package as this document — so a reader following the doc
+# already has the real file next to the instructions.
+test_wizard_doc_ships_no_second_install_path_for_the_skill() {
+    local f="$REPO_ROOT/CLAUDE_CODE_SDLC_WIZARD.md"
+    [ -f "$f" ] || { fail "wizard doc missing"; return; }
+    # Length is NOT the discriminator, though the first version of this guard
+    # used it (longest ````-fence, fail above 100 lines) and a reviewer proved it
+    # wrong in all four directions: a legitimate unrelated 120-line example
+    # fails, a 99-line second install path passes, a 639-line copy in an ordinary
+    # ```-fence passes with a measured length of zero, and a copy split across
+    # two 80-line blocks passes. The property is "this block IS the skill", so
+    # `skillcopy` asks that directly, and NOT all of it about fenced blocks:
+    # rules A (heading reproduction) and B (frontmatter at real-file size) look at
+    # REGIONS — fenced blocks plus indented runs — while rule C measures the RAW
+    # DOCUMENT's reproduction of the skill's body prose, with no markup model at
+    # all. C is markup-blind because a verbatim copy indented four spaces carries
+    # no fence, and because a block-scoped C scored the same copy at 105 or 131
+    # lines purely by 3- vs 4-backtick wrapper choice.
+    local out
+    if out=$(python3 "$SCRIPT_DIR/lib/skillcopy.py" "$REPO_ROOT" 2>&1); then
+        pass "wizard doc ships no second install path for the skill"
+    else
+        fail "wizard doc embeds a copy of the shipped skill — a second install path for a file the CLI already installs. One skill, one source (#513):
+$out"
+    fi
+}
+test_wizard_doc_ships_no_second_install_path_for_the_skill
+
+# The invariant that stops this recurring, and the more valuable of the two.
+#
+# Assertions across this corpus grepped the wizard doc for strings that exist
+# ONLY inside that fence — `## Cross-Model Review (REQUIRED`, `### Release Review
+# Focus`, `gh pr merge --auto`, `no stall watchdog and no timeout`. They were
+# written to check what the DOCUMENT tells a reader, and passed by matching a
+# quotation of a draft nobody installs. Guard and artifact pointed at different
+# objects.
+#
+# ONE count, with its method, because an earlier note gave a bare figure that no
+# measurement reproduced: `fence-only-assertions.py` run against the `main`
+# document, with skill-copy blocks stripped, reports 18 such assertions across 2
+# suites (test-doc-consistency.sh, test-self-update.sh) — measured 2026-08-08,
+# after the re.M and GREP_STDIN repairs, which recovered assertions the earlier
+# count of 15 had been silently missing.
+# That is the guard's own reach and the number that regresses if it weakens. It
+# is NOT a claim about how many exist: shapes the scanner cannot resolve are
+# outside it by construction, which is what the reach-limits section of that
+# module documents.
+#
+# Same defect class as #517's fixture committing dummy files as the "pristine
+# gate" while executing the real script: a check that appears to verify X and
+# actually verifies Y. Third instance in one week, so it gets a test.
+test_no_wizard_doc_assertion_is_satisfied_only_inside_a_fence() {
+    local out
+    if out=$(python3 "$SCRIPT_DIR/lib/fence-only-assertions.py" "$REPO_ROOT" 2>&1); then
+        pass "no test asserts wizard-doc guidance that exists only inside a fenced block"
+    else
+        fail "assertions satisfied ONLY by text inside a fenced block — they verify a quotation, not the document (#513):
+$out"
+    fi
+}
+test_no_wizard_doc_assertion_is_satisfied_only_inside_a_fence
+
+# BOTH guards above are DORMANT while the repo is healthy: with no skill copy in
+# the document there is nothing to strip and nothing to flag, so they pass by
+# having no work to do. Dormant-by-precondition is legitimate; dormant-by-accident
+# is the exact defect (#513, #517) these guards exist to catch, and from the
+# outside the two look identical.
+#
+# The selftests are what tells them apart — each runs its detector against a
+# synthetic document that DOES contain a copy, so the machinery is exercised on
+# every CI run rather than only on the day the repo is already broken. They
+# existed but nothing invoked them, which made the whole dormancy argument
+# unevidenced. Every fixture inside them cites the specific review finding it
+# came from.
+test_guard_selftests_actually_run() {
+    local lib out
+    for lib in "mdfence.py" "skillcopy.py --selftest" "fence-only-assertions.py --selftest"; do
+        # shellcheck disable=SC2086  # the flag is part of the list entry
+        if out=$(python3 "$SCRIPT_DIR/lib/"$lib 2>&1); then
+            pass "guard selftest green: $lib"
+        else
+            fail "guard selftest FAILED: $lib — the detector no longer catches a
+copy it is supposed to catch, so the guard above may be passing vacuously:
+$out"
+        fi
+    done
+}
+test_guard_selftests_actually_run
 
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 

--- a/tests/test-self-update.sh
+++ b/tests/test-self-update.sh
@@ -277,16 +277,6 @@ test_skill_cross_model_review() {
     fi
 }
 
-# Test 19: Wizard embedded SKILL has a real TodoWrite step for cross-model review
-test_wizard_skill_cross_model_review() {
-    # The wizard's embedded SKILL checklist should have the real step, not just a comment
-    if grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -i 'content:.*cross-model review' | grep -qv '^\s*//'; then
-        pass "Wizard embedded SKILL has TodoWrite step for cross-model review"
-    else
-        fail "Wizard embedded SKILL should have a TodoWrite step (not a comment) for cross-model review"
-    fi
-}
-
 # Test 20: SKILL.md has a dedicated cross-model review instructions section
 test_skill_cross_model_review_instructions() {
     local skill_file="$SCRIPT_DIR/../.claude/skills/sdlc/SKILL.md"
@@ -294,15 +284,6 @@ test_skill_cross_model_review_instructions() {
         pass "SKILL.md has dedicated cross-model review section"
     else
         fail "SKILL.md should have a '## Cross-Model Review' section with instructions"
-    fi
-}
-
-# Test 21: Wizard embedded SKILL has a dedicated cross-model review section
-test_wizard_skill_cross_model_review_instructions() {
-    if grep -A 500 "## Full SDLC Checklist" "$WIZARD" | grep -q "## Cross-Model Review"; then
-        pass "Wizard embedded SKILL has cross-model review section"
-    else
-        fail "Wizard embedded SKILL should have a '## Cross-Model Review' section"
     fi
 }
 
@@ -383,9 +364,7 @@ test_version_consistency
 test_cross_model_review_section
 test_cross_model_review_step
 test_skill_cross_model_review
-test_wizard_skill_cross_model_review
 test_skill_cross_model_review_instructions
-test_wizard_skill_cross_model_review_instructions
 test_update_skill_exists
 test_update_skill_template_exists
 test_update_skill_parity
@@ -394,12 +373,26 @@ test_step_registry_update_wizard
 
 # --- Cross-Model Review Dialogue Tests (#40) ---
 
-# Helper: extract wizard cross-model blocks (embedded SKILL + deep-dive)
+# Helper: extract the wizard's cross-model section.
+#
+# There is ONE, not two. This helper used to run a second `sed` for
+# `## Cross-Model Review (REQUIRED` ... `## Test Review` — headings that lived
+# inside the 639-line hand-copy fence #513 deleted and that exist nowhere in the
+# document now. That range matched ZERO bytes, so every assertion built on it was
+# testing the extractor, not the document. Deleted rather than repaired: it has no
+# surviving target.
+#
+# The invariant it violated, which is the third instance of the same family in
+# this repo: AN EXTRACTION THAT FEEDS AN ASSERTION MUST ASSERT ITS OWN
+# NON-EMPTINESS, or the assertion silently tests the extractor.
 wizard_cross_model_blocks() {
-    # Embedded SKILL section: ## Cross-Model Review ... ## Test Review
-    sed -n '/^## Cross-Model Review (REQUIRED/,/^## Test Review/p' "$WIZARD"
-    # Deep-dive section: ### Cross-Model Review Loop ... next ### or EOF
-    sed -n '/^### Cross-Model Review Loop/,/^### [^C]/p' "$WIZARD"
+    local out
+    out=$(sed -n '/^### Cross-Model Review Loop/,/^### [^C]/p' "$WIZARD")
+    if [ -z "$out" ]; then
+        echo "EXTRACTOR RETURNED NOTHING — assertions below would test nothing" >&2
+        return 1
+    fi
+    printf '%s\n' "$out"
 }
 
 # Test 22: Wizard cross-model sections document response.json protocol
@@ -475,7 +468,12 @@ test_wizard_recheck_prompt_parity() {
     prompts=$(grep -c '"You are doing a TARGETED RECHECK.*First read .reviews/handoff.json' "$WIZARD")
     local total
     total=$(grep -c '"You are doing a TARGETED RECHECK' "$WIZARD")
-    if [ "$prompts" -eq "$total" ] && [ "$total" -ge 2 ]; then
+    # `-ge 2` encoded an accident, not a contract: the prompt appeared twice
+    # because the wizard doc carried a second copy of the skill that re-pasted
+    # it. #513 deleted that copy, so demanding two occurrences would have
+    # required re-duplicating the very text the fix de-duplicated. One canonical
+    # prompt is the goal; the parity check below is the actual invariant.
+    if [ "$prompts" -eq "$total" ] && [ "$total" -ge 1 ]; then
         pass "All $total wizard recheck prompts include handoff.json-first instruction"
     else
         fail "Wizard has $total recheck prompts but only $prompts include handoff.json-first ($total expected)"
@@ -1200,21 +1198,24 @@ test_wizard_release_review_trigger() {
     fi
 }
 
-# Wizard has Release Review Checklist subsection
-test_wizard_release_review_checklist() {
-    if grep -q "#### Release Review Checklist" "$WIZARD"; then
-        pass "Wizard has Release Review Checklist subsection"
+# Wizard has Release Review Focus subsection
+test_wizard_release_review_focus() {
+    # Renamed by #513: the doc carried both a "Release Review Checklist" and a
+    # near-identical "Release Review Focus"; they were merged under the latter.
+    # Anchored end-to-end, depth left free — depth is not the contract.
+    if grep -qE "^#+ Release Review Focus[[:space:]]*$" "$WIZARD"; then
+        pass "Wizard has Release Review Focus subsection"
     else
-        fail "Wizard should have a 'Release Review Checklist' subsection"
+        fail "Wizard should have a 'Release Review Focus' subsection"
     fi
 }
 
 # Wizard references v1.20.0 as evidence for release review
 test_wizard_release_review_evidence() {
-    if grep -A 30 "Release Review Checklist" "$WIZARD" | grep -q "v1.20.0"; then
+    if grep -A 30 "Release Review Focus" "$WIZARD" | grep -q "v1.20.0"; then
         pass "Wizard Release Review references v1.20.0 evidence"
     else
-        fail "Wizard Release Review Checklist should reference v1.20.0 as evidence"
+        fail "Wizard Release Review Focus should reference v1.20.0 as evidence"
     fi
 }
 
@@ -1232,43 +1233,61 @@ test_skill_release_review_trigger() {
 # a release — so it is on-demand content, not something the driver needs mid-task
 # without warning. Asserted against the doc that now owns it.
 test_skill_release_review_section() {
-    if grep -q "### Release Review Focus" "$WIZARD"; then
+    # Anchored end-to-end, depth left free. Unanchored, this matched the
+    # `#### Release Review Focus` heading by substring — accidentally correct
+    # after #513 renested it, which is not the same as being right. Depth is not
+    # the contract; the section existing under its own heading is.
+    if grep -qE "^#+ Release Review Focus[[:space:]]*$" "$WIZARD"; then
         pass "#489: Release Review Focus is in the wizard doc"
     else
-        fail "wizard doc is missing '### Release Review Focus' — the skill points here for it"
+        fail "wizard doc is missing a 'Release Review Focus' heading — the skill points here for it"
     fi
 }
 
-# Embedded SKILL "When to run" includes releases
-test_wizard_embedded_skill_release_trigger() {
-    # The embedded SKILL is inside a ```` code fence after "## Step 6: Create SDLC Skill"
-    if sed -n '/## Step 6: Create SDLC Skill/,/^````$/p' "$WIZARD" | grep "When to run" | grep -qi "release\|publish"; then
-        pass "Wizard embedded SKILL 'When to run' includes releases/publishes"
+# Shipped SKILL "When to run" includes releases
+test_shipped_skill_release_trigger() {
+    # GH #513: this used to read the wizard doc's embedded skill copy, inside a
+    # ```` fence under "## Step 6: Create SDLC Skill" — the lane the CLI never
+    # installs, and which this PR deletes. Re-pointed at the file that ships.
+    if grep "When to run" "$SCRIPT_DIR/../skills/sdlc/SKILL.md" | grep -qi "release\|publish"; then
+        pass "shipped SKILL.md 'When to run' includes releases/publishes"
     else
-        fail "Wizard embedded SKILL 'When to run' should include releases/publishes"
+        fail "shipped SKILL.md 'When to run' should include releases/publishes"
     fi
 }
 
 test_wizard_release_review_trigger
-test_wizard_release_review_checklist
+test_wizard_release_review_focus
 test_wizard_release_review_evidence
 test_skill_release_review_trigger
 test_skill_release_review_section
-test_wizard_embedded_skill_release_trigger
+test_shipped_skill_release_trigger
 
 # Release review focus areas — wizard doc only since #489 moved the section
 # out of the byte-capped skill. Checking the skill too would now assert that
 # on-demand content is duplicated into the always-loaded file, which is the
 # thing #489 exists to stop.
+# The five needles are INLINE rather than looped through "${areas[@]}". A needle
+# reaching grep through a variable is opaque to tests/lib/fence-only-assertions.py,
+# which reported it as unverifiable — correctly: had any of these strings existed
+# only inside the deleted hand-copy fence, this test would have passed by matching
+# a quotation of a draft nobody installs, which is the #513 defect exactly.
 test_release_review_focus_area_parity() {
-    local areas=("CHANGELOG consistency" "Version parity" "Stale examples" "Docs accuracy" "CLI-distributed file parity")
     local all_match=true
-    for area in "${areas[@]}"; do
-        if ! grep -q "$area" "$WIZARD"; then
+    local area
+    for area in "CHANGELOG consistency" "Version parity" "Stale examples" \
+                "Docs accuracy" "CLI-distributed file parity"; do
+        case "$area" in
+            "CHANGELOG consistency")        grep -q "CHANGELOG consistency" "$WIZARD" ;;
+            "Version parity")               grep -q "Version parity" "$WIZARD" ;;
+            "Stale examples")               grep -q "Stale examples" "$WIZARD" ;;
+            "Docs accuracy")                grep -q "Docs accuracy" "$WIZARD" ;;
+            "CLI-distributed file parity")  grep -q "CLI-distributed file parity" "$WIZARD" ;;
+        esac || {
             fail "Wizard missing release review focus area: $area"
             all_match=false
             break
-        fi
+        }
     done
     if [ "$all_match" = true ]; then
         pass "#489: all 5 release review focus areas present in the wizard doc"


### PR DESCRIPTION
Closes #513.

## The defect

`CLAUDE_CODE_SDLC_WIZARD.md` carried a **639-line** ` ````markdown ` fence telling readers to hand-copy it into `.claude/skills/sdlc/SKILL.md` — the exact file `npx agentic-sdlc-wizard init` already writes from `skills/sdlc/SKILL.md`. Two install paths, one destination. They diverged to **56,284 bytes against the live skill's 19,356**, and moved in *opposite directions inside single PRs* (#509 shrank the live skill 856 bytes while growing the fence 1,470).

Delete the fence; promote the sections that were only reachable inside it to document level.

## The guards

| File | What it detects |
|---|---|
| `mdfence.py` | Markdown fence grammar, shared so both guards agree on terms |
| `skillcopy.py` | A document that **is** a copy of the shipped skill |
| `fence-only-assertions.py` | Test assertions that grep the doc for strings existing only inside a copy |

`skillcopy` applies four rules that deliberately do **not** share a unit of analysis:

- **A** — heading reproduction, region-scoped
- **B** — frontmatter at real file size, region-scoped
- **C** — body prose over the **raw document**, markup-blind
- **Destination containment** — ignores the payload entirely

Rule C is markup-blind because every block model it wore was itself an attack surface: a verbatim copy **indented four spaces** carries no fence at all, and the same renamed copy measured **105 or 131** reproduced lines purely by the attacker's choice of 3- vs 4-backtick wrapper (the skill contains four of its own ``` fences).

## Why there is a fourth rule that ignores the payload

Rule C was redesigned **four times**, each repair fitted to the previous counterexample and beaten by the next. The fourth version was then beaten by a 200-of-254-line usable skill — valid frontmatter, all 29 TodoWrite entries, all tables, headings renamed, split across two blocks — built only from deletion, renaming and splitting, all already in the threat model.

It is now frozen behind an argument that a fifth **cannot** work. That artifact and a document that legitimately quotes the skill heavily differ by ~15 lines *of the same kind of content*, so any payload rule must fit a constant into a 15-line gap. Identity, structure, mass, density, locality, order — the whole signal space is spent.

> **When the legitimate document and the attack artifact are built from the same lines, no function of line-sharing separates them.**

So the fourth rule looks at what an install path cannot obfuscate and still work: **where the reader is told to put the file**. Strip the sentence naming the destination and the artifact is ugly quotation nobody installs.

| artifact | rules A/B/C | destination |
|---|---|---|
| the 200/254-line escape | 0 | **1 — caught** |
| historical #513 defect | 1 | 2 |
| heavy quotation, no install line | 0 | 0 |
| live document | 0 | 0 |

## Stated contract

These are **lints in a first-party repo, not a security boundary** — every author can edit the guard itself.

> Every artifact producible by plausible accident fires loudly, on several rules at once. Artifacts requiring multiple deliberate evasion steps are the review process's job.

Reach limits are documented rather than papered over: rule C's paraphrase bound, rule B's frontmatter false positive, destination containment's compositional-path evasion, and the shell reader's four known-open cases.

## Verification

- **86 behavioural fixtures** — 37 `skillcopy`, 49 `fence-only`
- **10 mutation axes**, each asserting the mutation applied before running, then verified to turn fixtures red
- Live tree: zero offenders, zero unverifiable reports, zero destination findings
- Suites 31/128/158; full `tests/*.sh` sweep 58 suites, 0 failures

Measured 2026-08-08: skill 19,356 bytes / 254 lines / 71 distinctive prose lines / 23 headings. Rule C trigger 35, live overlap 1, drift sentinel at 18.

## Cross-model review

11 Codex (GPT-5.6 Sol, `high`) rounds, one blind Fable diff-only review, and **three Fable design rulings**. Certified round 11 with no P0/P1; its three non-blocking P2 documentation defects were fixed after certification.

The three design rulings each ended a loop that patching could not — and that lesson is filed as #526, since Fable was used as a *reviewer* for the first eight rounds when it should have been the brain.

## Follow-ups

- **#527** — retire `fence-only`'s shell parser for a containment scan (27 files, 175 mentions, measured)
- **#521** — incremental review/commit loop
- **#525** — config changes reach no reviewer
- **#526** — escalate to design authority on the second repair
