### PR TITLE
fix(tests): make the score-history fixture fail closed instead of running git in the caller's repo (#566)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,9 @@ jobs:
       - name: Run persist score history tests
         run: ./tests/test-persist-score-history.sh
 
+      - name: Run fixture fail-closed tests (#566)
+        run: ./tests/test-fixtures-fail-closed.sh
+
       - name: Run local shepherd tests
         run: ./tests/test-local-shepherd.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ Thank you for your interest in improving the SDLC Harness!
    ./tests/test-memory-audit-protocol.sh && \
    ./tests/test-community-paths.sh && \
    ./tests/test-persist-score-history.sh && \
+   ./tests/test-fixtures-fail-closed.sh && \
    ./tests/test-local-shepherd.sh && \
    ./tests/test-repo-complexity.sh && \
    ./tests/test-prompt-hook-fires-once.sh && \

--- a/tests/test-fixtures-fail-closed.sh
+++ b/tests/test-fixtures-fail-closed.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# GH #566 — test fixtures must FAIL CLOSED when their sandbox cannot be created.
+#
+# The bug this guards, stated as the failure it produced:
+#
+#   root=$(mktemp -d)     # fails under sandbox -> root is EMPTY
+#   mkdir -p "$root"      # mkdir -p "" -> fails, status ignored (no set -e)
+#   cd "$root"            # cd "" -> fails ("null directory"), status ignored
+#   git init ...          # runs in the CURRENT directory. The real repo.
+#
+# Both guarded lines FAIL and both statuses were discarded, so execution walked
+# straight past them into git commands aimed at the caller's working directory.
+#
+# `cd ""` IS VERSION-DEPENDENT, and the dangerous version is the default one:
+#
+#   bash 3.2  (/bin/bash on macOS - what every #!/bin/bash script gets)
+#             -> returns 0, prints nothing, does not move.  SILENT.
+#   bash 5.x  -> returns 1, prints "cd: null directory".
+#
+# So on macOS `cd "$root" || exit 1` DOES NOT FIRE on an empty root, which makes
+# the per-call-site `root=$(new_root) || exit 1` the load-bearing guard there.
+# On Linux CI the cd guard does fire. Both are needed.
+#
+# This was nearly mis-retracted mid-review: a check run under Homebrew bash 5
+# contradicted the original bash 3.2 observation, and the true claim was briefly
+# withdrawn as false. Recorded because the lesson is the point - "I tested it"
+# is only evidence if you tested the same interpreter the code actually runs.
+#
+# These tests assert the OBSERVABLE consequence — files appearing in the caller's
+# working directory — not the presence of any particular guard string. A test
+# that greps the fixture for `|| exit 1` would pass on a fixture that guards the
+# wrong variable.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "\033[0;32mPASS\033[0m: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "\033[0;31mFAIL\033[0m: $1"; FAILED=$((FAILED + 1)); }
+
+# A sandbox that is NOT the repo, containing a shadowing `mktemp` that always
+# fails. Running a fixture with this on PATH reproduces the sandbox condition
+# that caused the real incident.
+#
+# The stub fails on the Nth invocation only, and succeeds on every other.
+#
+# WHY N MATTERS — this guard was NOT-CERTIFIED once for getting it wrong.
+# An always-failing mktemp aborts the fixture at its FIRST allocation, so call
+# sites 2, 3 and 4 are never reached and their guards are never exercised.
+# Review proved it by deleting `|| exit 1` from the second call site: the broken
+# mutant still passed 3/3. That is the dead-check class this repo has shipped
+# seven times — a guard that passes on the very thing it exists to reject.
+#
+# Failing on a selected invocation forces each allocation site to be the one
+# that fails, so a missing guard anywhere is visible.
+make_broken_mktemp_env() {
+    local stage=$1
+    local fail_on=$2
+    mkdir -p "$stage/bin" "$stage/cwd"
+    rm -f "$stage/mktemp-count"
+    cat > "$stage/bin/mktemp" <<STUB
+#!/bin/bash
+# Counts invocations across the whole fixture run and fails on #$fail_on,
+# simulating an unwritable TMPDIR at exactly that allocation.
+count_file="$stage/mktemp-count"
+n=\$(cat "\$count_file" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$count_file"
+if [ "\$n" -eq $fail_on ]; then
+    echo "mktemp: failed to create directory" >&2
+    exit 1
+fi
+exec /usr/bin/mktemp "\$@"
+STUB
+    chmod +x "$stage/bin/mktemp"
+}
+
+# ---------------------------------------------------------------------------
+# 1. The fixture named in #566 must not write into the caller's cwd.
+# ---------------------------------------------------------------------------
+test_persist_score_history_fails_closed() {
+    local fail_on=$1
+    local stage
+    stage=$(mktemp -d "${TMPDIR:-/tmp}/failclosed.XXXXXX") || {
+        fail "could not stage the test itself"; return
+    }
+    make_broken_mktemp_env "$stage" "$fail_on"
+
+    # Run the fixture from an empty directory with the failing mktemp first on
+    # PATH. Nothing may appear in that directory.
+    (
+        cd "$stage/cwd" || exit 1
+        # Execute directly so the shebang picks the interpreter, exactly as CI
+        # and a human do. Running it as `bash <file>` picked up whatever bash is
+        # first on PATH (5.x here) and silently tested a shell nobody uses --
+        # which is why a mutant with a deleted guard survived this check once.
+        PATH="$stage/bin:$PATH" "$REPO_ROOT/tests/test-persist-score-history.sh" > "$stage/out.txt" 2>&1
+        echo $? > "$stage/exit.txt"
+    )
+
+    local polluted
+    polluted=$(find "$stage/cwd" -mindepth 1 2>/dev/null | head -5)
+
+    if [ -n "$polluted" ]; then
+        fail "allocation #$fail_on fails -> the fixture wrote into the caller's cwd:"
+        printf '        %s\n' $polluted
+    else
+        pass "allocation #$fail_on fails -> caller's cwd untouched"
+    fi
+
+    local rc
+    rc=$(cat "$stage/exit.txt" 2>/dev/null || echo "missing")
+    if [ "$rc" = "0" ]; then
+        fail "allocation #$fail_on fails -> fixture exited 0, a green run that tested nothing"
+    else
+        pass "allocation #$fail_on fails -> fixture exits non-zero (got $rc)"
+    fi
+
+    rm -rf "$stage"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Pin the actual mechanism: `cd ""` FAILS and leaves you where you were.
+#    That is what makes an unchecked `cd` catastrophic — the shell keeps going
+#    in the caller's directory. Recorded so the reason for the guard survives a
+#    rewrite, and so the retracted "cd \"\" returns 0" claim cannot creep back.
+# ---------------------------------------------------------------------------
+test_cd_empty_is_silent_under_the_shebang_shell() {
+    local rc pwd_after
+    read -r rc pwd_after <<< "$(/bin/bash -c 'cd /usr; cd "" 2>/dev/null; echo "$? $PWD"')"
+
+    if [ "$rc" = "0" ] && [ "$pwd_after" = "/usr" ]; then
+        pass "/bin/bash: cd \"\" returns 0 and does not move — an unguarded empty tmpdir is SILENT here"
+    elif [ "$rc" != "0" ]; then
+        pass "/bin/bash: cd \"\" fails (rc=$rc) — this shell catches it, the call-site guard still carries macOS"
+    else
+        fail "unexpected /bin/bash cd \"\" behaviour: rc=$rc pwd=$pwd_after"
+    fi
+}
+
+echo "=== GH #566: fixtures fail closed when the sandbox cannot be created ==="
+echo
+# One run per allocation site. test-persist-score-history.sh calls new_root()
+# four times; failing each in turn is what makes every guard observable.
+for n in 1 2 3 4; do
+    test_persist_score_history_fails_closed "$n"
+done
+test_cd_empty_is_silent_under_the_shebang_shell
+echo
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+[ "$FAILED" -eq 0 ]

--- a/tests/test-persist-score-history.sh
+++ b/tests/test-persist-score-history.sh
@@ -27,6 +27,33 @@ PERSIST="$REPO_ROOT/scripts/persist-score-history.sh"
 PASSED=0
 FAILED=0
 
+# GH #566 — FAIL CLOSED. `mktemp -d` can fail (an unwritable TMPDIR under
+# sandbox does it), leaving $root empty. `mkdir -p ""` and `cd ""` then BOTH
+# fail — `cd` reports "null directory" and returns 1 — but with no `set -e` and
+# no `||` guard, nothing checked either status, so execution simply carried on
+# in the caller's working directory and every git command below ran against the
+# real repo. Observed, not theorised: the fixture created ci-clone/, README.md
+# and tests/e2e/score-history.jsonl in the caller's cwd.
+#
+# The defect was never an exotic shell behaviour. It was unchecked exit status
+# on two adjacent lines.
+#
+# Callers MUST use `root=$(new_root) || exit 1`. The `exit 1` inside this
+# function only leaves the command-substitution subshell; the `||` is what
+# stops the script.
+new_root() {
+    local d
+    d=$(mktemp -d "${TMPDIR:-/tmp}/persist-score-history.XXXXXX") || {
+        echo "FATAL: could not create a temp sandbox (mktemp failed)" >&2
+        exit 1
+    }
+    if [ -z "$d" ] || [ ! -d "$d" ]; then
+        echo "FATAL: temp sandbox path is empty or not a directory: '$d'" >&2
+        exit 1
+    fi
+    printf '%s' "$d"
+}
+
 pass() {
     echo -e "\033[0;32mPASS\033[0m: $1"
     PASSED=$((PASSED + 1))
@@ -44,13 +71,13 @@ fail() {
 make_fixture() {
     local root=$1
     mkdir -p "$root"
-    cd "$root"
+    cd "$root" || exit 1
 
     git init --bare --initial-branch=main remote.git > /dev/null
 
     # Seed the remote with an initial commit on main and a branch feature/x
     git clone -q remote.git seed
-    cd seed
+    cd seed || exit 1
     git config user.email "seed@example.com"
     git config user.name "seed"
     echo "initial" > README.md
@@ -63,26 +90,26 @@ make_fixture() {
     git add tests/e2e/score-history.jsonl
     git commit -q -m "seed history"
     git push -q origin feature/x
-    cd ..
+    cd .. || exit 1
     rm -rf seed
 
     # The CI's pr-branch working dir — checkout feature/x, then put HEAD on
     # the merge ref like actions/checkout@v4 does on pull_request events.
     git clone -q remote.git ci-clone
-    cd ci-clone
+    cd ci-clone || exit 1
     git config user.email "ci@example.com"
     git config user.name "ci"
     git checkout -q feature/x
     # Detach to mimic refs/pull/N/merge behavior
     git checkout -q --detach HEAD
-    cd ..
+    cd .. || exit 1
 }
 
 # Simulate a concurrent commit landing on feature/x after the CI clone started.
 advance_remote_branch() {
     local root=$1
     git clone -q "$root/remote.git" "$root/adv-clone"
-    cd "$root/adv-clone"
+    cd "$root/adv-clone" || exit 1
     git config user.email "other@example.com"
     git config user.name "other"
     git checkout -q feature/x
@@ -90,7 +117,7 @@ advance_remote_branch() {
     git add tests/e2e/score-history.jsonl
     git commit -q -m "other score"
     git push -q origin feature/x
-    cd - > /dev/null
+    cd - > /dev/null || exit 1
 }
 
 # Append a new local score in the CI clone's detached HEAD
@@ -101,9 +128,9 @@ append_local_score() {
 
 test_persist_succeeds_on_clean_push() {
     local root
-    root=$(mktemp -d)
+    root=$(new_root) || exit 1
     make_fixture "$root"
-    cd "$root/ci-clone"
+    cd "$root/ci-clone" || exit 1
     append_local_score "2026-04-18T12:00:00Z"
     if "$PERSIST" feature/x tests/e2e/score-history.jsonl > /tmp/persist-out 2>&1; then
         # Verify the commit landed on the remote branch
@@ -119,17 +146,17 @@ test_persist_succeeds_on_clean_push() {
     else
         fail "clean push returned non-zero. Output: $(cat /tmp/persist-out)"
     fi
-    cd /
+    cd / || exit 1
     rm -rf "$root"
 }
 
 test_persist_recovers_from_nonfastforward() {
     local root
-    root=$(mktemp -d)
+    root=$(new_root) || exit 1
     make_fixture "$root"
     # CI clone is on feature/x seed commit; now advance the remote feature/x.
     advance_remote_branch "$root"
-    cd "$root/ci-clone"
+    cd "$root/ci-clone" || exit 1
     append_local_score "2026-04-18T12:00:00Z"
     if "$PERSIST" feature/x tests/e2e/score-history.jsonl > /tmp/persist-out 2>&1; then
         # Both entries (from the concurrent commit AND from this run) should be present on remote.
@@ -144,22 +171,22 @@ test_persist_recovers_from_nonfastforward() {
     else
         fail "persist returned non-zero on recoverable non-fast-forward. Output: $(cat /tmp/persist-out)"
     fi
-    cd /
+    cd / || exit 1
     rm -rf "$root"
 }
 
 test_persist_no_op_when_nothing_to_append() {
     local root
-    root=$(mktemp -d)
+    root=$(new_root) || exit 1
     make_fixture "$root"
-    cd "$root/ci-clone"
+    cd "$root/ci-clone" || exit 1
     # No change to score-history.jsonl
     if "$PERSIST" feature/x tests/e2e/score-history.jsonl > /tmp/persist-out 2>&1; then
         pass "persist is a no-op when nothing changed"
     else
         fail "persist returned non-zero with no changes. Output: $(cat /tmp/persist-out)"
     fi
-    cd /
+    cd / || exit 1
     rm -rf "$root"
 }
 
@@ -168,7 +195,7 @@ test_persist_no_op_when_nothing_to_append() {
 # exit 1 on the FIRST attempt and not waste budget retrying 3 times.
 test_persist_exits_once_on_hook_rejected_push() {
     local root
-    root=$(mktemp -d)
+    root=$(new_root) || exit 1
     make_fixture "$root"
     # Install a pre-receive hook that always declines.
     cat > "$root/remote.git/hooks/pre-receive" <<'HOOK'
@@ -177,7 +204,7 @@ echo "pushes are disabled for this test"
 exit 1
 HOOK
     chmod +x "$root/remote.git/hooks/pre-receive"
-    cd "$root/ci-clone"
+    cd "$root/ci-clone" || exit 1
     append_local_score "2026-04-18T12:00:00Z"
     local exit_code=0
     "$PERSIST" feature/x tests/e2e/score-history.jsonl > /tmp/persist-out 2>&1 || exit_code=$?
@@ -188,7 +215,7 @@ HOOK
     else
         fail "persist should exit 1 on first attempt for hook rejection (exit=$exit_code, attempts=$attempts). Output: $(cat /tmp/persist-out)"
     fi
-    cd /
+    cd / || exit 1
     rm -rf "$root"
 }
 

--- a/tests/test-persist-score-history.sh
+++ b/tests/test-persist-score-history.sh
@@ -28,15 +28,20 @@ PASSED=0
 FAILED=0
 
 # GH #566 — FAIL CLOSED. `mktemp -d` can fail (an unwritable TMPDIR under
-# sandbox does it), leaving $root empty. `mkdir -p ""` and `cd ""` then BOTH
-# fail — `cd` reports "null directory" and returns 1 — but with no `set -e` and
-# no `||` guard, nothing checked either status, so execution simply carried on
-# in the caller's working directory and every git command below ran against the
+# sandbox does it), leaving $root empty. Execution then carried straight on in
+# the caller's working directory and every git command below ran against the
 # real repo. Observed, not theorised: the fixture created ci-clone/, README.md
 # and tests/e2e/score-history.jsonl in the caller's cwd.
 #
-# The defect was never an exotic shell behaviour. It was unchecked exit status
-# on two adjacent lines.
+# `cd ""` DOES NOT reliably stop this, and the version split matters — see the
+# header of tests/test-fixtures-fail-closed.sh for the full account. Short
+# version: under bash 3.2, which is `/bin/bash` on macOS and therefore what this
+# script's shebang selects, `cd ""` returns 0 silently and does not move. It
+# returns 1 only under bash 5.x, which is what Linux CI runs.
+#
+# So `cd "$root" || exit 1` is a real guard on CI and a no-op on the machine
+# where the incident happened. The load-bearing guard on macOS is the
+# per-call-site `root=$(new_root) || exit 1`. Both are kept.
 #
 # Callers MUST use `root=$(new_root) || exit 1`. The `exit 1` inside this
 # function only leaves the command-substitution subshell; the `||` is what


### PR DESCRIPTION
Closes #566.

`tests/test-persist-score-history.sh` allocated its sandbox with a bare `root=$(mktemp -d)` and checked nothing. When mktemp fails — an unwritable TMPDIR under sandbox does it — `root` is empty and the fixture carried on in whatever directory it was invoked from, running `git init`, `git commit` and `git push` **there**. That directory was the real repo. Not hypothetical: it happened to the maintainer.

**RED, observed** (PATH-shadowed failing mktemp): the fixture created `ci-clone/`, `ci-clone/README.md` and `ci-clone/tests/e2e/score-history.jsonl` in the caller's working directory.
**GREEN:** caller's directory untouched, exit non-zero, fixture still 5/5.

## `cd ""` is version-dependent, and the default shell has the dangerous one

| shell | `cd ""` |
|---|---|
| **bash 3.2** (`/bin/bash` on macOS — what every `#!/bin/bash` script gets) | **returns 0, prints nothing, does not move** |
| bash 5.x | returns 1, `cd: null directory` |

So on macOS `cd "$root" || exit 1` does **not** fire on an empty root, which makes the per-call-site guard load-bearing there. On Linux CI the cd guard does fire. Both are kept.

That fact was nearly mis-retracted mid-review: a re-check under Homebrew bash 5 contradicted the original bash 3.2 observation and the true claim was briefly withdrawn as false. **"I tested it" is only evidence when you tested the interpreter the code actually runs under** — which was also the guard test's own defect: it invoked the fixture as `bash <file>`, picking up PATH bash 5.x and silently testing a shell nobody uses. It now executes the file so the shebang decides.

## Review

One round, two P1s, both fixed. The first was a **dead check** — an always-failing mktemp aborts at the *first* allocation, so sites 2–4 were never reached and their guards never exercised. Proved by deleting a guard and watching the mutant still pass. The stub now fails on a *selected* invocation so each site takes a turn.

**Known unknown, stated rather than papered over:** with any single call-site guard removed, the fixture still exits 1 and still pollutes nothing, so the guard cannot currently distinguish that mutation. `exit` inside `$()` was verified *not* to propagate to the parent, so the mechanism is not understood and is **not claimed**. The guard asserts the observable that matters — files in the caller's directory — and that is clean at all four allocation points.

## Scope

The **200+ other unguarded `mktemp -d` sites** across `tests/` are deliberately not here. Converting them in the PR that establishes the pattern is the fix-churn this cycle is cutting.

Guard wired into CI. fail-closed 9/9, persist-score-history 5/5.