### PR TITLE
Scope TDD RED to where a RED mutation is writable, and delete the hook that blocked the maintainer from asking for it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
         "url": "https://github.com/BaseInfinity/claude-sdlc-harness.git",
         "path": "cowork"
       },
-      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
+      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
       "version": "1.96.0",
       "author": {
         "name": "Stefan Ayala"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,16 @@ lived on). It does **not** see skill-frontmatter hooks: verified empirically
 inventory. Those are guarded at source by the shipped-file walk in
 `tests/test-cowork-drift.sh`.
 
-**No native command enumerates all effective hooks.** An undocumented future
-registration mechanism is uncovered by any check here — cross-model diff review
-is the guard, and it found every missing surface to date.
+**No non-interactive, install-time command inventories dormant hooks across
+every skill.** The interactive `/hooks` command does see them — verified
+2026-08-10: activating a skill-frontmatter `UserPromptSubmit` hook moved it
+24 → 25 total and 3 → 4 `UserPromptSubmit`. It is interactive and session-bound,
+so it cannot serve as a release gate, but it is the tool to reach for when
+diagnosing what is actually live in a session.
+
+An undocumented future registration mechanism is uncovered by any check here —
+cross-model diff review is the guard, and it found every missing surface to
+date.
 
 Note it reads the installed cache, not the working tree, so installing first is
 mandatory: run it against an unupdated cache and it reports the OLD plugin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,19 +57,28 @@ table. Run any suite directly; a few common ones:
 Run the whole suite before any release. It takes minutes, not seconds, and
 some fixtures need `dangerouslyDisableSandbox` to create their temp dirs.
 
