### PR TITLE
fix(audit): delete the unmeasured 20,000-byte ceiling gate (#489)

### DIFF
--- a/scripts/audit-session-load.sh
+++ b/scripts/audit-session-load.sh
@@ -9,6 +9,14 @@
 # a mechanical inventory of every file/output that hits a session, so trim
 # candidates surface before they bloat the context budget.
 #
+# #489: THIS TOOL IS ADVISORY. The TRIM threshold is not a measured ceiling —
+# it is 5,000 (a round number) times 4 (a chars-per-token rule of thumb from a
+# different vendor), and SDLC_AUDIT_THRESHOLD_TOKENS can move it at will. A
+# test once turned that flag into a CI failure, which made an unmeasured number
+# a hard contract on a shipped file and forced every later edit to buy its
+# bytes by degrading something else. That gate is deleted. No measured ceiling
+# exists today; #483 is where one would come from.
+#
 # Usage:
 #   scripts/audit-session-load.sh           # human-readable table
 #   scripts/audit-session-load.sh --json    # machine-readable

--- a/tests/test-audit-session-load.sh
+++ b/tests/test-audit-session-load.sh
@@ -143,33 +143,68 @@ test_audit_ranks_by_size_descending() {
     fi
 }
 
-# Eat-our-own-dogfood: the wizard's own SKILL.md files must come in below the
-# bloat threshold the audit warns about. Phase 2 follow-up to PR #272 — the
-# audit tool flagged 2 of our 4 SKILL.md files (sdlc 12,427 tokens; update
-# 8,555 tokens) on the day we shipped it. Acting on the tool's findings closes
-# the Prove-It loop: a tool that surfaces real issues whose owner ignores them
-# is just a louder lint warning.
-test_wizard_own_skills_below_threshold() {
+# #489: the build gate that used to live here is deleted.
+#
+# It failed CI whenever a SKILL.md crossed the audit's TRIM threshold, which
+# made 20,000 bytes a hard contract on a shipped file. That number was never
+# measured: `scripts/audit-session-load.sh` computes it as THRESHOLD_TOKENS
+# (5,000, a round number) times 4 (a chars-per-token rule of thumb from a
+# different vendor), and the whole thing is tunable by an environment variable.
+# Under the CLAIM RULE we cannot enforce a number we never measured.
+#
+# The cost was real and compounding. With sdlc/SKILL.md sitting at 19,997 of
+# 20,000, every subsequent edit had to buy its own bytes by degrading another
+# instruction in the same file, and that trading shipped three defects in a
+# single session — including invalid JSON and a dropped instruction value.
+# A budget that forces a silent trade on every edit is a circling generator.
+#
+# The audit itself is untouched: it still reports sizes and still raises TRIM,
+# because observability was always its job. Only build-red is gone. If a real
+# ceiling is ever measured, it belongs here — see #483, which is where such a
+# measurement would come from.
+#
+# Still enforced elsewhere, deliberately: tests/test-cowork-drift.sh keeps
+# skills/sdlc/SKILL.md and cowork/skills/sdlc/SKILL.md byte-identical.
+#
+# One thing the deleted test was doing incidentally, kept below: it was the
+# only place that ran a real json.loads over the audit's REAL multi-entry
+# output. Cross-model review caught that removing the gate would have taken
+# that coverage with it — the other JSON test greps for substrings, so
+# stripping the commas between entries left all nine survivors green while
+# `python3 -m json.tool` rejected the output.
+
+# Parses the audit's output for THIS repo, which is the only fixture with
+# enough entries for a malformed separator to show up. Asserts validity and
+# shape only — never sizes, never flags. That distinction is the point: the
+# tool's contract is that it emits parseable JSON, not that any file in this
+# repo is under some particular number.
+test_audit_json_is_parseable_on_real_repo() {
     local repo_root="$SCRIPT_DIR/.."
-    local output flagged
+    local output verdict
     output=$(SDLC_AUDIT_ROOT="$repo_root" "$AUDIT" --json 2>&1)
-    flagged=$(printf '%s' "$output" | python3 -c '
+    verdict=$(printf '%s' "$output" | python3 -c '
 import json, sys
 try:
     data = json.loads(sys.stdin.read())
-except json.JSONDecodeError:
-    print("INVALID_JSON")
+except json.JSONDecodeError as e:
+    print("INVALID_JSON: %s" % e)
     sys.exit(0)
-flagged = [e["path"] for e in data.get("entries", [])
-           if e.get("type") == "skill" and e.get("flag") == "TRIM"]
-print("\n".join(flagged))
+entries = data.get("entries")
+if not isinstance(entries, list):
+    print("NO_ENTRIES_LIST")
+elif len(entries) < 2:
+    print("TOO_FEW_ENTRIES: %d" % len(entries))
+elif any(k not in e for e in entries for k in ("path", "type", "flag")):
+    print("ENTRY_MISSING_KEYS")
+elif "trim_candidate_count" not in data:
+    print("NO_TRIM_COUNT")
+else:
+    print("OK")
 ' 2>/dev/null)
-    if [ -z "$flagged" ]; then
-        pass "wizard repo's own SKILL.md files all stay below 5000-token threshold"
-    elif [ "$flagged" = "INVALID_JSON" ]; then
-        fail "audit --json produced invalid JSON; cannot enforce SKILL budget"
+    if [ "$verdict" = "OK" ]; then
+        pass "audit --json stays parseable with the real repo's multi-entry output"
     else
-        fail "wizard SKILL.md files exceed token threshold (act on the tool's findings): $flagged"
+        fail "audit --json must parse and carry >=2 well-formed entries, got: $verdict"
     fi
 }
 
@@ -221,11 +256,11 @@ test_audit_flags_oversized_skill_as_trim_candidate
 test_audit_does_not_flag_small_files
 test_audit_threshold_boundary_inclusive
 test_audit_json_output_includes_trim_count
+test_audit_json_is_parseable_on_real_repo
 test_audit_threshold_override
 test_audit_empty_repo_no_crash
 test_audit_ranks_by_size_descending
 test_audit_scans_consumer_install_layout
-test_wizard_own_skills_below_threshold
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
Closes #489.

## What

Deletes the CI gate that turned the session-load audit's TRIM flag into a build failure for `skills/sdlc/SKILL.md`. The audit tool itself is untouched — it still inventories every session-loaded asset and still raises TRIM rows.

## Why the number could not be enforced

`scripts/audit-session-load.sh` computes the threshold as `THRESHOLD_TOKENS × 4` — 5,000 (a round number) times 4 (a chars-per-token rule of thumb from a different vendor) — and `SDLC_AUDIT_THRESHOLD_TOKENS` moves it at will. Under the CLAIM RULE we do not enforce a number we never measured. #483 is where a measured ceiling would come from; it is still open.

## Why the cost was real

`skills/sdlc/SKILL.md` sat at **19,997 of 20,000 bytes**. Every subsequent edit had to buy its own bytes by degrading another instruction in the same file, and that trading shipped three defects in a single session — including invalid JSON and a dropped instruction value. A budget that forces a silent trade on every edit is a circling generator, which is the exact failure this milestone exists to end.

## The gate was never a coherent bloat policy

Found by Fable during review, verified independently by running the audit at base. The gate filtered `type == "skill"` only. Both files the audit actually flags today are ones it never touched:

```
40795  10198  hook          TRIM  hooks/instructions-loaded-check.sh
25711   6427  instructions  TRIM  SDLC.md
```

It failed the build over the smallest of the three oversized files while twice-larger shipped files sailed past.

## Coverage that was nearly lost

GPT-5.6 filed a P1 in round 1: the deleted test was the only place a real `json.loads` ran over the audit's REAL multi-entry output. The surviving JSON test greps substrings; the other parser test uses a single-entry fixture. Dropping the inter-entry commas left all nine survivors green.

Replaced with `test_audit_json_is_parseable_on_real_repo`, which asserts validity, `>= 2` entries, per-entry `path`/`type`/`flag`, and `trim_candidate_count` — and asserts **nothing** about sizes or flags, so it cannot become the ceiling gate by the back door. It passes today with `trim_candidate_count = 2`, which is the live proof of that.

Fable's audit of the swap found the replacement is a strict superset of the old test's JSON coverage: the old test *silently passed* a non-list `entries`, a missing per-entry key, and a missing `trim_candidate_count`, because the resulting `TypeError`/`KeyError` was swallowed by `2>/dev/null`. The only behaviour lost is the gate itself.

## Accepted, documented risk

Nothing automated runs the audit in report mode — the only invoker outside the test file is CI running the test suite. TRIM rows now surface **on demand**, when someone runs `scripts/audit-session-load.sh`. Until #483 produces a measured ceiling there is no automated bloat backstop for shipped skills. That is the deliberate trade, not an oversight.

## Verification

- RED/GREEN proven both directions: 20 bytes over the threshold → `Failed: 1` at base, `Failed: 0` on this branch, with the audit still printing the TRIM row.
- 65/65 non-E2E CI suites green locally; shellcheck clean (only the pre-existing SC2295, identical on base).
- `tests/test-cowork-drift.sh` byte-parity untouched: 31/31.
- `scripts/audit-session-load.sh` is comment-only — `--json` byte-identical to base at the default threshold and under `SDLC_AUDIT_THRESHOLD_TOKENS` override.

## Review

Two reviewers, two rounds each, independently:

- **GPT-5.6 Sol `high`** — round 1 NOT CERTIFIED (one P1, accepted and fixed); round 2 **CERTIFIED**, confidence 99, after running its own five JSON malformations, all caught.
- **Fable `xhigh`** — **CLEAR**, zero unresolved findings, after applying the diff to a scratchpad copy of base, running its own mutation RED proof, and fact-checking every load-bearing claim in the new comments.
