### PR TITLE
release: v1.97.0 — the hook that blocked the maintainer is gone, and TDD RED is scoped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "SDLC enforcement plugins for AI-assisted development",
-    "version": "1.96.0"
+    "version": "1.97.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "BaseInfinity/claude-sdlc-harness"
       },
       "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "author": {
         "name": "Stefan Ayala"
       },
@@ -36,7 +36,7 @@
         "path": "cowork"
       },
       "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "description": "SDLC enforcement for AI agents \u2014 TDD, planning, self-review, CI shepherd",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,92 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+## [1.97.0] - 2026-08-10
+
+### Removed — a hook that denied its own maintainer, twice
+
+- **The Cowork `UserPromptSubmit` prompt classifier is deleted.** It blocked the maintainer's
+  own instruction to codify a policy change, classifying a *description* of policy as an attempt
+  to *evade* it. That was the second denial, not the first: on 2026-08-07 it refused "do the
+  prose rename now, dont TDD something like this... just verify after" — a stated reason plus a
+  stated alternative, a safeguard being **substituted**, not removed. A justified-exception
+  carve-out shipped in response and a test pinned its text. The test passed. The hook denied the
+  maintainer anyway.
+
+  No prompt wording guarantees an LLM classification outcome, so it is unsatisfiable by
+  narrowing, and it is unfalsifiable from inside — reporting the false positive requires a
+  prompt it may block. Same class and same remedy as the `Stop` hook removed in v1.92.0.
+  Blocking hooks fire on **acts** (`PreToolUse`), never on turn-level subject matter. (#561)
+
+- **The honest cost, stated rather than hidden.** In Cowork, a prompt asking to skip planning or
+  review, followed by edits to files that already exist, now hits **no gate at all** —
+  `PreToolUse` fails open for edits, and the CLI's commit and merge gates cannot run there.
+  That loss is preferable to a classifier that denied its maintainer twice, but it is real and
+  it is written down in `cowork/README.md`, not buried. (#561)
+
+### Changed — TDD RED is scoped to where a RED mutation is writable
+
+- **An unqualified test-first mandate does not produce more testing. It produces fake testing.**
+  This repo shipped **six guards that passed on every input, including the ones they existed to
+  reject** — every one green in CI for its whole life. A seventh was found *inside this release*:
+  the new guard protecting the hook deletion was itself dead on arrival, caught by a reviewer
+  mutating the file rather than reading the assertion. When the driver must satisfy the rule
+  and the only satisfying artifact for meaning-level prose is a grep that cannot fail, that is
+  what gets written.
+
+  The boundary is now mechanical: write the wrong version the test must catch **before** writing
+  the test. If catching it requires understanding meaning, no assertion can. That gives a
+  three-way call for every change — **EVAL it**, **plain-assert it**, or **DON'T TEST IT** and
+  let cross-model review be the guard. Two loopholes were closed before shipping: the meaning
+  exception applies only to prose judged by a reader (any observable input/output difference
+  means RED *is* writable), and implement-first requires a gate that blocked the RED or evidence
+  act itself — a gate refusing implementation because RED is missing is the gate working, not an
+  entry ticket. (#561)
+
+### Added — a guard that covers surfaces nobody knew existed
+
+- **Hook-registration absence is now checked over the shipped file set, not a list of
+  mechanisms.** Three enumerations of "where a hook can be registered" were each declared
+  complete and each disproven within a review round, every miss found by reading Anthropic's
+  documentation rather than ours — because each attempt quantified over *Anthropic's* set of
+  registration mechanisms, which they own and extend.
+
+  The check now quantifies over a set this repo owns: every tracked shipped file, rejecting any
+  `hooks` declaration outside `cowork/hooks/hooks.json`, and **failing closed** on any format it
+  has no parser for. Review then found that Anthropic also documents hooks in **agent frontmatter
+  and command frontmatter** — a fifth and sixth surface no enumeration ever named — and the walk
+  already covered both. It guards surfaces nobody involved knew existed. (#561)
+
+- **"Fixed" now means observed.** Name the observable that would differ if a change were not
+  fixed, then go look at it. Out-of-repo changes — global `settings.json`, env vars, shell rc,
+  scheduler entries — get no gate at all: no diff, no PR, no reviewer. They need the verification
+  command stated in the same message as the change. (#525)
+
+- **The review pass budget is cumulative per root task, and planning requires a scope card**
+  naming one issue, an estimated diff, and allowed paths. A budget that resets on re-freeze is
+  not a budget. (#539, #538)
+
+- **The wizard's own autocompact guidance was breaking compaction.** It recommended setting two
+  knobs that multiply, so a 1M-token window compacted at a fraction of it. (#531)
+
+- **`/sdlc` carries the standing setup itself.** Fable decides the approach, and a guard may not
+  outgrow the change it guards — both were instructions the maintainer had been retyping every
+  session. (#530)
+
+- **The unmeasured 20,000-byte ceiling gate on `skills/sdlc/SKILL.md` is deleted**, not raised.
+  It was never measured against anything, and every edit had begun by degrading something else to
+  stay under it. (#489)
+
+- **Install guidance recommends the native Claude Code installer** and warns off the
+  `sudo npm install -g` footgun. (#476)
+
+### Note on delivery
+
+Merging delivered none of this. **Updating does.** Cowork users remain on whatever plugin
+version is in their local cache until it refreshes past v1.93.0 — the release is what moves it.
+To verify the classifier is actually gone rather than assuming: `claude plugin details
+sdlc-wizard-cowork` should report one hook, `PreToolUse`.
+
 ## [1.96.0] - 2026-08-09
 
 ### Fixed — the wizard doc shipped a second, diverged copy of the SDLC skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ All notable changes to the SDLC Wizard.
 - **An unqualified test-first mandate does not produce more testing. It produces fake testing.**
   This repo shipped **six guards that passed on every input, including the ones they existed to
   reject** — every one green in CI for its whole life. A seventh was found *inside this release*:
-  the new guard protecting the hook deletion was itself dead on arrival, caught by a reviewer
-  mutating the file rather than reading the assertion. When the driver must satisfy the rule
+  the new guard protecting the hook deletion was itself *partially* dead — it caught a populated
+  re-add and missed an empty one — found by a reviewer mutating the file rather than reading the
+  assertion. When the driver must satisfy the rule
   and the only satisfying artifact for meaning-level prose is a grep that cannot fail, that is
   what gets written.
 
@@ -85,8 +86,9 @@ All notable changes to the SDLC Wizard.
 
 ### Note on delivery
 
-Merging delivered none of this. **Updating does.** Cowork users remain on whatever plugin
-version is in their local cache until it refreshes past v1.93.0 — the release is what moves it.
+Merging delivered none of this. **Updating does.** The `UserPromptSubmit` classifier shipped in
+every Cowork plugin version up to and including v1.96.0, so Cowork users remain on whatever
+version is in their local cache **until it refreshes to v1.97.0** — the release is what moves it.
 To verify the classifier is actually gone rather than assuming: `claude plugin details
 sdlc-wizard-cowork` should report one hook, `PreToolUse`.
 

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2994,7 +2994,7 @@ If deployment fails or post-deploy verification catches issues:
 
 **SDLC.md:**
 ```markdown
-<!-- SDLC Harness Version: 1.96.0 -->
+<!-- SDLC Harness Version: 1.97.0 -->
 <!-- Setup Date: [DATE] -->
 <!-- Completed Steps: step-0.1, step-0.2, step-0.4, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: [PRs or Solo] -->
@@ -4452,7 +4452,7 @@ Walk through updates? (y/n)
 Store wizard state in `SDLC.md` as metadata comments (invisible to readers, parseable by Claude):
 
 ```markdown
-<!-- SDLC Harness Version: 1.96.0 -->
+<!-- SDLC Harness Version: 1.97.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Git Workflow: PRs -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,9 +15,17 @@ Triage: **31 open → 22, unmilestoned 12 → 0.** Closed with reasons on each i
 
 Row 485 is **superseded by #511 and #517** — do not action it. Analysis lives on the issues, not here: #513 (the embedded install path), #482 (why this file stops being a store), #489 (byte ceiling).
 
-**Last release: v1.96.0, 2026-08-09** (`agentic-sdlc-wizard`). Deletes the wizard doc's 639-line embedded copy of the SDLC skill — a second install path to the same destination the CLI writes, diverged to 56,284 bytes against the live skill's 19,356 — and the 18 assertions that were grepping that copy instead of the document. Adds four guards against its return, three measuring the payload and one measuring where the reader is told to install. Also: same-model self-review deleted as an instruction (including from a shipped per-prompt hook), dual cross-model certification as merge authorization, and a `validate` lookup that could read a red or queued CI run as green. See `CHANGELOG.md`.
+**Last release: v1.97.0, 2026-08-10** (`agentic-sdlc-wizard`). Deletes the Cowork
+`UserPromptSubmit` prompt classifier, which denied the maintainer's own instructions twice — the
+second time after a repair that a passing test had pinned. Scopes TDD RED to where a RED mutation
+is writable, with the three-way call (EVAL it / plain-assert it / don't test it), after six guards
+shipped that passed on every input including the ones they existed to reject. Adds a shipped-file
+walk that guards every documented hook-registration surface — including agent and command
+frontmatter, two surfaces no enumeration across six review rounds ever named. Also: "fixed" means
+observed, a cumulative per-root-task pass budget, the planning scope card, the autocompact
+guidance fix, and native-installer guidance. See `CHANGELOG.md`.
 
-**Prior release: v1.95.0, 2026-08-07.** Carried the stdin-hang fix for six shipped hooks — each could block forever on a stdin that never reaches EOF, observed at 10h19m against a 10-second timeout — plus fail-closed gate semantics and a `CLAUDE.md` shipped-surface guard, including the five-iteration history of the fix itself.
+**Prior release: v1.96.0, 2026-08-09.** Deleted the wizard doc's 639-line embedded copy of the SDLC skill — a second install path to the same destination the CLI writes, diverged to 56,284 bytes against the live skill's 19,356 — and the 18 assertions that were grepping that copy instead of the document. Added four guards against its return.
 
 **The "Last release" marker above was stale and is worth noting as a defect, not just correcting.** It read "Last release: v1.90.0" through the v1.92.0 and v1.93.0 releases; a version sweep grepping for the *outgoing* version can never find a marker frozen at an older one. Caught by cross-model release review 2026-08-05, not by any test. A guard belongs in `tests/test-doc-consistency.sh` — cross-ref GH #493 (the guard itself) and #491 (the wider CI/CD audit).
 
@@ -204,7 +212,7 @@ Living tracker of projects shipped using this wizard. **Rule:** only list projec
 
 | Project | Repo | Status |
 |---------|------|--------|
-| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.96.0 (living tracker — bump every release) |
+| SDLC Harness itself | BaseInfinity/claude-sdlc-harness | Dogfooded, v1.97.0 (living tracker — bump every release) |
 | Codex SDLC Adapter | BaseInfinity/codex-sdlc-wizard | v0.7.x, shipped with SDLC workflow |
 | GDLC Wizard (games sibling) | BaseInfinity/claude-gdlc-wizard | v0.2.x, persona-driven playtest cycles |
 | _(add as projects are marked)_ | | |

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,4 +1,4 @@
-<!-- SDLC Harness Version: 1.96.0 -->
+<!-- SDLC Harness Version: 1.97.0 -->
 <!-- Setup Date: 2026-01-24 -->
 <!-- Completed Steps: step-0.1, step-0.2, step-1, step-2, step-3, step-4, step-5, step-6, step-7, step-8, step-9 -->
 <!-- Claude Code Baseline: v2.1.220 -->
@@ -10,7 +10,7 @@
 
 | Property | Value |
 |----------|-------|
-| Wizard Version | 1.96.0 |
+| Wizard Version | 1.97.0 |
 | Last Updated | 2026-07-04 |
 | Claude Code Minimum | v2.1.219+ (required for `opus` alias to resolve to Opus 5, the current default); v2.1.154+ for the older `opus[1m]` alias resolution; v2.1.105+ for `PreCompact` hook |
 | Claude Code Recommended | v2.1.220+ — **v2.1.214 changed single-segment `dir/**` hook `if:` conditions to match only `<cwd>/dir`; any-depth now needs `**/dir/**`. This silently disabled the shipped TDD hook for every consumer whose source is not at repo-root `src/` (fixed in v1.91.0).** Also in this range: exit-code-2 hooks now block even when their stdout JSON fails schema validation (v2.1.214 — we were never exposed, our exit-2 hooks write to stderr); plugin skills with a `name` frontmatter field keep their plugin prefix in slash-command autocomplete (v2.1.216, affects `sdlc-wizard-cowork:sdlc`); transcripts record reasoning effort per assistant message (v2.1.212); subagent nesting defaults changed twice (disabled v2.1.217, re-enabled at depth 3 in v2.1.219). Earlier baseline rationale: `SessionStart`/`Setup`/`SubagentStart` hooks no longer hide stderr on exit 2 (v2.1.199), hook events no longer dropped during `SessionStart` in headless sessions (v2.1.204), duplicate skill-instruction context bloat fixed (v2.1.202). |

--- a/cowork/.claude-plugin/marketplace.json
+++ b/cowork/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "SDLC enforcement for Claude Cowork sessions via skills and one prompt-based hook",
-    "version": "1.96.0"
+    "version": "1.97.0"
   },
   "plugins": [
     {
       "name": "sdlc-wizard-cowork",
       "source": ".",
       "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
-      "version": "1.96.0",
+      "version": "1.97.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-wizard-cowork",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "description": "SDLC enforcement for Claude Cowork \u2014 TDD, planning, self-review via skills and one prompt-based hook",
   "author": {
     "name": "Stefan Ayala",

--- a/cowork/README.md
+++ b/cowork/README.md
@@ -128,4 +128,4 @@ This plugin is for Cowork-only users who want methodology guidance without the f
 
 ## Version
 
-Tracks the main wizard version: **1.96.0**
+Tracks the main wizard version: **1.97.0**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-sdlc-wizard",
-  "version": "1.96.0",
+  "version": "1.97.0",
   "description": "Self-evolving SDLC enforcement for Claude Code \u2014 hooks, skills, and one-command setup",
   "bin": {
     "sdlc-wizard": "cli/bin/sdlc-wizard.js"

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -95,7 +95,7 @@ Parse CHANGELOG entries between the user's installed version and the resolved la
 
 ```
 Installed: 1.42.0
-Latest:    1.96.0
+Latest:    1.97.0
 
 What changed:
 - [1.92.0] Cowork `Stop` hook REMOVED — it fired 12 times in one session and was wrong 11; Cowork now has no completion enforcement (documented in cowork/README.md).


### PR DESCRIPTION
Ships v1.97.0. Seven issues are merged and undelivered — **merging delivered none of them.** Cowork plugins run from a local cache, and the maintainer's is still v1.93.0 with the `UserPromptSubmit` classifier live. The tag is what moves it.

## What a consumer gets

**The hook that denied its own maintainer, twice, is deleted.** The second denial came *after* a repair that a passing test had pinned — which is the case for deleting rather than narrowing a third time. The enforcement cost is stated in `cowork/README.md`, not hidden: in Cowork, a skip-the-process prompt followed by edits to existing files now hits no gate at all.

**TDD RED is scoped to where a RED mutation is writable**, with the three-way call — EVAL it, plain-assert it, or don't test it and let cross-model review be the guard. Six guards had shipped that passed on every input including the ones they existed to reject.

**A guard that covers surfaces nobody knew existed.** Hook-registration absence is now checked over the shipped file set rather than a hand-list of mechanisms, failing closed on unparseable formats. Review then found that Anthropic also documents hooks in agent and command frontmatter — a fifth and sixth surface no enumeration across six rounds ever named — and the walk already covered both.

Plus: "fixed" means observed (#525), the cumulative pass budget and planning scope card (#539, #538), the autocompact guidance fix (#531), `/sdlc` carrying the standing setup (#530), the deleted 20,000-byte ceiling gate (#489), and native-installer guidance (#476).

## Review found two P1s, both mine

**Version parity was incomplete after I declared the sweep complete.** Four markers still read 1.96.0 — `cowork/README.md` and three in `ROADMAP.md`, all maintained surfaces that the v1.96.0 release commit had rolled forward — and **every suite passed anyway.** That is #493's class for the third time: the guards cover a set someone once enumerated by hand, and everything outside it fails silently. Filed as **#569**, with the enumeration-vs-globbing treatment #561 just proved out. Not fixed here; it is not release work.

**The CHANGELOG was wrong in four places.** I compressed #531, #530 and #489 into a single line and misdescribed all three — #489 *deleted* the unmeasured ceiling gate rather than adding one — omitted #476 entirely despite it changing the shipped `README.md`, and claimed seven historical dead guards where six is the evidenced number. Now four accurate entries, and the seventh guard is stated as what it actually was: found *inside* #567, in the guard protecting the hook deletion, caught by a reviewer mutating the file rather than reading the assertion.

Both fixed and re-certified at 99%.

## Verification

`doc-consistency` 137/137, `release-drift` 21/21, `roadmap-integrity` 5/5, `cowork-drift` 30/30. `npm pack --dry-run` contains 25 expected files with every `files` entry present. `test-persist-score-history.sh` fails identically on `main` — pre-existing, confirmed by merge-base repro, tracked as #566.

An isolated working-tree install reports exactly `Hooks (1)  PreToolUse`; the real v1.93.0 cache reports two. That difference is the release.

## After merge

`git tag v1.97.0 && git push origin v1.97.0`. Four documents in this release hard-pin the literal string "v1.97.0" and ship true only once the tag exists.
