### PR TITLE
feat(sdlc): Fable decides the approach, and a guard may not outgrow its change (#530)

### DIFF
--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -124,6 +124,10 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **Skip (log justification):** trivial, hotfixes, risk < review cost. **Reviewer:** `gpt-5.6-sol` `high` — adversarial diversity. **Cadence:** Fable during design, Codex once per frozen scope; don't stack both unless the decision needs two independent reviewers.
 
+**Fable decides, Codex checks.** Fable rules on design, priority and sequencing *before* you commit to an approach — not a reviewer of work already done. A second repair to the same component in one cycle is a design question for Fable, not a third patch: review converges on a fix, never on the right design.
+
+**No test costs more rounds than the change it guards.** When a guard accretes rounds past its own change, delete the guard and file the follow-up — the rounds are being spent on the needle, not the risk. #476 spent six on twenty doc lines: four bought real defects, two bought spellings of `sudo`, and the guard was deleted at round six anyway (#551).
+
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 
 **Handoff/preflight mechanics: wizard doc.** These two stay; improvising them cost real time (#364, #437).

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -124,6 +124,10 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **Skip (log justification):** trivial, hotfixes, risk < review cost. **Reviewer:** `gpt-5.6-sol` `high` — adversarial diversity. **Cadence:** Fable during design, Codex once per frozen scope; don't stack both unless the decision needs two independent reviewers.
 
+**Fable decides, Codex checks.** Fable rules on design, priority and sequencing *before* you commit to an approach — not a reviewer of work already done. A second repair to the same component in one cycle is a design question for Fable, not a third patch: review converges on a fix, never on the right design.
+
+**No test costs more rounds than the change it guards.** When a guard accretes rounds past its own change, delete the guard and file the follow-up — the rounds are being spent on the needle, not the risk. #476 spent six on twenty doc lines: four bought real defects, two bought spellings of `sudo`, and the guard was deleted at round six anyway (#551).
+
 PROTOCOL is universal across domains; only `review_instructions` and `verification_checklist` change.
 
 **Handoff/preflight mechanics: wizard doc.** These two stay; improvising them cost real time (#364, #437).

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -3728,6 +3728,102 @@ $negated"
 test_wizard_prereqs_recommend_native_claude_install
 
 
+# Tests (#530): the standing setup the maintainer kept retyping every session
+# must live in the skill, not in a human's muscle memory.
+#
+# Most of what #530 asked for already shipped: the escalation ladder, the
+# model/effort policy, the clearance format, and PROCESS BUDGET are all in
+# skills/sdlc/SKILL.md already. Two things were not, and both are retyped:
+# Fable's role is to DECIDE, and a guard may not outgrow its change.
+#
+# Greps run INSIDE the Cross-Model Review section, never against the whole
+# file — a keyword that lands anywhere in a 20KB skill proves nothing. #493
+# caught three such assertions before they shipped, and that release went out
+# without the guard rather than with a vacuous one; #551 is the same story.
+#
+# `[^.;]*` throughout, not `[^.]*`: a semicolon ends a clause, and both
+# reviewers' inversion attacks worked by hopping one. These guards are
+# deliberately NOT a semantics engine — they catch drift and deletion, which
+# is what a grep can honestly promise. Adversarial prose is what the reviewers
+# are for, and chasing it is what cost #476 its last two rounds.
+extract_sdlc_cross_model_section() {
+    awk '
+        /^## Cross-Model Review/ { in_section = 1; print; next }
+        in_section && /^## / { in_section = 0 }
+        in_section { print }
+    ' "$1"
+}
+
+# The weak form already shipped: "Cadence: Fable during design". That says WHEN
+# Fable is consulted, not that Fable's answer settles the approach. The rule
+# being retyped is the strong one — Fable rules on design/priority/sequencing
+# BEFORE an approach is committed to.
+test_sdlc_skill_makes_fable_the_deciding_role() {
+    local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
+    if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
+    local section
+    section=$(extract_sdlc_cross_model_section "$SKILL")
+    if [ -z "$section" ]; then
+        fail "#530: no '## Cross-Model Review' section in skills/sdlc/SKILL.md to carry the standing setup"
+        return
+    fi
+    # Both halves required, each with its object named, each within one clause.
+    # Naming the objects is what defeats the inversion both reviewers found:
+    # "Fable decides nothing before lunch; Codex alone chooses every design"
+    # hops the semicolon to reach `design`, and its `before` takes `lunch`.
+    if ! printf '%s\n' "$section" | grep -qiE 'Fable[^.;]*\b(decides|rules|settles|chooses)\b[^.;]*\b(design|priority|sequencing)\b'; then
+        fail "#530: Cross-Model Review section must state that Fable DECIDES design/priority/sequencing — 'Fable during design' only says when to consult, which is why the role kept getting retyped"
+        return
+    fi
+    if ! printf '%s\n' "$section" | grep -qiE '\bbefore\b[^.;]*\b(approach|commit)'; then
+        fail "#530: the skill says Fable decides but not that it decides BEFORE an approach is committed to — deciding after the fact is just review, which is the role it already had"
+        return
+    fi
+    pass "#530: skill states Fable DECIDES design/priority/sequencing before an approach is committed to"
+}
+
+# #476 spent six review rounds on a twenty-line doc change. Rounds 1-4 bought
+# real defects; rounds 5-6 bought spellings of `sudo`.
+#
+# This is deliberately NOT a second round counter. The skill already has one —
+# "TWO PASSES PER FROZEN SCOPE" with its own recorded continue/stop escape —
+# and #476 burned six rounds with that rule already shipped, because each
+# repair re-froze the scope and bought two more passes. A cap was never the
+# missing piece; both reviewers said so independently, and the wizard doc
+# separately blesses continuation past round 4 for large migrations, where
+# v1.84.0's round 8 found a real shipped bug. A narrow cap would have
+# suppressed that round.
+#
+# What was missing is a RATIO: the guard may not outgrow the change. Both
+# halves must land in one clause, because three independent greps are
+# satisfiable by three unrelated sentences — which is precisely how a reviewer
+# broke the first draft of this test.
+test_sdlc_skill_caps_guard_cost_by_its_change() {
+    local SKILL="$REPO_ROOT/skills/sdlc/SKILL.md"
+    if [ ! -f "$SKILL" ]; then fail "skills/sdlc/SKILL.md not found"; return; fi
+    local section
+    section=$(extract_sdlc_cross_model_section "$SKILL")
+    if [ -z "$section" ]; then
+        fail "#530: no '## Cross-Model Review' section in skills/sdlc/SKILL.md to carry the guard-cost rule"
+        return
+    fi
+    if ! printf '%s\n' "$section" | grep -qiE '\btests?\b[^.;]*\brounds?\b[^.;]*\bchange it guards\b'; then
+        fail "#530: Cross-Model Review section does not tie a test's review cost to the change it guards — #476 spent six rounds on twenty doc lines and two of them bought spellings"
+        return
+    fi
+    # An over-budget guard has to go somewhere. Deleting it silently loses the
+    # risk it was written for; keeping it is what cost the six rounds.
+    if ! printf '%s\n' "$section" | grep -qiE '\bdelete\b[^.;]*\b(guard|test)\b[^.;]*(follow.up|file)'; then
+        fail "#530: the rule says a guard can outgrow its change but not what to do about it — deleting it without filing the follow-up loses the risk, keeping it is the six rounds"
+        return
+    fi
+    pass "#530: skill caps a guard's review cost by the change it guards, and routes the deleted guard to a follow-up"
+}
+
+test_sdlc_skill_makes_fable_the_deciding_role
+test_sdlc_skill_caps_guard_cost_by_its_change
+
+
 echo "=== Results: $PASSED passed, $FAILED failed ==="
 
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
Closes #530.

## What was actually missing

#530 said the maintainer is retyping the same standing setup every session. A DRY check first: most of it already ships.

| Asked for | Status |
|---|---|
| Escalation ladder (Fable → Codex → user) | ships, `SKILL.md:107` |
| Effort per model | ships, `:119` |
| `advisorModel: "fable"` setup | ships, `:121` |
| "Never ask what a model can settle" | ships, `:107` |
| PROCESS BUDGET + termination rules | ships, `:176-178` (#531) |
| Clearance format (marker, one json block, four keys) | ships, `:167` |

Two things were not, and both are ones that keep getting restated.

**1. Fable's role was a cadence, not an authority.** `"Fable during design"` says *when* to consult; it does not say the answer settles the approach. Now: Fable rules on design, priority and sequencing *before* an approach is committed to, and a second repair to the same component in one cycle is a design question rather than a third patch (#526).

**2. A guard may not outgrow its change.** See below — this one was redesigned mid-review.

## The acceptance bullets, one by one

- **"A test that fails if the standing setup is absent — not a keyword grep, an assertion that can actually go RED"** — MET. Section-scoped to `## Cross-Model Review`, four branches proven RED in isolation.
- **"The brief template shipped and referenced from the skill"** — DROPPED, premise falsified. `advisor()` works; it was used repeatedly while building this PR, including for the design ruling that produced it. The issue's mechanism paragraph ("server-side disabled repo-wide") is stale, and with it the 20x-invocation-cost argument for a template. The one sliver that survives — merge clearance needs a *fresh* subagent on the diff, because `advisor()` reads your transcript and structurally cannot be an independent reader of the artifact — is already documented at `:167`. Evidence posted to #530.
- **"SKILL.md is at 19,356/20,000 bytes, so any addition needs an equal-or-greater trim"** — OBSOLETE. #489 deleted that ceiling; it filtered `type=="skill"` while the files the audit actually flags are a hook at 40,795 chars and `SDLC.md` at 25,711.

## The redesign both reviewers forced

This shipped as **"Two review rounds per issue"** in round 1. Codex and Fable independently killed it, and they were right: `SKILL.md:138` already carries the counter — **"Convergence — TWO PASSES PER FROZEN SCOPE"** — with its own `scope_decisions` continue/stop escape. A second counter with a different unit (issue vs. frozen scope) and a second escape hatch (false-claim-or-dead-check) contradicts it.

Fable found the argument that settled it: `CLAUDE_CODE_SDLC_WIZARD.md:4108` and `:4271` bless recorded-decision continuation past round 4 for large migrations, and **v1.84.0's round 8 found a real shipped bug**. The narrow exception would have suppressed that round.

And #476 burned six rounds *with the TWO PASSES rule already shipped*, because each repair re-froze scope and bought two more passes. A cap was never the missing piece.

So the paragraph is deleted, not reworded. What ships is the ratio:

> **No test costs more rounds than the change it guards.** When a guard accretes rounds past its own change, delete the guard and file the follow-up — the rounds are being spent on the needle, not the risk.

`git diff` against base shows **zero deletions** in `SKILL.md` — pure additions — so `:138` and the CI "Max 3 iterations" line are provably untouched. Both reviewers verified this independently.

## Guard design, and its declared limit

Section-scoped, never file-wide: a keyword landing anywhere in a 20KB skill proves nothing. #493 caught three such assertions and that release shipped *without* the guard rather than with a dead one. (An earlier draft of this PR's comment said #493 *shipped* three vacuous assertions — false, caught by Codex, fixed.)

Clause-bounded with `[^.;]*` and requiring the objects (`design|priority|sequencing`; `before … approach|commit`), because both reviewers' inversions worked by hopping a semicolon. Every counterexample either reviewer wrote now goes RED — verified by substituting each into the file and running, not by assertion:

| Prose | Result |
|---|---|
| `Fable decides nothing before lunch; Codex alone chooses every design after implementation.` | RED |
| `Fable never decides anything before Codex has reviewed the finished diff; consult whoever is available.` | RED |
| `Three rounds happened yesterday. False claims and dead checks are words. Follow up about lunch.` | RED |
| `We once spent three review rounds here; no finding was a false claim or a dead check, and the discussion moved to a follow-up thread.` | RED |

**Declared residual, non-blocking:** in-clause negation (`Fable never rules on design…`) still passes. Stated in the test comments themselves. Fable rated it P3 self-closing, primary-sourcing #551's five-rung escalation ladder where every rung is negation handling or needle widening, and ruled the current form stops before rung 1. Chasing it would make this test cost more rounds than the four lines it guards — the rule this PR ships.

## Review

**GPT-5.6 Sol `high` — CERTIFIED 98**, 3 rounds. Round 1 NOT CERTIFIED (99) with four P1s: the counter contradiction, two vacuity findings, and a false claim about #493. Round 2 NOT CERTIFIED (99) holding on two negation inversions. Round 3 was a **zero-diff dispute**, and it accepted:

> I would take neither proposed door: adding negation handling exceeds issue 530's closed allowlist and enters issue 551's unbounded semantic ladder. Deleting the tests violates issue 530's explicit acceptance criterion. The appropriate disposition is to accept the documented limitation as non-blocking.

The dispute opened by retracting my own error: I had told Codex in the round-2 prompt that "wrong-rule prose passing is a live finding," which is not #530's criterion. It was blocking on a bar I invented, and said so.

**Fable `xhigh` — CLEAR 95** (90 → 95), 2 rounds. Verified everything by running against a scratch copy of base+diff, ratified the scope decision under `:138`'s own procedure, and fact-checked both historical claims (#476's six rounds, #489's ceiling) against primary sources.

**Process:** the redesign exceeded the round-1 diff, so the continue/stop decision and its cost were written into `.reviews/handoff.json` **before** the pass — the first live use of the rule being shipped. Reviewer invocation 3 (#542's pre-registered failure signal) was likewise recorded before the call; Codex independently verified that record's accuracy and timestamps.

**Tests:** 65/65 non-E2E suites green. `doc-consistency` 132/132, `cowork-drift` 31/31, byte parity `cmp`-verified.