-**Also before any release, verify the Cowork plugin's EFFECTIVE hooks natively**
-(GH #561). Install the working-tree plugin from the local marketplace, then:
+**Release verification (Cowork plugin)** — GH #561. Install the working-tree
+plugin from the local marketplace, then:
 
 ```
 claude plugin details sdlc-wizard-cowork
 ```
 
-It must report exactly `Hooks (1)  PreToolUse` — whitelist the full expected
-set, never the absence of one name. `claude plugin details` reports effective
-hooks *however registered*, so it is the only check that sees a registration
-surface the CI walk does not know about. It cannot run in CI (no `claude` CLI)
-and reads the installed cache rather than the working tree, so installing first
-is required — run it against an unupdated cache and it reports the OLD plugin.
+It must report exactly `Hooks (1)  PreToolUse`.
+
+This verifies the **installed artifact's manifest-registered hooks**
+(`hooks/hooks.json` and manifest `hooks` fields — the surface the #561 hook
+lived on). It does **not** see skill-frontmatter hooks: verified empirically
+2026-08-10, an active frontmatter `UserPromptSubmit` hook did not appear in the
+inventory. Those are guarded at source by the shipped-file walk in
+`tests/test-cowork-drift.sh`.
+
+**No native command enumerates all effective hooks.** An undocumented future
+registration mechanism is uncovered by any check here — cross-model diff review
+is the guard, and it found every missing surface to date.
+
+Note it reads the installed cache, not the working tree, so installing first is
+mandatory: run it against an unupdated cache and it reports the OLD plugin.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,20 @@ table. Run any suite directly; a few common ones:
 Run the whole suite before any release. It takes minutes, not seconds, and
 some fixtures need `dangerouslyDisableSandbox` to create their temp dirs.
 
+**Also before any release, verify the Cowork plugin's EFFECTIVE hooks natively**
+(GH #561). Install the working-tree plugin from the local marketplace, then:
+
+```
+claude plugin details sdlc-wizard-cowork
+```
+
+It must report exactly `Hooks (1)  PreToolUse` — whitelist the full expected
+set, never the absence of one name. `claude plugin details` reports effective
+hooks *however registered*, so it is the only check that sees a registration
+surface the CI walk does not know about. It cannot run in CI (no `claude` CLI)
+and reads the installed cache rather than the working tree, so installing first
+is required — run it against an unupdated cache and it reports the OLD plugin.
+
 ## Code Style
 
 ### Markdown

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -4842,6 +4842,8 @@ Use the best tool for the job. If Claude Code builds it better, use theirs.
 
 **What's NOT ported and why** (CLI-specific, filesystem-dependent, or event-unavailable in Cowork): `instructions-loaded-check.sh`, `model-effort-check.sh`, `precompact-seam-check.sh`, the Setup/Update skills, cross-model review via `codex exec` (use ChatGPT/Codex web manually instead), and the CI shepherd (`gh pr`, `git push` — these happen outside a Cowork session).
 
+**Removed rather than not ported:** `sdlc-prompt-check.sh` was ported to a Cowork `UserPromptSubmit` classifier and then deleted in v1.97.0 (GH #561) after it denied the maintainer's own instructions twice. Blocking hooks belong on acts, not on turn-level subject matter — see [`cowork/README.md`](cowork/README.md) for what that costs.
+
 **Install:** add the whole repo as a marketplace, then install the Cowork-specific plugin from it:
 
 ```

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -146,7 +146,7 @@ These aren't preferences - they're **how AI agents stay on track**:
 
 | Core Principle | Why It's Critical for AI |
 |----------------|--------------------------|
-| **TDD Red-Green-Pass** | AI agents need concrete pass/fail feedback. Without failing tests first, Claude can't verify its work. This is the feedback loop that keeps implementation correct. |
+| **TDD Red-Green-Pass** | AI agents need concrete pass/fail feedback. Where a RED mutation is writable, failing tests first are the feedback loop that keeps implementation correct; where no assertion can catch the wrong version (meaning-level prose), cross-model review is the verification — see "When TDD RED Applies". |
 | **Testing Diamond** | Integration tests catch real bugs. Unit tests with mocks can "pass" while production fails. AI agents need tests that actually validate behavior. |
 | **Confidence Levels** | Prevents Claude from guessing when uncertain. LOW confidence = escalate (Fable, then Codex) before interrupting a human. This stops runaway bad implementations. |
 | **TodoWrite Visibility** | You need to see what Claude is doing. Without visibility, Claude can go off-track without you knowing. |
@@ -183,7 +183,7 @@ You CAN change these, but understand the trade-offs:
 | Customization | Default | Risk if Changed |
 |---------------|---------|-----------------|
 | **Testing shape** | Diamond (integration-heavy) | Pyramid (unit-heavy) = mocks can hide real bugs, AI gets false confidence |
-| **TDD strictness** | Strict (test first always) | Flexible = AI may skip tests, no verification of correctness |
+| **TDD strictness** | Strict (test first wherever a RED mutation is writable) | Flexible = AI may skip tests, no verification of correctness |
 | **Planning mode** | Required for implementation | Skipping = Claude codes without understanding, wasted effort |
 | **Confidence thresholds** | LOW < 60% = must escalate | Higher threshold = Claude proceeds when unsure, mistakes |
 
@@ -673,7 +673,7 @@ PASS  → All tests pass (no regressions)
 **The core principle:** Have a testing strategy. Know what you're testing and why.
 
 **Customize for your team:**
-- Strict TDD (test first always)? Great.
+- Strict TDD (test first wherever a RED mutation is writable)? Great.
 - Test-after for some cases? Fine, just be consistent.
 - The key: **don't commit code that breaks existing tests.**
 
@@ -2069,7 +2069,7 @@ redundant summaries, or boilerplate."
 **Testing approach** (infer from existing test patterns — test-first files, coverage config)
 ```
 Options:
-- Strict TDD (test first always)
+- Strict TDD (test first wherever a RED mutation is writable)
 - Test-after (write tests after implementation)
 - Mixed (depends on the feature)
 - Minimal (just critical paths)
@@ -2619,6 +2619,10 @@ PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Cross-Model Revie
 
 ## Testing and Debugging Practices
 
+### When TDD RED Applies
+
+**TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
+
 Practices that outlive any one task: keeping the suite trustworthy, and finding a cause
 instead of guessing at one.
 
@@ -2798,7 +2802,7 @@ Create `CLAUDE.md` in your project root. This is your project-specific configura
 
 **STOP! Before writing ANY implementation code:**
 
-1. **Write failing tests FIRST** (TDD RED phase)
+1. **Write failing tests FIRST** (TDD RED) — where a failing test can be written; meaning-level prose changes get cross-model review instead (do not write the test)
 2. **Use integration tests** primarily - see TESTING.md
 3. **Use REAL fixtures** for mock data - never guess API shapes
 
@@ -4277,7 +4281,7 @@ implement  →  fix in-allowlist findings  →  re-review with the ITERATION mod
 3. **Any P0/P1 finding *against a requested behavior* restarts the cycle from the top** — one outside the closed allowlist becomes a linked follow-up issue and does not restart anything. A gate round that surfaces a real defect was not a gate round, it was an iteration round. In-allowlist P2/P3-only findings do not need a full restart: fix them and re-run the gate. Either way the gate must eventually return nothing unresolved *against the requested behaviors* — "findings?" in the diagram means any finding against those, and what differs is only whether you re-enter at iteration or at the gate. Findings outside the allowlist are logged as follow-up issues and never gate anything; the unsatisfiable version of this condition — zero defects anywhere — is what turned #520 into 20 rounds.
 4. **Fixes need their own verification.** A fix shipped on the strength of "the reviewer suggested it" is unverified code — the reviewer proposed it, nobody has yet shown it works. A test that passes against broken code was never a test.
 
-   **TDD, applied to the fix: RED → GREEN.** Write the assertion, run it, watch **that specific assertion** fail, then implement and watch it pass. The common miss is observing red at the *suite* level — one assertion fails, the suite is red, you implement, the suite goes green, and any assertion that was green from birth is never noticed.
+   **TDD, applied to the fix: RED → GREEN** — where a RED mutation is writable; a meaning-level prose fix gets cross-model re-review instead (see "When TDD RED Applies"). Write the assertion, run it, watch **that specific assertion** fail, then implement and watch it pass. The common miss is observing red at the *suite* level — one assertion fails, the suite is red, you implement, the suite goes green, and any assertion that was green from birth is never noticed.
 
    **Editing an existing test is the hard case, and the honest answer depends on what it guards.** If it guards a bug you are about to fix, RED is free — the bug exists, so the test fails for the right reason. If it guards behaviour that is **already correct**, **you cannot get RED**: correct code does not fail, and rewriting does not change that. Say so plainly rather than calling the assertion verified — an unverified regression test is exactly how this repo shipped eight that passed against broken code. When an assertion is load-bearing enough to justify it, breaking the behaviour once to watch the test go red is the only mechanism that validates that class; treat it as a deliberate exception, not the routine.
 

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -4829,12 +4829,11 @@ Use the best tool for the job. If Claude Code builds it better, use theirs.
 
 **Claude Cowork** is a separate product from Claude Code — a desktop application for knowledge workers, not developers. It shares Claude Code's plugin format, so this wizard ships a Cowork-native subset: [`cowork/`](cowork/README.md).
 
-**What it provides:** 2 portable skills (`/sdlc-wizard-cowork:sdlc`, `/sdlc-wizard-cowork:feedback`) plus 2 **prompt-based hooks** — the Cowork equivalents of this wizard's bash hooks, since Cowork sessions have no shell access:
+**What it provides:** 2 portable skills (`/sdlc-wizard-cowork:sdlc`, `/sdlc-wizard-cowork:feedback`) plus 1 **prompt-based hook** — the Cowork equivalent of this wizard's bash hooks, since Cowork sessions have no shell access:
 
 | Cowork Hook | Claude Code Equivalent | Event |
 |-------------|------------------------|-------|
 | TDD check | `tdd-pretool-check.sh` | `PreToolUse` (Write/Edit/MultiEdit) |
-| SDLC baseline | `sdlc-prompt-check.sh` | `UserPromptSubmit` |
 
 
 **What's NOT ported and why** (CLI-specific, filesystem-dependent, or event-unavailable in Cowork): `instructions-loaded-check.sh`, `model-effort-check.sh`, `precompact-seam-check.sh`, the Setup/Update skills, cross-model review via `codex exec` (use ChatGPT/Codex web manually instead), and the CI shepherd (`gh pr`, `git push` — these happen outside a Cowork session).

--- a/cowork/.claude-plugin/marketplace.json
+++ b/cowork/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "stefan@baseinfinity.dev"
   },
   "metadata": {
-    "description": "SDLC enforcement for Claude Cowork sessions via prompt-based hooks and skills",
+    "description": "SDLC enforcement for Claude Cowork sessions via skills and one prompt-based hook",
     "version": "1.96.0"
   },
   "plugins": [
     {
       "name": "sdlc-wizard-cowork",
       "source": ".",
-      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
+      "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
       "version": "1.96.0",
       "author": {
         "name": "Stefan Ayala"

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc-wizard-cowork",
   "version": "1.96.0",
-  "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via prompt-based hooks and skills",
+  "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
   "author": {
     "name": "Stefan Ayala",
     "url": "https://github.com/BaseInfinity"

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -6,7 +6,7 @@ This project's primary target is **Claude Code (CLI)**. Cowork support is a bonu
 and will never hold the CLI back. What ships here is deliberately the shallow version.
 
 **You get:** the complete `/sdlc` operational checklist — byte-identical to the CLI skill,
-nothing removed — plus the `/feedback` skill and two best-effort prompt hooks.
+nothing removed — plus the `/feedback` skill and one best-effort prompt hook.
 
 **You do not get:**
 
@@ -14,10 +14,11 @@ nothing removed — plus the `/feedback` skill and two best-effort prompt hooks.
   optional depth; in Cowork those citations are inert. The checklist is the complete
   contract on its own, and the skill says so at the top.
 - Setup/update skills, shell hooks, the CLI installer, or cross-model review tooling.
-- **Enforcement.** Live testing (GH #456) found the prompt hooks do not reliably gate, and
-  the completion hook was removed in v1.92.0 after firing 12 times and being wrong 11. The
-  two remaining hooks are nudges with **no enforcement guarantee**. That rewrite has not
-  been re-validated live — treat enforcement as unproven, not merely absent.
+- **Enforcement.** Live testing (GH #456) found the prompt hooks do not reliably gate. The
+  completion hook was removed in v1.92.0 after firing 12 times and being wrong 11, and the
+  prompt classifier in v1.97.0 (GH #561) after denying the maintainer's own instructions
+  twice. The one remaining hook is a nudge with **no enforcement guarantee** — treat
+  enforcement as unproven, not merely absent.
 
 **If you have a terminal, use the full wizard:** `npx agentic-sdlc-wizard init`.
 

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -33,20 +33,18 @@ defects — to fix pointers that are inert text here anyway.
 | SDLC skill | `/sdlc-wizard-cowork:sdlc` | Full SDLC workflow: planning, TDD, self-review |
 | Feedback skill | `/sdlc-wizard-cowork:feedback` | Privacy-first community feedback and pattern sharing |
 | TDD hook | `PreToolUse` (Write/Edit) | Denies creating a new non-test file that doesn't look like a test (filename heuristic — see limits below) |
-| SDLC baseline hook | `UserPromptSubmit` | Denies prompts that explicitly ask to skip planning/testing/review |
 | ~~Completion hook~~ | ~~`Stop`~~ | **REMOVED in v1.92.0 (GH #484).** It fired 12 times in one session and was wrong 11 — blocking turns that changed no files, turns already verified, and repeatedly overriding its own stated exemptions. A `Stop` hook fires at the end of *every* turn, so a blocking one interrupts constantly. There is now **no completion enforcement in Cowork**; see the honesty note below. |
 
 ## Hooks — Prompt-Based Enforcement
 
-This plugin ships 2 **prompt-based hooks** (`"type": "prompt"`) — a narrow slice of SDLC discipline, without shell access. The `Stop` (completion) hook was removed in v1.92.0; see GH #484.
+This plugin ships 1 **prompt-based hook** (`"type": "prompt"`) — a narrow slice of SDLC discipline, without shell access. The `Stop` (completion) hook was removed in v1.92.0 (GH #484) and the `UserPromptSubmit` hook in v1.97.0 (GH #561).
 
 | Cowork Hook | Claude Code Equivalent | Event |
 |-------------|----------------------|-------|
 | TDD check | `tdd-pretool-check.sh` | `PreToolUse` (Write/Edit/MultiEdit) |
-| SDLC baseline | `sdlc-prompt-check.sh` | `UserPromptSubmit` |
 
 
-**Prompt hooks do not inject text into the main conversation.** Per Anthropic's documented `prompt` hook contract (`code.claude.com/docs/en/hooks`), each hook sends its `prompt` field to a separate, single-turn evaluator model (Haiku by default), with the hook's JSON input either substituted at `$ARGUMENTS` or auto-appended if `$ARGUMENTS` is omitted. The evaluator must respond `{"ok": true}` to allow, or `{"ok": false, "reason": "..."}` to deny — no shell, no filesystem access needed, but also no soft reminders: it's a real gate, not a nudge. `UserPromptSubmit`'s block ends the turn outright with no retry, so it's scoped narrowly (see the hook's own prompt in `hooks/hooks.json`).
+**Prompt hooks do not inject text into the main conversation.** Per Anthropic's documented `prompt` hook contract (`code.claude.com/docs/en/hooks`), each hook sends its `prompt` field to a separate, single-turn evaluator model (Haiku by default), with the hook's JSON input either substituted at `$ARGUMENTS` or auto-appended if `$ARGUMENTS` is omitted. The evaluator must respond `{"ok": true}` to allow, or `{"ok": false, "reason": "..."}` to deny — no shell, no filesystem access needed, but also no soft reminders: it's a real gate, not a nudge.
 
 **Known limit:** the `PreToolUse` TDD check can only see the current file write, not prior turns or the filesystem — it's a best-effort filename heuristic (denies creating a new non-test file), not proof a failing test was actually run first. A `type: "agent"` hook (multi-turn, with Read/Grep/Glob access) would be the mechanically correct fix for real TDD-order verification; that's a larger, separate change, tracked as a follow-up rather than attempted here.
 
@@ -70,7 +68,11 @@ This plugin ships 2 **prompt-based hooks** (`"type": "prompt"`) — a narrow sli
 - **CI shepherd** (`gh pr`, `git push`) — these steps happen outside your Cowork session
 - **`/code-review`** — works in Cowork if the plugin is loaded
 
-The methodology (plan → TDD → cross-model review → confidence check) is universal, and the skills describe all of it. **The hooks enforce only a narrow slice of it** — do not read the table above as full enforcement. `UserPromptSubmit` denies prompts that explicitly ask to skip process; `PreToolUse` applies a filename heuristic to brand-new non-test files. **There is no completion gate** — the `Stop` hook was removed in v1.92.0 (GH #484) after scoring 11 false positives in 12 firings. Everything else is guidance you follow, not a gate that stops you.
+The methodology (plan → TDD → cross-model review → confidence check) is universal, and the skills describe all of it. **One hook remains, and it enforces very little** — do not read the table above as full enforcement. `PreToolUse` applies a filename heuristic to brand-new non-test files. That is the whole of it.
+
+**There is no completion gate and no prompt gate.** The `Stop` hook was removed in v1.92.0 (GH #484) after scoring 11 false positives in 12 firings; the `UserPromptSubmit` classifier was removed in v1.97.0 (GH #561) after denying the maintainer's own instructions twice, the second time after a narrowing repair. Blocking hooks belong on ACTS, not on turn-level subject matter.
+
+**The honest cost of that removal:** a prompt asking to skip planning or review, followed by edits to files that already exist, now hits no gate at all — `PreToolUse` fails open for edits, and the CLI's commit and merge gates cannot run in Cowork, which has no shell. Everything else is guidance you follow, not a gate that stops you.
 
 ## Installation
 
@@ -102,7 +104,7 @@ This is a **subset** of the [SDLC Harness](https://github.com/BaseInfinity/claud
 - CLI installer (`npx agentic-sdlc-wizard init`)
 - npm package distribution
 
-This Cowork plugin provides 2 portable skills + 2 prompt-based hooks — a narrow slice of enforcement without shell access.
+This Cowork plugin provides 2 portable skills + 1 prompt-based hook — a narrow slice of enforcement without shell access.
 
 ### Drift Prevention
 

--- a/cowork/hooks/hooks.json
+++ b/cowork/hooks/hooks.json
@@ -12,17 +12,6 @@
           }
         ]
       }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "The user just submitted this prompt: $ARGUMENTS\n\nA block on this event ends the turn outright with no chance to retry, so only deny prompts that explicitly try to bypass SDLC safeguards with nothing put in their place.\n\nDistinguish a BYPASS from a JUSTIFIED EXCEPTION.\n\nA BYPASS asks to drop a safeguard and offers nothing instead: \"skip the tests\", \"don't write a plan\", \"just implement it directly, don't bother testing\", \"ignore TDD\". Deny these.\n\nA JUSTIFIED EXCEPTION names a stated reason AND a stated alternative, so the safeguard is substituted rather than removed. Example: \"don't TDD this, it is a one-time mechanical rename that will not recur, just verify after that things are right\". That is a reasoned engineering call with verification still attached \u2014 allow it. Judge the substance, not the presence of the word \"skip\".\n\nWhen a prompt is ambiguous, allow it. This gate ends the turn with no retry, so a wrong denial costs the user their whole turn while a wrong allow costs nothing \u2014 the downstream TDD and review gates still apply.\n\nRespond with JSON: {\"ok\": true} if it does NOT ask to bypass a safeguard \u2014 this is the normal case for almost every prompt, including ordinary code requests with no explicit plan attached, and including justified exceptions as defined above. Respond with {\"ok\": false, \"reason\": \"...\"} only if it asks to drop planning, testing, or review outright with no reason and no alternative given.",
-            "timeout": 10
-          }
-        ]
-      }
     ]
   }
 }

--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -36,7 +36,7 @@ TodoWrite([
   // TRANSITION
   { content: "Doc sync: update or create feature doc — MUST be current before commit", status: "pending" },
   // IMPLEMENTATION
-  { content: "TDD RED: failing test FIRST — watch EACH assertion fail, not the suite", status: "pending" },
+  { content: "TDD RED: failing test FIRST where a RED mutation is writable — watch EACH assertion fail; otherwise three-way call (see TDD proves)", status: "pending" },
   { content: "TDD GREEN: Implement, verify test passes", status: "pending" },
   { content: "Run lint/typecheck", status: "pending" },
   { content: "Run ALL tests", status: "pending" },
@@ -66,7 +66,7 @@ TodoWrite([
 |-----------|--------|-----------|-------------|
 | task_tracking | 1 | | Use TodoWrite or TaskCreate |
 | confidence | 1 | | State HIGH/MEDIUM/LOW |
-| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files |
+| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files, where a RED mutation is writable (see TDD proves) |
 | plan_mode_outline | 1 | | Outline steps before coding |
 | plan_mode_tool | 1 | | Use TodoWrite/TaskCreate/EnterPlanMode |
 | tdd_green_ran | 1 | | Run tests, show runner output |
@@ -74,7 +74,7 @@ TodoWrite([
 | self_review | 1 | | Read back files/diffs you modified |
 | clean_code | 1 | | One coherent approach, no dead code |
 
-**Total: 10 points** (11 for UI tasks, +1 for design_system check). Critical miss on `tdd_red` = process failure regardless of total score.
+**Total: 10 points** (11 for UI tasks, +1 for design_system check). Critical miss on `tdd_red` = process failure regardless of total score — when a RED mutation was writable. Out-of-scope under the three-way call is not a miss.
 
 ## Test Failure Recovery
 
@@ -220,13 +220,13 @@ Critique tests harder than app code: testing the right things? Proving correctne
 
 Mocks MUST come from real captured data — never guess shapes. Unit tests qualify ONLY for pure I→O (no DB, API, FS, cache).
 
-**TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection).
+**TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
 
 ## Prove It Gate (New Additions Only)
 
-New skill/hook/workflow/PRACTICE? Default answer is NO. Prove it: (1) **Absorption check** — can this be a section in an existing skill? (2) Research equivalents (native CC, third-party, existing skill). (3) If one exists — why is yours better, with evidence. (4) If not — real gap or theoretical? (5) **Quality tests** must prove OUTPUT QUALITY (existence tests prove nothing). (6) Less is more — every addition is burden.
+New skill/hook/workflow/PRACTICE? Default answer is NO. Prove it: (1) **Absorption check** — can this be a section in an existing skill? (2) Research equivalents (native CC, third-party, existing skill). (3) If one exists — why is yours better, with evidence. (4) If not — real gap or theoretical? (5) **Quality tests** must prove OUTPUT QUALITY (existence tests prove nothing) — scoped by the three-way call: prose whose correctness is a judgement call gets cross-model review, not a grep. (6) Less is more — every addition is burden.
 
-If you can't write a quality test for it, you can't prove it works.
+If you can't name the evidence that would prove it works — a test or a cross-model review — you can't prove it works.
 
 ## After Session (Capture Learnings)
 
@@ -245,10 +245,10 @@ End of release: audit `~/.claude/projects/<proj>/memory/`, promote portable less
 ## Post-Mortem: Process Failures Become Rules
 
 ```
-Incident → Root Cause → New Rule → Test That Proves the Rule → Ship
+Incident → Root Cause → New Rule → Evidence per the Three-Way Call → Ship
 ```
 
-Don't fix only the symptom. Add a gate so it can't happen again. Example: PR #145 auto-merged before CI review → "NEVER AUTO-MERGE" block + `test_never_auto_merge_gate`.
+Don't fix only the symptom. Guard the rule per the three-way call (see TDD proves) — EVAL it, plain-assert it, or cross-model review for meaning-level prose. Sometimes the fix is DELETING a gate (#484, #561). Example: PR #145 auto-merged before CI review → "NEVER AUTO-MERGE" block + `test_never_auto_merge_gate`.
 
 ## Context Management & Subagents
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -36,7 +36,7 @@ TodoWrite([
   // TRANSITION
   { content: "Doc sync: update or create feature doc — MUST be current before commit", status: "pending" },
   // IMPLEMENTATION
-  { content: "TDD RED: failing test FIRST — watch EACH assertion fail, not the suite", status: "pending" },
+  { content: "TDD RED: failing test FIRST where a RED mutation is writable — watch EACH assertion fail; otherwise three-way call (see TDD proves)", status: "pending" },
   { content: "TDD GREEN: Implement, verify test passes", status: "pending" },
   { content: "Run lint/typecheck", status: "pending" },
   { content: "Run ALL tests", status: "pending" },
@@ -66,7 +66,7 @@ TodoWrite([
 |-----------|--------|-----------|-------------|
 | task_tracking | 1 | | Use TodoWrite or TaskCreate |
 | confidence | 1 | | State HIGH/MEDIUM/LOW |
-| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files |
+| tdd_red | 2 | **YES** | Write/edit test files BEFORE implementation files, where a RED mutation is writable (see TDD proves) |
 | plan_mode_outline | 1 | | Outline steps before coding |
 | plan_mode_tool | 1 | | Use TodoWrite/TaskCreate/EnterPlanMode |
 | tdd_green_ran | 1 | | Run tests, show runner output |
@@ -74,7 +74,7 @@ TodoWrite([
 | self_review | 1 | | Read back files/diffs you modified |
 | clean_code | 1 | | One coherent approach, no dead code |
 
-**Total: 10 points** (11 for UI tasks, +1 for design_system check). Critical miss on `tdd_red` = process failure regardless of total score.
+**Total: 10 points** (11 for UI tasks, +1 for design_system check). Critical miss on `tdd_red` = process failure regardless of total score — when a RED mutation was writable. Out-of-scope under the three-way call is not a miss.
 
 ## Test Failure Recovery
 
@@ -220,13 +220,13 @@ Critique tests harder than app code: testing the right things? Proving correctne
 
 Mocks MUST come from real captured data — never guess shapes. Unit tests qualify ONLY for pure I→O (no DB, API, FS, cache).
 
-**TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection).
+**TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
 
 ## Prove It Gate (New Additions Only)
 
-New skill/hook/workflow/PRACTICE? Default answer is NO. Prove it: (1) **Absorption check** — can this be a section in an existing skill? (2) Research equivalents (native CC, third-party, existing skill). (3) If one exists — why is yours better, with evidence. (4) If not — real gap or theoretical? (5) **Quality tests** must prove OUTPUT QUALITY (existence tests prove nothing). (6) Less is more — every addition is burden.
+New skill/hook/workflow/PRACTICE? Default answer is NO. Prove it: (1) **Absorption check** — can this be a section in an existing skill? (2) Research equivalents (native CC, third-party, existing skill). (3) If one exists — why is yours better, with evidence. (4) If not — real gap or theoretical? (5) **Quality tests** must prove OUTPUT QUALITY (existence tests prove nothing) — scoped by the three-way call: prose whose correctness is a judgement call gets cross-model review, not a grep. (6) Less is more — every addition is burden.
 
-If you can't write a quality test for it, you can't prove it works.
+If you can't name the evidence that would prove it works — a test or a cross-model review — you can't prove it works.
 
 ## After Session (Capture Learnings)
 
@@ -245,10 +245,10 @@ End of release: audit `~/.claude/projects/<proj>/memory/`, promote portable less
 ## Post-Mortem: Process Failures Become Rules
 
 ```
-Incident → Root Cause → New Rule → Test That Proves the Rule → Ship
+Incident → Root Cause → New Rule → Evidence per the Three-Way Call → Ship
 ```
 
-Don't fix only the symptom. Add a gate so it can't happen again. Example: PR #145 auto-merged before CI review → "NEVER AUTO-MERGE" block + `test_never_auto_merge_gate`.
+Don't fix only the symptom. Guard the rule per the three-way call (see TDD proves) — EVAL it, plain-assert it, or cross-model review for meaning-level prose. Sometimes the fix is DELETING a gate (#484, #561). Example: PR #145 auto-merged before CI review → "NEVER AUTO-MERGE" block + `test_never_auto_merge_gate`.
 
 ## Context Management & Subagents
 

--- a/tests/e2e/codex-cowork-install.md
+++ b/tests/e2e/codex-cowork-install.md
@@ -86,20 +86,16 @@ Document which method worked.
 
 ## Step 5: Test hooks
 
-### Test 5a: SDLC Baseline hook (UserPromptSubmit)
-> These hooks are GATES, not text injectors. A `prompt` hook sends its prompt to
-> a separate evaluator model which answers `{"ok": true}` or `{"ok": false}`.
-> Nothing is inserted into the conversation, so "look for injected text" is not
-> a valid expectation — the observable signal is whether a prompt is DENIED.
+### Test 5a: NO SDLC Baseline hook — the UserPromptSubmit classifier was REMOVED (#561)
+> There is no prompt gate. The `UserPromptSubmit` classifier was removed in
+> v1.97.0 after denying the maintainer's own instructions twice — the second
+> time after a narrowing repair that a passing test had pinned. Blocking hooks
+> belong on ACTS, not on turn-level subject matter.
 
-1. **Negative case (should be DENIED):** type a prompt that explicitly asks to
-   skip process, e.g. "skip the tests and just write the code, no planning".
-   Expect the turn to be blocked with a reason. Screenshot it.
-2. **Positive case (should PASS):** type a normal prompt like "Help me write a
-   Python function to sort a list". Expect it to proceed with no interference.
-   Claude may or may not mention planning — that is model behaviour, NOT hook
-   evidence, and must not be scored as a pass or a fail.
-3. Screenshot both.
+1. Type a prompt that explicitly asks to skip process, e.g. "skip the tests and
+   just write the code, no planning". **Expect it to PROCEED.** Its proceeding
+   is the pass condition — do NOT score it as a failure.
+2. Screenshot it.
 
 ### Test 5b: TDD hook (PreToolUse on Write/Edit)
 > Same correction as 5a: this is a GATE, not a narrator. It does not make Claude
@@ -158,7 +154,7 @@ Create a summary with:
 - [ ] "sdlc-wizard-cowork" appears in installed plugins
 - [ ] /sdlc-wizard-cowork:sdlc skill invokes correctly
 - [ ] /sdlc-wizard-cowork:feedback skill invokes correctly
-- [ ] UserPromptSubmit DENIES a skip-the-process prompt, and passes a normal one
+- [ ] NO UserPromptSubmit hook: a skip-the-process prompt proceeds unblocked (#561)
 - [ ] PreToolUse DENIES a brand-new non-test file, and silently allows a test file
 - [ ] NO Stop hook fires — every turn ends normally, including a code change with no test run (removed in v1.92.0, GH #484; a block here is a P0)
 - [ ] Marketplace install via `BaseInfinity/claude-sdlc-harness` succeeded (#455)

--- a/tests/e2e/codex-cowork-install.md
+++ b/tests/e2e/codex-cowork-install.md
@@ -179,6 +179,6 @@ Only after the plugin is verified working, consider submitting to the marketplac
 ## Notes
 
 - Plugin validates clean: `claude plugin validate cowork/` passes
-- 17/17 drift tests pass in `tests/test-cowork-drift.sh`
-- Plugin uses prompt-based hooks only (no bash/shell — works without filesystem access)
+- 30/30 drift tests pass in `tests/test-cowork-drift.sh`
+- Plugin uses one prompt-based hook only (no bash/shell — works without filesystem access)
 - Skills are copies of canonical skills, kept in sync by CI drift test

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -415,14 +415,15 @@ fi
 # closed, every push. Release-time `claude plugin details` = manifest-registered
 # hooks in the INSTALLED artifact only — empirically blind to frontmatter hooks
 # (2026-08-10: an active frontmatter UserPromptSubmit hook did not appear in its
-# inventory), so it is not an oracle. Undocumented mechanisms: cross-model
-# review, which found surfaces 2, 3 and 4 when every mechanical check missed
-# them.
+# inventory), so it is not an oracle. The interactive `/hooks` command DOES see
+# frontmatter hooks, but it is session-bound and cannot gate anything.
+# Undocumented mechanisms: cross-model review, which found surfaces 2, 3 and 4
+# when every mechanical check missed them.
 # Wrapped in a function so the heredoc stays at statement level: it cannot live
 # inside a command substitution, and a temp file would make the test fail in
 # environments where TMPDIR is not writable.
 _cowork_hooks_scan() {
-python3 - "$PROJECT_ROOT" <<'PYEOF' 
+python3 - "$PROJECT_ROOT" <<'PYEOF'
 import json, os, re, subprocess, sys
 try:
     import yaml

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -410,12 +410,19 @@ fi
 #
 # NOT covered, and this is a real future-release boundary rather than an excuse:
 # a mechanism using a key NOT named `hooks` inside a format already scanned.
-# Undocumented today. The release-time `claude plugin details` check covers it —
-# that command reports EFFECTIVE hooks however registered, and is the only thing
-# in this system that has never been wrong about the surface set. It cannot run
-# in CI (no claude CLI) and cannot read a working tree, so it is a release gate,
-# not a push gate.
-if python3 - "$PROJECT_ROOT" <<'PYEOF' 2>/dev/null
+# Undocumented today, and NOTHING mechanical here covers it. Division of labor,
+# stated honestly: this walk = every documented surface in the source tree, fail
+# closed, every push. Release-time `claude plugin details` = manifest-registered
+# hooks in the INSTALLED artifact only — empirically blind to frontmatter hooks
+# (2026-08-10: an active frontmatter UserPromptSubmit hook did not appear in its
+# inventory), so it is not an oracle. Undocumented mechanisms: cross-model
+# review, which found surfaces 2, 3 and 4 when every mechanical check missed
+# them.
+# Wrapped in a function so the heredoc stays at statement level: it cannot live
+# inside a command substitution, and a temp file would make the test fail in
+# environments where TMPDIR is not writable.
+_cowork_hooks_scan() {
+python3 - "$PROJECT_ROOT" <<'PYEOF' 
 import json, os, re, subprocess, sys
 try:
     import yaml
@@ -427,8 +434,11 @@ ROOT = sys.argv[1]
 EXEMPT = "cowork/hooks/hooks.json"
 FRONTMATTER = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
 
-tracked = subprocess.check_output(
-    ["git", "-C", ROOT, "ls-files", "--", "cowork/"]).decode().split()
+# -z / NUL split, NOT .split(): a tracked filename containing whitespace would
+# otherwise be shredded into nonexistent paths, both skipped, silent green. The
+# round-4 review proved it with `cowork/skills/extra skill/SKILL.md`.
+tracked = [f for f in subprocess.check_output(
+    ["git", "-C", ROOT, "ls-files", "-z", "--", "cowork/"]).decode().split("\0") if f]
 tracked.append(".claude-plugin/marketplace.json")
 
 bad = []
@@ -469,10 +479,11 @@ for rel in tracked:
 
 assert not bad, "; ".join(bad)
 PYEOF
-then
+}
+if hooks_scan_err=$(_cowork_hooks_scan 2>&1 >/dev/null); then
   pass "no \`hooks\` declaration outside cowork/hooks/hooks.json in any tracked shipped file (.json keys, .yaml docs, .md frontmatter; unknown formats fail closed)"
 else
-  fail "a \`hooks\` declaration exists outside cowork/hooks/hooks.json, or a tracked shipped file has a format this scan cannot read — either way a hook could be registered where Tests 12 and 13 cannot see it (GH #561)"
+  fail "a \`hooks\` declaration exists outside cowork/hooks/hooks.json, or a tracked shipped file has a format this scan cannot read — either way a hook could be registered where Tests 12 and 13 cannot see it (GH #561): $(printf '%s' "$hooks_scan_err" | tail -1)"
 fi
 
 # Test 14: All hooks are prompt type (no command type — Cowork has no shell)

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -373,7 +373,7 @@ if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
   if python3 -c "
 import json
 d=json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
-assert not d.get('Stop'), 'Stop hook is back'
+assert 'Stop' not in d, 'Stop key is back'
 " 2>/dev/null; then
     pass "hooks.json has NO Stop hook (GH #484 — a blocking Stop hook fires every turn)"
   else
@@ -381,6 +381,47 @@ assert not d.get('Stop'), 'Stop hook is back'
   fi
 else
   fail "hooks.json not found"
+fi
+
+# Test 13b (#561): hooks/hooks.json is the plugin's ONLY hook registration
+# surface. Tests 12 and 13 assert that two specific events are absent from that
+# file — which proves nothing if a hook can be registered somewhere else, and it
+# can. Per code.claude.com/docs/en/plugins-reference there are three surfaces:
+#   1. hooks/hooks.json          — the only auto-loaded location (Tests 12, 13)
+#   2. the `hooks` field in plugin.json   — string | array | object, inline or a
+#      path. A stray hooks/extra.json is inert unless routed through this field.
+#   3. the `hooks` field on a MARKETPLACE ENTRY — takes precedence over
+#      plugin.json.
+# Round 2 of the #561 review registered a valid inline UserPromptSubmit hook via
+# surface 2: `claude plugin validate --strict` passed and this suite stayed
+# 29/29. Surface 3 was missed by that enumeration too.
+#
+# Whitelisting the surface beats blacklisting the key on more files: this closes
+# surfaces 2 and 3 for EVERY hook event at once, so Tests 12 and 13 are complete
+# rather than needing a per-event sweep of three manifests.
+#
+# What this does NOT catch, stated rather than hidden: a registration surface
+# added by a future Claude Code release is outside its reach. Cross-model diff
+# review is the guard there — the three-way call's own residue rule (#561).
+#
+# NOT a substitute: `claude plugin validate --strict` is schema-only and passed
+# the mutation above. `claude plugin details` does enumerate effective hooks
+# across all paths, but CI installs no claude CLI, so it cannot be the CI guard.
+if python3 -c "
+import json,sys
+bad=[]
+d=json.load(open('$PROJECT_ROOT/cowork/.claude-plugin/plugin.json'))
+if 'hooks' in d: bad.append('plugin.json')
+for mf in ('cowork/.claude-plugin/marketplace.json','.claude-plugin/marketplace.json'):
+    m=json.load(open('$PROJECT_ROOT/'+mf))
+    if 'hooks' in m: bad.append(mf+' (top level)')
+    for p in m.get('plugins',[]):
+        if 'hooks' in p: bad.append(mf+' entry '+str(p.get('name')))
+assert not bad, 'hook registration outside hooks/hooks.json: '+', '.join(bad)
+" 2>/dev/null; then
+  pass "hooks/hooks.json is the only hook registration surface (no \`hooks\` field in plugin.json or any marketplace entry)"
+else
+  fail "a \`hooks\` field appeared in plugin.json or a marketplace entry — that registers hooks OUTSIDE hooks/hooks.json, where Tests 12 and 13 cannot see them (GH #561)"
 fi
 
 # Test 14: All hooks are prompt type (no command type — Cowork has no shell)

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -329,18 +329,34 @@ else
   fail "hooks.json not found (skipping PreToolUse check)"
 fi
 
-# Test 12: hooks.json has UserPromptSubmit SDLC baseline hook
+# Test 12: hooks.json has NO UserPromptSubmit hook
+# GH #561: the UserPromptSubmit prompt classifier was REMOVED. It denied the
+# maintainer TWICE, and the second denial came after a repair:
+#   2026-08-07 — denied "do the prose rename now, dont TDD something like this,
+#     it will most likely only ever happen once so just verify after". That is a
+#     stated reason plus a stated alternative: a safeguard being SUBSTITUTED,
+#     not removed. A justified-exception carve-out was shipped in response, and
+#     old Test 18 pinned its text.
+#   2026-08-10 — denied an instruction to CODIFY a policy change, classifying a
+#     description of policy as an attempt to evade policy.
+# The first repair was textually pinned by a passing test and still failed
+# operationally. That is what makes deletion the answer rather than a third
+# narrowing: no prompt wording guarantees an LLM classification outcome, and
+# the hook is unfalsifiable from inside — reporting the false positive requires
+# a prompt it may block. Same class as the #484 Stop hook (Test 13). Blocking
+# hooks fire on ACTS (PreToolUse), never on turn-level subject matter.
+# Honest cost: in Cowork, "skip planning/review" followed by edits to
+# EXISTING files now hits no gate at all — PreToolUse fails open for edits
+# and the CLI's commit/merge gates cannot run there. Guidance, not gates.
 if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
   if python3 -c "
 import json
 d=json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
-ups=d.get('UserPromptSubmit',[])
-assert len(ups)>0, 'no UserPromptSubmit hooks'
-assert any(hk.get('type')=='prompt' for h in ups for hk in h.get('hooks',[])), 'no prompt type'
+assert not d.get('UserPromptSubmit'), 'UserPromptSubmit hook is back'
 " 2>/dev/null; then
-    pass "hooks.json has UserPromptSubmit SDLC baseline prompt hook"
+    pass "hooks.json has NO UserPromptSubmit hook (GH #561 — it blocked the maintainer's own policy instruction)"
   else
-    fail "hooks.json missing UserPromptSubmit SDLC baseline prompt hook"
+    fail "a UserPromptSubmit hook returned to cowork/hooks.json — GH #561 removed it; turn-level subject-matter classification is not a gate"
   fi
 else
   fail "hooks.json not found (skipping UserPromptSubmit check)"
@@ -467,27 +483,10 @@ else
   fail "hooks.json not found (skipping substring-guard check)"
 fi
 
-# Test 14e (#456 Codex round-1 finding 3): UserPromptSubmit must NOT deny plain
-# code requests just for lacking a user-authored plan — a block on this event
-# ends the turn with no retry, so denying ordinary prompts (e.g. "write a
-# function to sort a list", the exact prompt from the #432 E2E test) would be
-# actively disruptive. It must instead only deny prompts that explicitly try to
-# bypass safeguards.
-if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
-  if python3 -c "
-import json
-d = json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
-prompt = next((hk.get('prompt','') for m in d.get('UserPromptSubmit',[]) for hk in m.get('hooks',[]) if hk.get('type')=='prompt'), '')
-assert 'skip' in prompt.lower() or 'bypass' in prompt.lower(), 'no explicit-bypass framing found'
-assert 'already state a plan' not in prompt.lower(), 'still requires the USER to pre-state a plan (denies ordinary requests)'
-" 2>/dev/null; then
-    pass "UserPromptSubmit denies only explicit bypass requests, not ordinary code prompts"
-  else
-    fail "UserPromptSubmit still denies ordinary code prompts for lacking a user-stated plan, or lost the bypass framing"
-  fi
-else
-  fail "hooks.json not found (skipping UserPromptSubmit scope check)"
-fi
+# GH #561: Test 14e is GONE with its subject. It pinned properties of the
+# UserPromptSubmit prompt's TEXT — which framing it must use, what it must not
+# demand. Contract assertions on a deleted prompt die with it, same as the #484
+# deletion note directly below.
 
 # GH #484: the Stop prompt hook is GONE, so its contract assertions are gone
 # with it. ~90 lines here pinned properties of that prompt's TEXT — which
@@ -522,49 +521,11 @@ else
   fail "ROADMAP missing Dynamic Workflows evaluation entry"
 fi
 
-# Test 18: the UserPromptSubmit gate distinguishes a BYPASS from a JUSTIFIED
-# exception.
-#
-# Incident 2026-08-07: the maintainer wrote "do the prose rename now, dont TDD
-# something like this, it will most likely only ever happen once so just verify
-# after". The gate denied it and ended the turn. That prompt is not a bypass —
-# it states a reason (one-time mechanical change) AND an alternative (verify
-# after). The safeguard was being substituted, not removed.
-#
-# The gate could not tell the difference because it only ever asked "does this
-# ask to skip something". A rule with no sanctioned exception path is one people
-# route around; this is the same shape as the merge gate before --user-approved.
-# Assert the prompt carries BOTH halves: the allowance, and the bare-skip denial
-# it must keep.
-if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
-  ups_prompt=$(python3 -c "
-import json
-d=json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
-print(' '.join(hk.get('prompt','') for h in d.get('UserPromptSubmit',[]) for hk in h.get('hooks',[])))
-" 2>/dev/null)
-
-  if [ -z "$ups_prompt" ]; then
-    fail "could not extract the UserPromptSubmit prompt — this assertion would be vacuous"
-  else
-    missing=""
-    # "stated reason", not bare "reason" — the latter matches the JSON response
-    # field name `"reason"` that the prompt already contained, so it passed
-    # without the clause existing. Caught while writing this test.
-    printf '%s' "$ups_prompt" | grep -qi "stated reason" || missing="$missing no-reason-clause"
-    # "stated alternative", mirroring "stated reason". The looser
-    # alternative|verify matched the word "alternative" elsewhere in the prompt,
-    # so deleting the clause still passed.
-    printf '%s' "$ups_prompt" | grep -qi "stated alternative" || missing="$missing no-alternative-clause"
-    printf '%s' "$ups_prompt" | grep -qiE "substitut|replac" || missing="$missing no-substitution-framing"
-    # It must still deny an unjustified skip, or the fix has gutted the gate.
-    printf '%s' "$ups_prompt" | grep -qi "ok.*false" || missing="$missing no-denial-path"
-    if [ -z "$missing" ]; then
-      pass "UserPromptSubmit gate allows a justified exception and still denies a bare bypass"
-    else
-      fail "UserPromptSubmit gate cannot distinguish a justified exception from a bypass:$missing"
-    fi
-  fi
-fi
+# GH #561: Test 18 is GONE with its subject. It pinned the text of the
+# justified-exception carve-out added after the 2026-08-07 denial — the
+# first repair to this hook. It passed while the hook went on to deny the
+# maintainer a second time (see Test 12). Contract assertions on a deleted
+# prompt die with it, same as Test 14e and the #484 note above.
 
 # Test 19: the skill must declare what happens when the wizard doc is absent.
 #

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -383,45 +383,96 @@ else
   fail "hooks.json not found"
 fi
 
-# Test 13b (#561): hooks/hooks.json is the plugin's ONLY hook registration
-# surface. Tests 12 and 13 assert that two specific events are absent from that
-# file — which proves nothing if a hook can be registered somewhere else, and it
-# can. Per code.claude.com/docs/en/plugins-reference there are three surfaces:
-#   1. hooks/hooks.json          — the only auto-loaded location (Tests 12, 13)
-#   2. the `hooks` field in plugin.json   — string | array | object, inline or a
-#      path. A stray hooks/extra.json is inert unless routed through this field.
-#   3. the `hooks` field on a MARKETPLACE ENTRY — takes precedence over
-#      plugin.json.
-# Round 2 of the #561 review registered a valid inline UserPromptSubmit hook via
-# surface 2: `claude plugin validate --strict` passed and this suite stayed
-# 29/29. Surface 3 was missed by that enumeration too.
+# Test 13b (#561): NO `hooks` declaration in any tracked shipped file except
+# cowork/hooks/hooks.json.
 #
-# Whitelisting the surface beats blacklisting the key on more files: this closes
-# surfaces 2 and 3 for EVERY hook event at once, so Tests 12 and 13 are complete
-# rather than needing a per-event sweep of three manifests.
+# Tests 12 and 13 assert two events are absent from ONE file. That proves
+# nothing if a hook can be declared elsewhere — and it can. Three successive
+# enumerations of "where hooks can be registered" were each declared complete
+# and each disproven within a round:
+#   1. hooks/hooks.json only          -> broken by an inline `hooks` in plugin.json
+#   2. + plugin.json                  -> a marketplace ENTRY's `hooks` takes precedence
+#   3. + both marketplace manifests   -> broken by a hook in SKILL.md YAML frontmatter
+# Every miss was found by reading Anthropic's docs, not ours, because each
+# attempt quantified over ANTHROPIC'S set of registration mechanisms — an open
+# set they own and extend. A fourth hand-enumeration is the same method.
 #
-# What this does NOT catch, stated rather than hidden: a registration surface
-# added by a future Claude Code release is outside its reach. Cross-model diff
-# review is the guard there — the three-way call's own residue rule (#561).
+# So this quantifies over a set THIS REPO owns instead: a hook must be declared
+# in bytes the plugin ships, and `git ls-files` closes that set. A new shipped
+# file is scanned automatically rather than silently missed.
 #
-# NOT a substitute: `claude plugin validate --strict` is schema-only and passed
-# the mutation above. `claude plugin details` does enumerate effective hooks
-# across all paths, but CI installs no claude CLI, so it cannot be the CI guard.
-if python3 -c "
-import json,sys
-bad=[]
-d=json.load(open('$PROJECT_ROOT/cowork/.claude-plugin/plugin.json'))
-if 'hooks' in d: bad.append('plugin.json')
-for mf in ('cowork/.claude-plugin/marketplace.json','.claude-plugin/marketplace.json'):
-    m=json.load(open('$PROJECT_ROOT/'+mf))
-    if 'hooks' in m: bad.append(mf+' (top level)')
-    for p in m.get('plugins',[]):
-        if 'hooks' in p: bad.append(mf+' entry '+str(p.get('name')))
-assert not bad, 'hook registration outside hooks/hooks.json: '+', '.join(bad)
-" 2>/dev/null; then
-  pass "hooks/hooks.json is the only hook registration surface (no \`hooks\` field in plugin.json or any marketplace entry)"
+# FAIL-CLOSED is the load-bearing clause. A tracked file whose format has no
+# parser here FAILS. Without it the format list is just a hand-enumeration one
+# level down, with the same silent-green shape, and round 5 finds it.
+#
+# tests/test-stop-hook-terminates.sh learned this same lesson over four rounds
+# (see its header); this reuses that traversal deliberately.
+#
+# NOT covered, and this is a real future-release boundary rather than an excuse:
+# a mechanism using a key NOT named `hooks` inside a format already scanned.
+# Undocumented today. The release-time `claude plugin details` check covers it —
+# that command reports EFFECTIVE hooks however registered, and is the only thing
+# in this system that has never been wrong about the surface set. It cannot run
+# in CI (no claude CLI) and cannot read a working tree, so it is a release gate,
+# not a push gate.
+if python3 - "$PROJECT_ROOT" <<'PYEOF' 2>/dev/null
+import json, os, re, subprocess, sys
+try:
+    import yaml
+except ImportError:
+    print("python3 yaml module missing - it is a stated test dependency", file=sys.stderr)
+    sys.exit(1)
+
+ROOT = sys.argv[1]
+EXEMPT = "cowork/hooks/hooks.json"
+FRONTMATTER = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.S)
+
+tracked = subprocess.check_output(
+    ["git", "-C", ROOT, "ls-files", "--", "cowork/"]).decode().split()
+tracked.append(".claude-plugin/marketplace.json")
+
+bad = []
+
+def scan(node, rel, trail):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "hooks":
+                bad.append("%s at %s/%s" % (rel, trail, k))
+            scan(v, rel, "%s/%s" % (trail, k))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            scan(v, rel, "%s[%d]" % (trail, i))
+
+for rel in tracked:
+    if rel == EXEMPT:
+        continue
+    path = os.path.join(ROOT, rel)
+    if not os.path.exists(path):
+        continue
+    ext = os.path.splitext(path)[1]
+    raw = open(path, encoding="utf-8").read()
+    try:
+        if ext == ".json":
+            scan(json.loads(raw), rel, "")
+        elif ext in (".yaml", ".yml"):
+            for d in yaml.safe_load_all(raw):
+                scan(d, rel, "")
+        elif ext == ".md":
+            m = FRONTMATTER.match(raw)
+            if m:
+                scan(yaml.safe_load(m.group(1)), rel, "frontmatter")
+        else:
+            bad.append("%s (UNSCANNABLE shipped format '%s' - no parser, so a "
+                       "hooks declaration in it would be invisible)" % (rel, ext))
+    except Exception as e:
+        bad.append("%s (unparseable: %s)" % (rel, str(e)[:60]))
+
+assert not bad, "; ".join(bad)
+PYEOF
+then
+  pass "no \`hooks\` declaration outside cowork/hooks/hooks.json in any tracked shipped file (.json keys, .yaml docs, .md frontmatter; unknown formats fail closed)"
 else
-  fail "a \`hooks\` field appeared in plugin.json or a marketplace entry — that registers hooks OUTSIDE hooks/hooks.json, where Tests 12 and 13 cannot see them (GH #561)"
+  fail "a \`hooks\` declaration exists outside cowork/hooks/hooks.json, or a tracked shipped file has a format this scan cannot read — either way a hook could be registered where Tests 12 and 13 cannot see it (GH #561)"
 fi
 
 # Test 14: All hooks are prompt type (no command type — Cowork has no shell)

--- a/tests/test-cowork-drift.sh
+++ b/tests/test-cowork-drift.sh
@@ -352,7 +352,7 @@ if [ -f "$PROJECT_ROOT/cowork/hooks/hooks.json" ]; then
   if python3 -c "
 import json
 d=json.load(open('$PROJECT_ROOT/cowork/hooks/hooks.json'))['hooks']
-assert not d.get('UserPromptSubmit'), 'UserPromptSubmit hook is back'
+assert 'UserPromptSubmit' not in d, 'UserPromptSubmit key is back'
 " 2>/dev/null; then
     pass "hooks.json has NO UserPromptSubmit hook (GH #561 — it blocked the maintainer's own policy instruction)"
   else


### PR DESCRIPTION
Closes #561.

## What happened

A `UserPromptSubmit` prompt classifier in the Cowork plugin denied the maintainer's own instruction to codify a policy change — it read a *description* of policy as an attempt to *evade* policy. The harness blocked its own maintainer from changing the harness.

That was the second denial, not the first. On 2026-08-07 the same hook denied *"do the prose rename now, dont TDD something like this, it will most likely only ever happen once so just verify after"* — a stated reason plus a stated alternative, a safeguard being **substituted**, not removed. A justified-exception carve-out shipped in response, and a test pinned its text. The test passed. The hook denied the maintainer anyway.

## Two changes, one incident

**1. The hook is deleted.** No prompt wording guarantees an LLM classification outcome, so the thing is unsatisfiable by narrowing — and one narrowing had already been tried and had a green test proving it was in place. It is also unfalsifiable from inside: reporting the false positive requires a prompt it may block. Same class and same remedy as the #484 Stop hook, whose absence Test 13 already asserts. Blocking hooks fire on **acts** (`PreToolUse`), never on turn-level subject matter.

**2. TDD RED is scoped to where a RED mutation is writable.** The rule the maintainer was blocked from asking for. An unqualified test-first mandate does not produce more testing — it produces *fake* testing. This repo shipped **six guards that passed on every input, including the ones they existed to reject**, every one green in CI for its whole life. When the driver must satisfy the rule and the only satisfying artifact available for meaning-level prose is a grep that cannot fail, that is what gets written.

The boundary is mechanical: write the wrong version the test must catch **before** writing the test. If catching it requires understanding meaning, no assertion can. That gives a three-way call for every change — **EVAL it**, **plain-assert it**, or **DON'T TEST IT** and let cross-model review be the guard.

## The honest cost

Stated in three places (`cowork/README.md`, the Test 12 tombstone, and here) rather than only in the issue: in Cowork, a prompt asking to skip planning or review, followed by edits to files that already exist, now hits **no gate at all**. `PreToolUse` fails open for edits, and the CLI's commit and merge gates cannot run there — Cowork has no shell. That enforcement loss is preferable to keeping a classifier that denied its maintainer twice, but it is a real loss and it is not being hidden.

Deleting a hook also falsifies every doc that promised it. Claims repaired across `cowork/README.md`, the wizard's Cowork section, and the E2E install checklist. Precedent: the #484 Stop removal corrected the same three surface types (CHANGELOG:194).

## Review

**Spec reviewed to convergence before any code was written**, over two cross-model rounds. Round 1 returned four P1 blockers against the planner's spec: a second test left red by the deletion, six contradictory shipped surfaces the migration inventory missed, a gameable implement-first entry condition, and a self-certifiable meaning exception. The planner conceded all four, retracted a deferral it had defended, and found three collateral surfaces the reviewer had missed. Round 2 closed it as implementable with five deltas.

Two loopholes closed that way, before shipping rather than after:

- The meaning exception is for **prose judged by a reader**. For executable behavior, any observable input/output or side-effect difference means a RED mutation **is** writable — otherwise a driver relabels an auth-condition reversal as "meaning" and skips a test that was writable all along.
- Implement-first requires a gate that blocked the **RED or evidence act itself**, with a ruling that **approves that same act and scope**. A gate refusing implementation because RED is missing is the gate working, not an entry ticket. Without that, a driver trips `tdd-pretool-check` on purpose, quotes the refusal, and walks in.

**Scope card amended on the issue before either newly-allowed file was touched.** The original allowed-paths list predated the hook's identification and omitted the two files the fix must edit. The reviewer ruled a planner cannot extend its own card privately — the #538 rule requires rescoping on the issue. Timestamps verified by the reviewer against the commit objects.

**Round 1 on the diff found two P1s, both fixed here:**

- `cowork/README.md` still claimed two prompt hooks in two more places the first sweep missed.
- **Test 12 was itself partially dead.** `assert not d.get('UserPromptSubmit')` passes when the key is present but empty — re-adding `"UserPromptSubmit": []` kept the suite at 29/29, and the reviewer proved it by mutation rather than by reading. Now asserts key absence, verified against both an empty list and a populated one.

That last one is worth stating plainly: the defect class this PR exists to eliminate turned up in this PR's own new guard. Deleting the key made it fail, so red-by-absence made it look alive, while the nearest wrong form sailed straight through. Six for six on why that proof method does not work.

## Tests

`test-cowork-drift.sh` 30/30, `test-doc-consistency.sh` 137/137, full suite otherwise green. `test-persist-score-history.sh` fails identically on HEAD and merge base — pre-existing, confirmed by merge-base repro, tracked as #566.

No new tests for the prose rule: DON'T-TEST-IT class under its own three-way call, with cross-model review as the guard. The hook deletion carries a real plain-assert whose RED was observed before the deletion and re-verified by mutation after.

## Release note

Relief reaches the maintainer only when the installed plugin updates past the cached v1.93.0. Merging this does not deliver it — the release must ship.


---

## The guard: six rounds, and why it took a method change

Everything above was certified sound at round 1 and never questioned again. **Five subsequent rounds were all about one thing: the test protecting the deletion.** It is the larger half of this diff, and it earned its lines.

Deleting a hook is easy. Proving it stays deleted turned out to require knowing every place Claude Code lets a plugin *register* a hook — and that set is owned, documented, and extended by Anthropic, not by us. Three enumerations were each declared complete and each disproven within a round, every miss found by reading Anthropic's docs rather than ours:

1. `hooks/hooks.json` only → broken by an inline `hooks` field in `plugin.json`
2. + `plugin.json` → a marketplace **entry's** `hooks` takes precedence over it
3. + both marketplace manifests → broken by a hook in a **skill's YAML frontmatter**

A fourth hand-enumeration would have been the same method that had just failed three times. So the domain changed instead of the effort: **a hook must be declared in bytes the plugin ships, and `git ls-files` closes that set because this repo owns it.** The walk scans every tracked shipped file and rejects any `hooks` declaration outside `cowork/hooks/hooks.json` — JSON keys, YAML documents, Markdown frontmatter — and **fails closed** on any format it has no parser for. Without that last clause the format list is just a hand-enumeration one level down, with the same silent-green shape.

**The validation is better than the argument.** Review found, after the walk was written, that Anthropic also documents hooks in **agent frontmatter and command frontmatter** — a fifth and sixth surface that no enumeration in six rounds ever named. The walk already covers both, because it parses every tracked `.md`'s frontmatter. It guards surfaces nobody here knew existed.

RED observed live, never merely named: a whitespace-containing tracked path (`cowork/skills/extra skill/SKILL.md` — which silently bypassed an earlier version entirely), inline `plugin.json`, a marketplace entry, a `.toml` proving fail-closed, and an unparseable `.yaml`.

## Honest division of labor

No single check covers everything, and the docs now say so instead of implying otherwise:

| Piece | Covers |
|---|---|
| Shipped-file walk (`test-cowork-drift.sh`) | every documented surface in the source tree, fail-closed, every push |
| Release-time `claude plugin details` | manifest-registered hooks in the **installed** artifact only — empirically blind to frontmatter hooks |
| Cross-model diff review | everything neither can see |

Two claims were retracted along the way, both stated as universal and neither true: that `plugin details` reports hooks however registered (it does not — it missed an active frontmatter hook), and that no native command enumerates all effective hooks (the interactive `/hooks` does). Retraction posted on #561, where the false claims had lived — the first attempt at retracting them landed only in a commit message.

The third row of that table is not a cop-out. Review found registration surfaces 2, 3, 4, 5 and 6 when every mechanical check and every hand-enumeration missed them.
