### PR TITLE
docs(sdlc): fixed means observed — name the observable before reporting a fix

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2781,6 +2781,12 @@ Reproduce → Isolate → Root Cause → Fix → Regression Test
 
 **Environment-specific bugs** (works locally, fails in CI/staging/prod): Check environment differences (env vars, OS version, dependency versions, file permissions). Reproduce the environment locally if possible. Add logging at the failure point — don't guess, observe.
 
+### Fixed Means Observed
+
+Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
+
+**Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
 ## Step 8: Create CLAUDE.md
 
 Create `CLAUDE.md` in your project root. This is your project-specific configuration:

--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -189,6 +189,12 @@ Mandatory steps:
 
 Reproduce → Isolate → Root Cause → Fix → Regression Test. No skipping. `git bisect` for regressions. 2 failed attempts → escalate (Confidence Check), not straight to the user.
 
+## Fixed Means Observed
+
+Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
+
+**Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
 ## Release Planning (Task Ships a Release)
 
 All ROADMAP items planned at 95%, dependencies identified, presented together (catches conflicts), pre-release CI audit across merged PRs — a green checkmark is insufficient. User approves, then implement in priority order.

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -189,6 +189,12 @@ Mandatory steps:
 
 Reproduce → Isolate → Root Cause → Fix → Regression Test. No skipping. `git bisect` for regressions. 2 failed attempts → escalate (Confidence Check), not straight to the user.
 
+## Fixed Means Observed
+
+Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
+
+**Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
 ## Release Planning (Task Ships a Release)
 
 All ROADMAP items planned at 95%, dependencies identified, presented together (catches conflicts), pre-release CI audit across merged PRs — a green checkmark is insufficient. User approves, then implement in priority order.


### PR DESCRIPTION
Closes #525.

A settings fix was reported fixed on 2026-08-08 while the bug was still live. The evidence for "fixed" was that the edit had been made — nothing had been observed. The answer was already sitting in `.reviews/` from PR #468.

Adds one section: name the observable that would differ if the change were NOT fixed, then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it.

Plus the corollary that makes this class recur: **out-of-repo changes get no gate.** Global `settings.json`, env vars, shell rc, scheduler entries produce no diff, no PR, and no reviewer. They need the verification command stated in the same message as the change, and if a live process won't pick up the edit, that has to be said instead of "fixed".

18 additive lines across `skills/sdlc/SKILL.md`, the byte-identical `cowork/` copy, and the wizard mirror.

**Tests: none, deliberately.** Bucket three of the three-way call — prose whose correctness is a judgement call. Cross-model review is the guard, and both legs ran. `test-doc-consistency.sh` 137/137 and `test-cowork-drift.sh` 31/31 already cover the mechanical contract (byte parity).

**Both reviewers certified at round 1 with zero findings at every severity** — the first zero-finding review of this cycle. Sol independently verified that PR #468's review artifact predates the incident and confirmed `Math.floor(window * (PCT_OVERRIDE / 100))` against Claude Code v2.1.221. Fable independently reproduced both verifications from primary sources and swept all shipped prose for contradicting rules, finding none.

Merging on `--user-approved` rather than `--dual-certified`: the gate requires `round >= 2`, and there were zero findings for a round 2 to be about. Filing that as its own defect.
