### PR TITLE
release: v1.96.0 — one skill, one install path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "SDLC enforcement plugins for AI-assisted development",
-    "version": "1.95.0"
+    "version": "1.96.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "BaseInfinity/claude-sdlc-harness"
       },
       "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
-      "version": "1.95.0",
+      "version": "1.96.0",
       "author": {
         "name": "Stefan Ayala"
       },
@@ -36,7 +36,7 @@
         "path": "cowork"
       },
       "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
-      "version": "1.95.0",
+      "version": "1.96.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,10 +34,14 @@ The SDLC Harness is a documentation-first approach to enforcing SDLC practices i
 
 **File**: `CLAUDE_CODE_SDLC_WIZARD.md`
 
-The main wizard document (installed by `npx agentic-sdlc-wizard init` or copied manually). Contains:
+The main wizard document (installed by `npx agentic-sdlc-wizard init`). Contains:
 - SDLC philosophy
-- Installation instructions
-- Hook/skill templates
+- Installation instructions — which run the CLI; the document is not a self-contained installer
+- Two illustrative hook templates out of the 8 shipped hooks. **No full, installable SDLC skill
+  template** — the embedded copy of `skills/sdlc/SKILL.md` was deleted in v1.96.0 because it was a
+  second install path to the destination the CLI already writes, and the two had diverged (GH
+  #513). A short illustrative frontmatter snippet remains, teaching `$ARGUMENTS`; it is not a
+  skill you can install
 - Usage guidelines
 
 ### 2. Hooks System

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,81 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.96.0] - 2026-08-09
+
+### Fixed — the wizard doc shipped a second, diverged copy of the SDLC skill
+
+- **A 639-line fence told you to hand-copy a skill the CLI already installs.**
+  `CLAUDE_CODE_SDLC_WIZARD.md` carried a ````markdown block instructing readers to paste it
+  into `.claude/skills/sdlc/SKILL.md` — the exact file `npx agentic-sdlc-wizard init` writes
+  from `skills/sdlc/SKILL.md`. Two install paths, one destination, and they had diverged to
+  56,284 bytes against the live skill's 19,356, moving in opposite directions inside single
+  PRs. If you hand-copied that block, you installed a draft nobody maintains. The fence is
+  deleted and the sections only reachable inside it are promoted to document level. (#513)
+
+- **18 assertions were verifying the quotation instead of the document.** Across two suites,
+  they grepped the wizard doc for strings that existed only inside that fence, so they passed by
+  matching text no consumer ever installs. Guard and artifact pointed at different objects.
+  (#513)
+
+### Added — four guards so it cannot come back
+
+Three of them ask whether a block reproduces the shipped skill's headings, its frontmatter at
+real file size, or its body prose. The fourth ignores the content entirely and asks whether the
+document tells a reader **where to install a file** — the one thing a hand-copy instruction
+cannot obfuscate and still work.
+
+The body-prose rule measures the raw document rather than fenced blocks, because a verbatim copy
+indented four spaces carries no fence at all, and the same copy measured 105 or 131 reproduced
+lines purely by the author's choice of three- or four-backtick wrapper.
+
+These are lints, not a security boundary, and they say so: every artifact producible by plausible
+accident fires loudly on several rules at once; multi-step deliberate evasion is review's job.
+Reach limits are documented rather than papered over.
+
+### Changed
+
+- **Same-model self-review is no longer instructed — including in a hook that fired every turn.**
+  `hooks/sdlc-prompt-check.sh` (a shipped hook) carried a per-prompt `/code-review` directive; it
+  is deleted, along with the skill's checklist item and its "Self-Review Loop" section. What stays
+  is the *measurement*: the `self_review` rubric row, same 1 point, minus its critical flag, so
+  `tdd_red` is now the only must-pass criterion. A model reviewing its own output was never
+  independent evidence — `/code-review` reported clean three times in one session while an
+  independent model found real P1s each time. Cross-model review is untouched. (#509)
+- **The Memory Audit Protocol now exists where it was advertised.** The skill pointed at the
+  wizard doc, the wizard doc pointed back at the skill, and the protocol lived in neither. It is
+  now written out in `CLAUDE_CODE_SDLC_WIZARD.md` — denylist table, promotion destinations,
+  `promoted_to` tracking, the mandatory human gate — and the skill keeps a pointer that leads
+  somewhere. Cross-model review mechanics moved the same direction. Net effect on the skill:
+  19,993 → 19,137 bytes, so it is no longer one edit from its ceiling. (#509)
+- **The review loop no longer hands the turn back every round.** The skill now states when it may
+  stop, and only three answers count: **CONVERGED** (required verdicts in on the head SHA, zero
+  unresolved findings), **DEADLOCK** (same finding unmoved after two rechecks), or **BOUND** (a
+  gate that mechanically needs a human). While findings are landing, the loop is working — fix and
+  launch the next round in the same turn. The load-bearing half is the anti-shopping invariant:
+  every round must carry a delta, because "always continue" without it is just resubmitting until
+  a tired YES. No fixed round cap. (#509)
+- **README brought in sync with the above.** It no longer tells you to run cross-model review
+  "after Claude's self-review passes" — the trigger is the change being high-stakes — and
+  `/code-review` is described as optional preflight input to that review rather than a gate of its
+  own. (#509)
+- **Cowork's surface is now stated, not discovered.** Cowork users receive six files and never the
+  wizard doc, so "full protocol: wizard doc" was a dead end for them. The skill now says it is
+  complete on its own and those pointers are optional depth. `cowork/README.md` states plainly
+  that Cowork is guidance, not enforcement — its prompt hooks are unproven as gates. (#509)
+- **Dual cross-model certification is now merge authorization.** `scripts/merge-pr.sh` requires
+  two distinct reviewers at >=95% confidence bound to the head commit, plus a CERTIFIED clearance
+  artifact at round >= 2. That round count is a *structural proxy*, not proof — no local script can
+  confirm a review dialogue was genuine, and the script says so rather than implying otherwise.
+  Both clearances are also posted by the same token, so this is attested, not authenticated. Never
+  cleared by any of it: red CI, net-removed tests, version bumps. Repo-local; it does not ship.
+  (#511, #517)
+- **CI `validate` lookup fixed — it could read a red or queued run as green.** The check took
+  `head -1`, so a green run shadowed a red one of the same name, and its regex could not see the
+  `"conclusion": null` a queued run carries. Found while building the above. (#517)
+- **README corrected**: the E2E scoring pipeline runs in this repo, not in yours. (#507)
+- **ROADMAP demoted to a view** over GitHub issues, which are the source of truth. (#518)
+
 ## [1.95.0] - 2026-08-07
 
 **The repo is now `BaseInfinity/claude-sdlc-harness`.** The npm package stays

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2938,7 +2938,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Harness Version: 1.95.0 -->
+<!-- SDLC Harness Version: 1.96.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4202,7 +4202,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Harness Version: 1.95.0 -->
+<!-- SDLC Harness Version: 1.96.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install -g agentic-sdlc-wizard
 sdlc-wizard init
 ```
 
-**Manual (advanced — escape hatch only):** Download `CLAUDE_CODE_SDLC_WIZARD.md` to your project and tell Claude `Run the SDLC wizard setup`. This skips the live-session auto-invoke and is only intended for environments where `npx`, `curl`, `brew`, and `gh` are all unavailable. The default human path is `npx init` → restart CC → first-prompt auto-setup, not this manual flow.
+**Manual (advanced — partial, not an escape hatch):** Download `CLAUDE_CODE_SDLC_WIZARD.md` to your project and tell Claude `Run the SDLC wizard setup`. This skips the live-session auto-invoke and generates your bespoke `CLAUDE.md`, `SDLC.md`, `TESTING.md` and `ARCHITECTURE.md`. **It does not give you a working install.** The document no longer contains the SDLC skill — Step 6 installs it by running the CLI (GH #513) — and only 2 of the 8 hooks have hand-typed templates here. So this path still needs `npx`; there is no npx-free route to a complete install. The default human path is `npx init` → restart CC → first-prompt auto-setup.
 </details>
 
 <details>
@@ -99,7 +99,7 @@ Layer 2: ENFORCEMENT
 
 Layer 1: PHILOSOPHY
   The wizard document. KISS. TDD. Confidence levels.
-  Copy it, run setup, get a bespoke SDLC.
+  Run the CLI; setup reads it and writes a bespoke SDLC.
 ```
 
 ## What Makes This Different

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,9 +15,11 @@ Triage: **31 open → 22, unmilestoned 12 → 0.** Closed with reasons on each i
 
 Row 485 is **superseded by #511 and #517** — do not action it. Analysis lives on the issues, not here: #513 (the embedded install path), #482 (why this file stops being a store), #489 (byte ceiling).
 
-**Last release: v1.95.0, 2026-08-07** (`agentic-sdlc-wizard`). Carries the stdin-hang fix for six shipped hooks — each could block forever on a stdin that never reaches EOF, observed at 10h19m against a 10-second timeout — plus fail-closed gate semantics and a `CLAUDE.md` shipped-surface guard. See `CHANGELOG.md`, including the five-iteration history of the fix itself.
+**Last release: v1.96.0, 2026-08-09** (`agentic-sdlc-wizard`). Deletes the wizard doc's 639-line embedded copy of the SDLC skill — a second install path to the same destination the CLI writes, diverged to 56,284 bytes against the live skill's 19,356 — and the 18 assertions that were grepping that copy instead of the document. Adds four guards against its return, three measuring the payload and one measuring where the reader is told to install. Also: same-model self-review deleted as an instruction (including from a shipped per-prompt hook), dual cross-model certification as merge authorization, and a `validate` lookup that could read a red or queued CI run as green. See `CHANGELOG.md`.
 
-**This marker was stale and is worth noting as a defect, not just correcting.** It read "Last release: v1.90.0" through the v1.92.0 and v1.93.0 releases; a version sweep grepping for the *outgoing* version can never find a marker frozen at an older one. Caught by cross-model release review 2026-08-05, not by any test. A guard belongs in `tests/test-doc-consistency.sh` — cross-ref GH #493 (the guard itself) and #491 (the wider CI/CD audit).
+**Prior release: v1.95.0, 2026-08-07.** Carried the stdin-hang fix for six shipped hooks — each could block forever on a stdin that never reaches EOF, observed at 10h19m against a 10-second timeout — plus fail-closed gate semantics and a `CLAUDE.md` shipped-surface guard, including the five-iteration history of the fix itself.
+
+**The "Last release" marker above was stale and is worth noting as a defect, not just correcting.** It read "Last release: v1.90.0" through the v1.92.0 and v1.93.0 releases; a version sweep grepping for the *outgoing* version can never find a marker frozen at an older one. Caught by cross-model release review 2026-08-05, not by any test. A guard belongs in `tests/test-doc-consistency.sh` — cross-ref GH #493 (the guard itself) and #491 (the wider CI/CD audit).
 
 **Historical, retained — v1.90.0, published to npm 2026-08-01** (`dist-tags.latest = 1.90.0` at that time). That release carried three consumer-visible fixes — the Cowork Stop hook blocking turns while background work was still in flight (unsatisfiable: an agent cannot make a background job finish sooner, the same shape as the #477 loop it was built to prevent); install instructions that pointed at a `.../tree/main/cowork` URL which is not a supported marketplace source and cannot ever have worked (#455); and `cowork/README.md` contradicting itself twice — plus the review loop, severity contract, and the TDD RED/GREEN + Testing Diamond sections in `TESTING.md`. **Deliberately NOT in it:** row #485 (still uncertified on its own branch) and the shellcheck CI gate (pulled on unanimous cross-model recommendation, tracked as #492 with the work preserved as a 362-line patch).
 
@@ -202,7 +204,7 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 
 | Project | Repo | Status |
 |---------|------|--------|
-| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.95.0 (living tracker — bump every release) |
+| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.96.0 (living tracker — bump every release) |
 | Codex SDLC Adapter | BaseInfinity/codex-sdlc-wizard | v0.7.x, shipped with SDLC workflow |
 | GDLC Wizard (games sibling) | BaseInfinity/claude-gdlc-wizard | v0.2.x, persona-driven playtest cycles |
 | _(add as projects are marked)_ | | |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Harness Version: 1.95.0 -->
+<!-- SDLC Harness Version: 1.96.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.220 -->
@@ -10,7 +10,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.95.0 |
+| Wizard Version | 1.96.0 |
 | Last Updated | 2026-07-04 |
 | Claude Code Minimum | v2.1.219+ (required for `opus` alias to resolve to Opus 5, the current default); v2.1.154+ for the older `opus[1m]` alias resolution; v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.220+ — **v2.1.214 changed single-segment `dir/**` hook `if:` conditions to match only `<cwd>/dir`; any-depth now needs `**/dir/**`. This silently disabled the shipped TDD hook for every consumer whose source is not at repo-root `src/` (fixed in v1.91.0).** Also in this range: exit-code-2 hooks now block even when their stdout JSON fails schema validation (v2.1.214 — we were never exposed, our exit-2 hooks write to stderr); plugin skills with a `name` frontmatter field keep their plugin prefix in slash-command autocomplete (v2.1.216, affects `sdlc-wizard-cowork:sdlc`); transcripts record reasoning effort per assistant message (v2.1.212); subagent nesting defaults changed twice (disabled v2.1.217, re-enabled at depth 3 in v2.1.219). Earlier baseline rationale: `SessionStart`/`Setup`/`SubagentStart` hooks no longer hide stderr on exit 2 (v2.1.199), hook events no longer dropped during `SessionStart` in headless sessions (v2.1.204), duplicate skill-instruction context bloat fixed (v2.1.202). |

--- a/cowork/.claude-plugin/marketplace.json
+++ b/cowork/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "SDLC enforcement for Claude Cowork sessions via prompt-based hooks and skills",
-    "version": "1.95.0"
+    "version": "1.96.0"
   },
   "plugins": [
     {
       "name": "sdlc-wizard-cowork",
       "source": ".",
       "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
-      "version": "1.95.0",
+      "version": "1.96.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard-cowork",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
   "author": {
     "name": "Stefan Ayala",

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -125,4 +125,4 @@ This plugin is for Cowork-only users who want methodology guidance without the f
 
 ## Version
 
-Tracks the main wizard version: **1.95.0**
+Tracks the main wizard version: **1.96.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "description": "Self-evolving SDLC enforcement for Claude Code \u2014 hooks, skills, and one-command setup",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -95,7 +95,7 @@ Parse CHANGELOG entries between the user's installed version and the resolved la
 
 ```
 Installed: 1.42.0
-Latest:    1.95.0
+Latest:    1.96.0
 
 What changed:
 - [1.92.0] Cowork `Stop` hook REMOVED — it fired 12 times in one session and was wrong 11; Cowork now has no completion enforcement (documented in cowork/README.md).


### PR DESCRIPTION
Cuts v1.96.0. Version bump, CHANGELOG entry, and three doc corrections the release review surfaced.

## What ships

**#513 — the wizard doc shipped a second, diverged copy of the SDLC skill.** A 639-line fence told readers to hand-copy it into `.claude/skills/sdlc/SKILL.md` — the exact file `npx agentic-sdlc-wizard init` writes. The two had diverged to 56,284 bytes against the live skill's 19,356, moving in opposite directions inside single PRs. 18 assertions across two suites were verifying that copy rather than the document. Fence deleted, four guards added, sections promoted to document level.

Also: #509 (same-model self-review deleted as an instruction, including from a per-prompt shipped hook; loop-autonomy stop conditions; Memory Audit Protocol moved to where it was advertised; Cowork's surface named), #517 (dual cross-model certification as merge authorization, plus a `validate` lookup that read red and queued runs as green), #507, #518.

## Release review

Three Codex rounds at `high`, eight findings, **every one factual**:

| Round | Findings |
|---|---|
| 1 | False CHANGELOG count (21 vs the measured 18); #509/#517 materially under-described; ROADMAP's last-release marker still on v1.95.0; README and ARCHITECTURE advertising an npx-free manual install that #513 had removed |
| 2 | A byte count I took from a commit message instead of measuring (18,633 — the merged tree says 19,137); two more #509 rules still omitted; the merge-gate entry overstating a structural proxy as proof of dialogue; an absolute "no skill template" claim the doc contradicts |
| 3 | **CERTIFIED**, zero unresolved |

Artifacts: `.reviews/codex-v1.96.0.md`, `-r2.md`, `-r3.md`, `handoff.json` (CERTIFIED, round 3, bound to `0afc99b`).

## Verification

- `tests/*.sh` — 65/65
- `npm pack --dry-run` — `agentic-sdlc-wizard@1.96.0`, 25 files
- `git diff --check` — clean

## Merging

This is a `package.json` version bump, so `scripts/merge-pr.sh` blocks it unconditionally — dual cross-model certification does not clear a release. It needs `--user-approved "<reason>"`. And merging does not publish: `git tag v1.96.0 && git push origin v1.96.0` is what triggers npm.