### PR TITLE
feat(sdlc): ship the review contract as one prose batch (#558, #557, #573, #574, #564, #556)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,40 @@ An undocumented future registration mechanism is uncovered by any check here —
 cross-model diff review is the guard, and it found every missing surface to
 date.
 
+**Update commands — run both, at release time (#573).** Every command this repo
+tells a reader to run must itself have been run. These are the ones the shipped
+docs instruct, so they belong in this list.
+
+```
+claude plugin update sdlc-wizard-cowork@sdlc-wizard-marketplace
+claude plugin update sdlc-wizard-cowork
+```
+
+Observed 2026-08-10 on an install already at the latest version:
+
+```
+$ claude plugin update sdlc-wizard-cowork@sdlc-wizard-marketplace
+Checking for updates for plugin "sdlc-wizard-cowork@sdlc-wizard-marketplace" at user scope…
+✔ sdlc-wizard-cowork is already at the latest version (1.97.0).
+
+$ claude plugin update sdlc-wizard-cowork
+Checking for updates for plugin "sdlc-wizard-cowork" at user scope…
+✘ Failed to update plugin "sdlc-wizard-cowork": Plugin "sdlc-wizard-cowork" not found
+```
+
+**The marketplace-qualified form is the only one that resolves. The bare name
+fails.** That is what the second command is here to keep proving.
+
+**Known unknown, and the docs must not overstate it:** the qualified form has
+been observed to *resolve*, never to *move a version*. Confirming movement needs
+a genuinely stale install. Until someone runs it against one, `cowork/README.md`
+says exactly that and names `/reload-plugins` as the only step observed to move
+a version (1.93.0 → 1.97.0, `Hooks (2)` → `Hooks (1)`).
+
+The version is on the **header line** of `claude plugin details`
+(`sdlc-wizard-cowork 1.97.0`) — that command prints no `Version:` field.
+`claude plugin list` is where the `Version:` label lives.
+
 Note it reads the installed cache, not the working tree, so installing first is
 mandatory: run it against an unupdated cache and it reports the OLD plugin.
 

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -2623,6 +2623,24 @@ PLANNING → DOCS → TDD RED → TDD GREEN → Tests Pass → Cross-Model Revie
 
 **TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
 
+#### RED is a set of mutations, not one deletion
+
+**List every observation the check promises. Break each one separately on a copy of the live deliverable.** The run fails unless every expected failure actually reports. If you cannot list the observations, do not write the guard.
+
+**Make the nearest wrong version fail, not just a deletion.** Deletion is the maximal mutation and the easiest to survive: a branch that pre-existing text already satisfies is invisible to it. *(Five dead checks shipped or nearly shipped in one session, several caught only when an independent reviewer mutated the deliverable instead of the base. #550's runner silently ran 30 of 65 suites and reported green.)*
+
+#### Never grep prose for meaning
+
+**A regex over prose may check an exact string or a structure. It may never check meaning, denial, or polarity.** Review the prose instead, or delete the marker (#493 requirement 6).
+
+**The first time a reversed live instruction stays green, delete the guard. Do not patch it.** Patching an unfixable mechanism is what turns round 2 into round 4.
+
+**Offer "delete the guard" as an outcome in any recheck of a guard.** Reviewers converge only to outcomes the prompt puts on the menu. And if you are repairing the same guard a second time in one cycle, the question is whether it should exist, not how to fix it.
+
+*Evidence (#539): a 23-line doc change, correct at round 1 and never changed again, carried a 197-line grep guard over prose. Four rounds, seven blocking findings — all seven in the test, none in the deliverable. Rounds 2–4 were the same defect three times, because a text-presence check cannot detect polarity. The final defeat was Markdown strikethrough: `~~the count never resets~~` keeps the searched string byte-identical while the live sentence teaches the opposite, and the suite stayed 137/137 green. Rounds 1–3 forbade expanding the surface, so "delete the guard" was off the menu. Round 4 offered it and it was taken immediately.*
+
+**Accepted residual:** nothing detects a document that states the required fields and then contradicts them in prose — by reversal, by strikethrough, or by an added "sanctioned exception" clause. No string check can close this. Cross-model review is the guard.
+
 Practices that outlive any one task: keeping the suite trustworthy, and finding a cause
 instead of guessing at one.
 
@@ -2790,6 +2808,20 @@ Reproduce → Isolate → Root Cause → Fix → Regression Test
 Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
 
 **Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
+### An Instruction Is Not a Claim
+
+**Never tell a reader to run a command you have not run.** Labeling can save a claim, because the reader evaluates it. It cannot save an instruction, because the reader executes it. Delete it instead.
+
+Run the exact string you are going to ship, and fill in every placeholder at least once.
+
+**Check that the output shows the promised behavior, not just exit 0.** This is the part that gets skipped. `✔ already at the latest version (1.97.0)` proves the identifier resolves; it does not prove the command updates anything. If you cannot observe the behavior, narrow the instruction to what you did observe rather than shipping the wider promise. A command you genuinely cannot run — destructive, or the environment is unavailable — may be *described*, never *instructed*.
+
+**Reviewers enforce this: do not certify a doc containing imperative commands without pasted execution output.** The other leg can check that, which is the point. Two-leg reading is the right instrument for judgement defects and the wrong one for empirical claims about a command.
+
+*Evidence (#572): 24 lines of documentation produced five P1s, every one a claim wider than any observation of it — including a documented update command that fails outright. That doc had labeled its evidence honestly, stating the semantics came from help text and that the command had not been run, and the broken instruction shipped anyway. Both legs certified it.*
+
+**Do not build a static guard for this.** Extracting command strings and requiring an adjacent output block passes on pasted, fabricated or stale output, and cannot tell an instruction from an illustration — it would pass on everything it exists to reject. The live guard is executing the commands. Put them in the repo's own release-verification list, which a maintainer runs, not in CI.
 
 ## Step 8: Create CLAUDE.md
 
@@ -4053,8 +4085,10 @@ codex exec \
   -o .reviews/latest-review.md \
   "You are an independent code reviewer. Read .reviews/handoff.json, \
    review the listed files. Output each finding with: an ID (1, 2, ...), \
-   severity (P0/P1/P2), description, and a 'certify condition' stating \
-   what specific change would resolve it. \
+   severity (P0/P1/P2/P3, graded by impact if it shipped), description, and \
+   a 'certify condition' stating what specific change would resolve it. \
+   Then give an architecture verdict for the change as a whole: \
+   SOUND, CONCERN, or WRONG SHAPE. \
    End with CERTIFIED or NOT CERTIFIED." \
   < /dev/null
 ```
@@ -4118,14 +4152,16 @@ codex exec \
    FIXED → verify the fix against the original certify condition. \
    DISPUTED → evaluate the justification (ACCEPT if sound, REJECT if not). \
    ACCEPTED → verify it was applied. \
-   Do NOT expand the review surface. Report every new P0, P1 or P2. A new finding BLOCKS when it shows a REQUESTED behavior is incorrect; one outside the requested behaviors is reported as a linked follow-up, not a blocker. Lesser observations go in 'Notes for next review' (non-blocking). \
+   Do NOT expand the review surface. Report every defect you find, at any severity. A finding BLOCKS only when it is P0 or P1 AND it shows a REQUESTED behavior is incorrect — and a finding that shows a requested behavior is incorrect IS P1, whatever label it arrived with. Anything outside the requested behaviors is reported as a linked follow-up, never a blocker. Lesser observations go in 'Notes for next review' (non-blocking). \
    End with CERTIFIED or NOT CERTIFIED." \
   < /dev/null
 ```
 
 **The key constraint:** Rechecks are scoped to previous findings only — a reviewer should not go hunting for unrelated new material during a recheck round, which is how a 3-round review becomes an 11-round one.
 
-**But scoped does not mean muzzled — and not everything it sees may block.** A recheck reports every defect it finds, at any severity. What **blocks** is bounded by the closed allowlist: a finding blocks when it shows a **requested** behavior is incorrect. A P2 outside the requested behaviors is reported and becomes a linked follow-up issue, not a certification blocker. Certification means *zero unresolved findings against the requested behaviors*, not *zero findings raised after round 1* — and not *zero defects anywhere*, which is unsatisfiable and is the shape that turned #520 into 20 rounds. Report-everything and block-on-scope are different questions; conflating them is how an invariant escalates. An earlier revision of this paragraph said new P2s could never block certification; that let a real defect through on the grounds of what round it was found in, which is not a property of the defect. What the scoping rule actually forbids is expanding the review's *surface*, not silencing what the reviewer sees.
+**But scoped does not mean muzzled — and not everything it sees may block.** A recheck reports every defect it finds, at any severity. What **blocks** is bounded by the closed allowlist: a finding blocks when it shows a **requested** behavior is incorrect. A finding outside the requested behaviors is reported and becomes a linked follow-up issue, not a certification blocker. Certification means *zero unresolved findings against the requested behaviors*, not *zero findings raised after round 1* — and not *zero defects anywhere*, which is unsatisfiable and is the shape that turned #520 into 20 rounds. Report-everything and block-on-scope are different questions; conflating them is how an invariant escalates. What the scoping rule actually forbids is expanding the review's *surface*, not silencing what the reviewer sees.
+
+**This is the blocking rule stated from the recheck's side.** A finding that shows a requested behavior is wrong means the thing does not work, so it is P1 — no matter who labelled it P2, or when it appeared. Grade by impact and the rule needs no exception.
 
 **Convergence:** the default is **two passes per frozen scope, counted cumulatively per root task** (see "When to stop" above); this section's older max-3-rechecks heuristic is the ceiling, not the target. If still NOT CERTIFIED after the budget, that is a **recorded continue/stop decision**, not an automatic escalation — see the Exception below for where the decision is written. A human is woken only when the two reviewers disagree, or a non-waivable gate has failed twice. Never ship uncertified; but running out of budget is not by itself a reason to interrupt the maintainer.
 
@@ -4148,8 +4184,8 @@ Claude writes code → handoff.json (round 1)
     |                                FIXED / DISPUTED / ACCEPTED
     |                                          |
     |                              Reviewer: TARGETED RECHECK
-    |                          (scoped surface; a new P0/P1/P2 blocks
-    |                           only if a REQUESTED behavior is wrong)
+    |                          (scoped surface; a new finding blocks only
+    |                           if P0/P1 AND a REQUESTED behavior is wrong)
     |                                          |
     |                              All resolved? → YES → CERTIFIED (write commit_sha)
     |                                          |
@@ -4213,7 +4249,7 @@ CLI-distributed file parity (skills, hooks, settings).
 
 #### Multiple reviewers (Claude review + Codex + human)
 
-Run them in parallel; collect feedback via `gh api repos/OWNER/REPO/pulls/PR/comments` (single source of truth). Respond per-reviewer (different blind spots — don't merge feedback). On conflicts, pick the stronger argument with reasoning, not the louder voice. Cap iterations at 3 per reviewer to avoid infinite loops.
+Run them in parallel; collect feedback via `gh api repos/OWNER/REPO/pulls/PR/comments` (single source of truth). Respond per-reviewer (different blind spots — don't merge feedback). On a conflict between two model reviewers, cross-feed their positions verbatim and let them reconcile — you relay, you do not pick a winner. A human-vs-model split goes to the human as one question. Cap iterations at 3 per reviewer to avoid infinite loops.
 
 #### Non-code domains (research, persuasion, medical content)
 
@@ -4229,12 +4265,27 @@ When two models review the same change, **run them in parallel and blind to each
 
 **Give both reviewers the SAME contract.** Same diff, same preflight, same severity scale, same fix policy — otherwise you cannot merge their findings or compare their verdicts, and you will not notice when one is grading on a different curve. Measured here 2026-07-29: one reviewer was given P0-P3 and the other HIGH/MEDIUM/LOW on the same change, which made two genuine reviews look like disagreement.
 
+**The review bar is the issue's acceptance criteria, verbatim.** A stricter criterion you invent while writing your own review prompt is self-inflicted scope, and it is invisible because it looks like rigour. *(#553: two rounds spent on a bar #530's acceptance never contained, retired only by a zero-diff dispute.)*
+
+**Grade severity by impact if it shipped.** Not by how hard the fix is. Not by which round found it. Either one gets gamed — a late finding inflated to buy another round, or deflated to close one out.
+
+This is also what lets P2 stop being a merge blocker without letting real defects through. A defect that means the thing does not work is P1, whatever round surfaced it.
+
 | Severity | Meaning | Action |
 |---|---|---|
-| P0/P1 | Wrong behaviour, security, data loss, or a test that passes against broken code | **Against a requested behavior: fix before merge, restarts the cycle. Outside the allowlist: linked follow-up issue.** |
-| P2 | Real defect, bounded blast radius. Inaccurate shipped prose belongs here | **Fix before merge.** Re-gate, no full restart |
+| P0 | Stop the world — prod broken, data loss, secret leaked | **Preempts the current task.** |
+| P1 | This PR does not merge: it doesn't work, or it breaks something that did | **Against a requested behavior: fix before merge, restarts the cycle. Outside the allowlist: linked follow-up issue.** |
+| P2 | Real, should fix, ships fine without it | Fix in this PR **only** if the diff is small and the file is already touched. Otherwise a linked issue |
 | P3 | Correctness or accuracy nit — a stale comment, an unclear message | Fix if cheap and it is about being *right* |
 | P3 (style) | Preference, naming, formatting with no correctness content | **Not review's job — encode it as a lint rule instead.** |
+
+**A finding blocks only if it is P0 or P1 and inside the issue's scope card.** An earlier revision of this table made P2 blocking, after an in-scope defect was waved through. The fix for that was the severity rule above, not a blocking P2 — the defect did not work, so it was P1.
+
+**Ask a second question, separate from the defect list: is this the right way to build it?** Should this code exist? Is it proportionate? The reviewer returns **SOUND**, **CONCERN** (ship it, here is the debt), or **WRONG SHAPE** (stop, redesign).
+
+No severity level says "this should not exist", so nobody says it. On #539 all seven findings across four rounds were legitimate P1s — the guard really was broken — and the right answer was that the guard should never have been written. It was deleted at round four. WRONG SHAPE ends that at round one.
+
+**File anything outside the scope card as a GitHub issue. Never build it in the current PR.** This binds reviewers on the same terms as the driver: an out-of-card finding gets reported and filed, and does not block certification. Without it the card describes a boundary nothing enforces, and growth is invisible because there is nothing to compare against. *(#520: 20 rounds, 46 lines.)*
 
 **Style findings become lint rules, not review findings.** A cross-model round is expensive, slow, and non-deterministic; a linter is free, instant and total. If a reviewer raises a style point worth honouring, the fix is not "change this line" — it is *add the rule so nothing can ever violate it again*, then let the linter enforce it in every repo that installs this. That converts a recurring review cost into a one-time one. Run the linters **before** requesting review (`shellcheck -s bash` on changed `.sh` files, plus whatever your language uses) so no reviewer round is spent on what a deterministic tool already reports. Review exists for **correctness** — behaviour, security, and whether the tests actually test anything. If you find yourself lacking a standard rather than lacking a fix, the deliverable is the rule.
 
@@ -4242,7 +4293,22 @@ Tell both reviewers this in the prompt, and tell them explicitly: **do not manuf
 
 **Diminishing returns — how to actually tell.** Judge by the *maximum severity per round*, never by finding count: count rises when a reviewer looks somewhere new, which is the opposite of a stopping signal (the round that found the most here also found the most serious bugs). You are converged when two consecutive rounds produce nothing above P3 **from reviewers that had not already cleared this code**. A single reviewer's own trend flattening means only that it has run out of defects *it* can see — one reviewer certified at high confidence here immediately before a fresh reviewer found six P1s in the same code.
 
-**Merging findings.** Combine, do not intersect. Two independent reviewers agreeing is a strong signal, but a finding raised by only one is the *common* case and is usually the valuable one — that is the entire point of using two. Respond to each reviewer's findings separately, and run the recheck round with each still blind to the other. **Blindness governs finding-generation and recheck only.** Once every reviewer has returned a verdict, reconciliation is a distinct, final phase: show each the other's *surviving disagreement* and re-ask once. Anchoring is only a hazard while defects are still being discovered; after the verdicts are in, the whole value is in the aggregation. Reconcile once, not per round.
+**Merging findings.** Combine, do not intersect. Two independent reviewers agreeing is a strong signal, but a finding raised by only one is the *common* case and is usually the valuable one — that is the entire point of using two. Respond to each reviewer's findings separately, and run the recheck round with each still blind to the other. **Blindness governs finding-generation and recheck only.** Once every reviewer has returned a verdict, reconciliation is a distinct, final phase. Reconcile once, not per round.
+
+### Reconciliation: the reviewers reconcile with each other
+
+**You relay their positions. You never merge their words.** Four phases:
+
+1. **Review blind.** No shared draft, no summary of the other's position. A reviewer who sees the first one confirms and extends it instead of looking somewhere new — you pay for two reviews and get one plus a proofread. Divergence here is the signal.
+2. **Cross-feed verbatim.** Pass each the other's position exactly as written. Paraphrase is where a position gets restated into something its author would not sign.
+3. **Let them argue.** Each concedes what is right and holds what is wrong with repo-verifiable evidence: a file, a line, a command output. Not an opinion. A concession to a misread is worse than a hold.
+4. **They return one position. You report it.** The user sees the settled answer and any surviving split — not two transcripts to referee.
+
+**Why the driver must not merge.** You are the lowest-ranked participant in a review of your own work: the most context, the least independence, and you wrote the thing. Merging two reviewers' words is grading yourself through a paraphrase you control. They outrank you here precisely because they did not write it.
+
+**Deadlock routes by where the position started.** A split that first appeared as a design question or a recorded scope decision belongs to the planner. One that first appeared in a verdict line, a defect list or a recheck response belongs to the reviewer, and the lower verdict applies. If a split spans both, the verdict's surface governs. Only what survives that reaches the human, and it goes as one question rather than two positions.
+
+*Evidence (#561): the adversarial leg opened with four P1 blockers against the planner's spec. The planner conceded all four, retracted a deferral it had defended, then found three more contradictory surfaces the attacker had missed. Neither model produced that list alone. The driver produced none of it.*
 
 **Cost control.** This is not free — each round costs wall-clock and, for a paid API reviewer, real money. Scale it to blast radius:
 
@@ -4278,7 +4344,7 @@ implement  →  fix in-allowlist findings  →  re-review with the ITERATION mod
 
 1. **Every finding gets a response before the next round** — FIXED, DISPUTED with reasoning, or ACCEPTED. Never silently drop one.
 2. **A dispute is a claim you owe evidence for.** If the reviewer rejects it and offers a concrete alternative, implement the alternative — you asked for an adversary, not an audience.
-3. **Any P0/P1 finding *against a requested behavior* restarts the cycle from the top** — one outside the closed allowlist becomes a linked follow-up issue and does not restart anything. A gate round that surfaces a real defect was not a gate round, it was an iteration round. In-allowlist P2/P3-only findings do not need a full restart: fix them and re-run the gate. Either way the gate must eventually return nothing unresolved *against the requested behaviors* — "findings?" in the diagram means any finding against those, and what differs is only whether you re-enter at iteration or at the gate. Findings outside the allowlist are logged as follow-up issues and never gate anything; the unsatisfiable version of this condition — zero defects anywhere — is what turned #520 into 20 rounds.
+3. **Any P0/P1 finding *against a requested behavior* restarts the cycle from the top** — one outside the closed allowlist becomes a linked follow-up issue and does not restart anything. A gate round that surfaces a real defect was not a gate round, it was an iteration round. In-allowlist P2/P3-only findings do not block at all — fix them here if the diff is small and the file is already touched, otherwise file them and let the gate return. Either way the gate must eventually return nothing unresolved *against the requested behaviors* — "findings?" in the diagram means any finding against those, and what differs is only whether you re-enter at iteration or at the gate. Findings outside the allowlist are logged as follow-up issues and never gate anything; the unsatisfiable version of this condition — zero defects anywhere — is what turned #520 into 20 rounds.
 4. **Fixes need their own verification.** A fix shipped on the strength of "the reviewer suggested it" is unverified code — the reviewer proposed it, nobody has yet shown it works. A test that passes against broken code was never a test.
 
    **TDD, applied to the fix: RED → GREEN** — where a RED mutation is writable; a meaning-level prose fix gets cross-model re-review instead (see "When TDD RED Applies"). Write the assertion, run it, watch **that specific assertion** fail, then implement and watch it pass. The common miss is observing red at the *suite* level — one assertion fails, the suite is red, you implement, the suite goes green, and any assertion that was green from birth is never noticed.
@@ -4306,7 +4372,7 @@ When multiple reviewers comment on a PR (Claude, Codex, human reviewers), addres
 
 1. **Read all reviews** — collect feedback from every active reviewer
 2. **Respond per-reviewer** — each reviewer has different blind spots. Address each one's findings separately
-3. **Resolve conflicts** — if reviewers disagree, pick the stronger argument, note why
+3. **Do not resolve conflicts yourself** — when two model reviewers disagree, cross-feed their positions verbatim and let them reconcile (see "Reconciliation: the reviewers reconcile with each other"). You relay; you never pick a winner. A human reviewer cannot be put in that loop, so a human-vs-model split goes to the human as one question, and the human decides
 4. **Iterate until all approve** — don't merge until every active reviewer is satisfied
 5. **Two passes per reviewer per frozen scope**, counted cumulatively per root task so a re-freeze does not reset it — past that, a recorded continue/stop decision, not a user interrupt
 

--- a/cowork/skills/sdlc/SKILL.md
+++ b/cowork/skills/sdlc/SKILL.md
@@ -120,6 +120,29 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Autocompact: set neither override by default.** For a deliberately earlier boundary use `CLAUDE_CODE_AUTO_COMPACT_WINDOW` alone — a smaller window compacts sooner, and nothing in that range switches compaction off. On **current Opus** a percentage alone is inert unless the window is also set, and then the two multiply; on Sonnet 5 and on a 200K Opus 4.6 pin it is live, so size it against THAT window (#520). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/claude-setup-wizard` Step 9.5.
 
+## The Review Contract (give BOTH reviewers this, verbatim)
+
+**Grade severity by impact if it shipped.** Not by how hard the fix is. Not by which round found it. Either one gets gamed to open or close a round.
+
+| | |
+|---|---|
+| **P0** | Stop the world. Prod broken, data loss, secret leaked. Preempts the task. |
+| **P1** | This PR does not merge. It doesn't work, or it broke something that did. |
+| **P2** | Real, should fix, ships fine without it. |
+| **P3** | Nit. |
+
+**A finding blocks only if it is P0 or P1 and inside the scope card.** Fix a P2 or P3 here only if the diff is small and you already touched the file. Otherwise file it.
+
+**Also answer: is this the right way to build it?** Should this code exist? Is it proportionate? Return **SOUND**, **CONCERN** (ship it, here's the debt), or **WRONG SHAPE** (stop, redesign). No severity level says "this should not exist", so nobody says it. *(#539: four rounds, seven real P1s, guard deleted at the end. WRONG SHAPE ends that at round 1.)*
+
+**File anything outside the scope card as a GitHub issue. Never build it here.** This binds reviewers too: an out-of-card finding gets reported and filed, and does not block certification. *(#520: 20 rounds, 46 lines, nothing to compare growth against.)*
+
+**Do not certify a doc that instructs commands unless the output is pasted.** The other leg can check this, which is the point. Reading catches judgement defects; only running catches wrong commands. *(#572: both legs certified a doc whose update command fails outright.)*
+
+**Review against the issue's acceptance criteria, verbatim.** A stricter bar you invented in your own prompt is self-inflicted scope. *(#553: two rounds on a bar #530 never contained.)*
+
+Ship good code, not perfect code. No glaring issues, right shape. Otherwise you never ship.
+
 ## Cross-Model Review (REQUIRED for High-Stakes)
 
 **When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **Skip (log justification):** trivial, hotfixes, risk < review cost. **Reviewer:** `gpt-5.6-sol` `high` — adversarial diversity. **Cadence:** Fable during design, Codex once per frozen scope; don't stack both unless the decision needs two independent reviewers.
@@ -133,12 +156,23 @@ PROTOCOL is universal across domains; only `review_instructions` and `verificati
 **Handoff/preflight mechanics: wizard doc.** These two stay; improvising them cost real time (#364, #437).
 
 1. **Run reviewer:** `codex exec -c 'model_reasoning_effort="high"' -s danger-full-access -o .reviews/latest-review.md "<prompt>" < /dev/null`. Always `high`, `run_in_background: true` + `dangerouslyDisableSandbox: true`, always `< /dev/null`. **Why:** `< /dev/null` prevents a stdin hang at 0% CPU; background avoids the Bash 10-min cap that kills foreground codex (bundles run 5–30 min). Foreground burned 70 min on a 7-min review (#364).
-2. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Report every defect; don't hunt new surfaces; new P0/P1/P2 blocks only if a REQUESTED behavior is wrong." **NEVER unilaterally dismiss** — run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
+2. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Report every defect at any severity; don't hunt new surfaces. A finding blocks only if it is P0/P1 AND against a REQUESTED behavior — and a finding showing a requested behavior is wrong IS P1, whatever label it arrived with." **NEVER unilaterally dismiss** — run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
 
 **Convergence — TWO PASSES PER FROZEN SCOPE, COUNTED CUMULATIVELY PER ROOT TASK.** One review, one verify (verify reads only the diff since last verdict). A fix adding code or promises beyond the reviewed diff is NEW SCOPE — log continue/stop + cost in `handoff.json` `scope_decisions` BEFORE the pass; single driver records its own, next pass ratifies; human only on a cross-model split. **The count is cumulative and never resets when scope is re-frozen** — record `root_task` (the verbatim request) and `base_sha` once, then let `round` accumulate across every re-freeze; new scopes **append** to `scope_decisions`, never replace it. Re-freezing after each fix is how two-per-scope becomes unlimited (#520: 20 rounds). This is accounting, not a cap: continuing stays the recorded decision's call. **Blame the line:** a blocker in code nobody asked for — cut it, don't repair it. Review committed SHAs, not a mutable tree. #520: 20 rounds, 46 lines.
 **Loop autonomy — no per-round check-ins.** While a pass is owed, don't hand the turn back: fix, push, launch it in the SAME turn. Ending a turn with no pending work IS a stop decision; cite **CONVERGED** (verdicts in on head SHA, zero unresolved in-allowlist), **DEADLOCK** (finding unmoved after 2 rechecks, or non-waivable gate after 2 attempts), **BOUND** (context ceiling, or gate needing a human), or **SCOPE** (two passes used — recorded decision required). Every pass carries a delta; resubmitting unchanged = reviewer-shopping.
 
-**Multi-reviewer — RECONCILE, don't collect.** Answer each blind; once all verdicts are in, show each the other's surviving position and re-ask once. The gain is the aggregation, not a second opinion. Only a split SURVIVING that reaches the user — as a decision, not a question. **Non-code domains:** add `"audience"`/`"stakes"` keys.
+**Multi-reviewer: let the reviewers reconcile with each other. You relay. You never merge their words.**
+
+1. **Review blind.** No shared draft, no summary of the other. A reviewer who saw the first one confirms it instead of looking elsewhere, and you paid for two reviews to get one.
+2. **Cross-feed verbatim.** Pass each the other's position as written. Paraphrase restates a position into something its author would not sign.
+3. **Let them argue.** Concede what's right. Hold what's wrong with a file, a line, or command output — never an opinion.
+4. **They hand back one position. You report it.** The user sees a settled answer, not two transcripts to referee.
+
+You are the lowest-ranked reviewer of your own work: most context, least independence, and you wrote it. Merging their words is grading yourself through a paraphrase you control.
+
+**On deadlock, route by where the position started.** A split that started as a design question belongs to the planner. One that started in a verdict, defect list, or recheck belongs to the reviewer, and the lower verdict applies. A split spanning both goes with the verdict. Only what survives that goes to the user, as one question. *(#561: the attacker opened with four P1s, the planner conceded all four and then found three surfaces the attacker missed. Neither produced that list alone.)*
+
+**Non-code domains:** add `"audience"`/`"stakes"` keys.
 
 **Full protocol** (rationale, full JSON example, anti-patterns like "find at least N", convergence diagrams): `CLAUDE_CODE_SDLC_WIZARD.md` → "Cross-Model Review Loop".
 
@@ -168,8 +202,8 @@ Mandatory steps:
 5. CI fails → fix, push (max 2 attempts)
 6. CI passes → `gh api .../pulls/PR/comments` for review feedback
 7. Implement valid suggestions (bugs, perf, dedup). Skip opinions. Max 3 iterations
-8. **Clearance, once CI green.** Ask reviewers *"safe to merge?"* — NOT "can you break this" (unsatisfiable; #478). Each posts `**CROSS-MODEL-CLEARANCE**` + one fenced json `{"reviewer","verdict":"YES","confidence","sha"}`. **`verdict` decides; confidence only qualifies it.** YES <95 names a residual → one focused round, never a human ask; re-asking unchanged is shopping.
-9. Explicit `gh pr merge --squash` (repo wrapper if any) — never auto-merge. Needs 2 YES ≥95 on head SHA AND: CI `validate` green, Codex `high` CERTIFIED via full dialogue; **fresh Fable subagent** (diff only) with **zero unresolved findings** in-allowlist after **≥1 dialogue round**. Merge-evidence paths (workflows, `hooks/`, `.claude/`, merge script) need a human — **unless** your repo has a merge gate mechanically checking CI, test deletions, clearance, and you run the *merged* copy, not this branch's edited one. No gate: human. Version bumps, reviewer deadlocks: always human. Tell the user after — never silent.
+8. **Clearance, once CI green.** Ask reviewers *"safe to merge?"* — NOT "can you break this" (unsatisfiable; #478). Each posts `**CROSS-MODEL-CLEARANCE**` + one fenced json `{"reviewer","verdict":"YES","confidence","sha"}`. **The verdict decides. Ignore the confidence number.** It does not separate certified-correct from certified-wrong, so never route a decision through it and don't spend output defending it. The field stays only because the merge gate still requires it (#574). *(#572: one leg certified at 100%, the other then found a P1 it had passed three times; the second certified at 96%, the first then found a P1 that only appeared by running the command. What discriminated was executing it.)*
+9. Explicit `gh pr merge --squash` (repo wrapper if any) — never auto-merge. Needs 2 YES ≥95 on head SHA (the ≥95 is the gate's mechanical requirement until PR-B, not a review signal — see #574 above) AND: CI `validate` green, Codex `high` CERTIFIED via full dialogue; **fresh Fable subagent** (diff only) with **zero unresolved findings** in-allowlist after **≥1 dialogue round**. Merge-evidence paths (workflows, `hooks/`, `.claude/`, merge script) need a human — **unless** your repo has a merge gate mechanically checking CI, test deletions, clearance, and you run the *merged* copy, not this branch's edited one. No gate: human. Version bumps, reviewer deadlocks: always human. Tell the user after — never silent.
 
 **Evidence:** PR #145 auto-merged, shipped a P1 bug. v1.92.0: two YES (97/93) dead-ended (#478).
 
@@ -194,6 +228,10 @@ Reproduce → Isolate → Root Cause → Fix → Regression Test. No skipping. `
 Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
 
 **Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
+**An instruction is not a claim.** Never tell a reader to run a command you have not run. Labeling saves a claim, because the reader evaluates it. It cannot save an instruction, because the reader executes it. Delete it instead.
+
+Run the exact string you ship, and fill in every placeholder at least once. **Check that the output shows the promised behavior, not just exit 0** — `✔ already at the latest version` proves the name resolves, not that the command updates. If you can't observe the behavior, narrow the instruction to what you did see. A command you genuinely cannot run may be described, never instructed. *(#572: 24 doc lines, five P1s, every one a claim wider than its evidence — including an update command that fails outright. That doc labeled its evidence honestly and still shipped broken.)*
 
 ## Release Planning (Task Ships a Release)
 
@@ -221,6 +259,18 @@ Critique tests harder than app code: testing the right things? Proving correctne
 Mocks MUST come from real captured data — never guess shapes. Unit tests qualify ONLY for pure I→O (no DB, API, FS, cache).
 
 **TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
+
+**List every observation the check promises, then break each one separately.** Mutate a copy of the live deliverable, not the base. The run fails unless every expected failure reports. Can't list them? Don't write the guard.
+
+**Make the nearest wrong version fail, not just a deletion.** Deletion is the easiest mutation to survive, because a branch that pre-existing text already satisfies never notices it. *(Five dead checks in one session. #550's runner ran 30 of 65 suites and reported green.)*
+
+**Grep prose for exact strings or structure only. Never for meaning, denial, or polarity.** Review the prose instead, or delete the marker (#493 req 6).
+
+**The first time a reversed live instruction stays green, delete the guard. Do not patch it.** *(#539: three patches to one unfixable mechanism turned round 2 into round 4. Strikethrough won — `~~the count never resets~~` keeps the string byte-identical while teaching the opposite, suite green at 137/137.)*
+
+**Offer "delete the guard" as an outcome in any guard recheck.** Reviewers only pick outcomes the prompt offers. Rounds 1–3 kept it off the menu; round 4 put it on and it was taken immediately. If you are repairing a guard for the second time this cycle, ask whether it should exist.
+
+**Accepted residual:** no string check can catch a doc that lists the required fields and then contradicts them in prose. Cross-model review is the only guard for that.
 
 ## Prove It Gate (New Additions Only)
 

--- a/skills/sdlc/SKILL.md
+++ b/skills/sdlc/SKILL.md
@@ -120,6 +120,29 @@ Native `/goal <condition>` (**v2.1.143+**). Haiku evaluator re-checks transcript
 
 **Autocompact: set neither override by default.** For a deliberately earlier boundary use `CLAUDE_CODE_AUTO_COMPACT_WINDOW` alone — a smaller window compacts sooner, and nothing in that range switches compaction off. On **current Opus** a percentage alone is inert unless the window is also set, and then the two multiply; on Sonnet 5 and on a 200K Opus 4.6 pin it is live, so size it against THAT window (#520). **Advisor (v2.1.170+):** `advisorModel: "fable"` works with all drivers above; set in `/claude-setup-wizard` Step 9.5.
 
+## The Review Contract (give BOTH reviewers this, verbatim)
+
+**Grade severity by impact if it shipped.** Not by how hard the fix is. Not by which round found it. Either one gets gamed to open or close a round.
+
+| | |
+|---|---|
+| **P0** | Stop the world. Prod broken, data loss, secret leaked. Preempts the task. |
+| **P1** | This PR does not merge. It doesn't work, or it broke something that did. |
+| **P2** | Real, should fix, ships fine without it. |
+| **P3** | Nit. |
+
+**A finding blocks only if it is P0 or P1 and inside the scope card.** Fix a P2 or P3 here only if the diff is small and you already touched the file. Otherwise file it.
+
+**Also answer: is this the right way to build it?** Should this code exist? Is it proportionate? Return **SOUND**, **CONCERN** (ship it, here's the debt), or **WRONG SHAPE** (stop, redesign). No severity level says "this should not exist", so nobody says it. *(#539: four rounds, seven real P1s, guard deleted at the end. WRONG SHAPE ends that at round 1.)*
+
+**File anything outside the scope card as a GitHub issue. Never build it here.** This binds reviewers too: an out-of-card finding gets reported and filed, and does not block certification. *(#520: 20 rounds, 46 lines, nothing to compare growth against.)*
+
+**Do not certify a doc that instructs commands unless the output is pasted.** The other leg can check this, which is the point. Reading catches judgement defects; only running catches wrong commands. *(#572: both legs certified a doc whose update command fails outright.)*
+
+**Review against the issue's acceptance criteria, verbatim.** A stricter bar you invented in your own prompt is self-inflicted scope. *(#553: two rounds on a bar #530 never contained.)*
+
+Ship good code, not perfect code. No glaring issues, right shape. Otherwise you never ship.
+
 ## Cross-Model Review (REQUIRED for High-Stakes)
 
 **When to run:** high-stakes changes (auth, payments, data), releases/publishes, complex refactors. **Skip (log justification):** trivial, hotfixes, risk < review cost. **Reviewer:** `gpt-5.6-sol` `high` — adversarial diversity. **Cadence:** Fable during design, Codex once per frozen scope; don't stack both unless the decision needs two independent reviewers.
@@ -133,12 +156,23 @@ PROTOCOL is universal across domains; only `review_instructions` and `verificati
 **Handoff/preflight mechanics: wizard doc.** These two stay; improvising them cost real time (#364, #437).
 
 1. **Run reviewer:** `codex exec -c 'model_reasoning_effort="high"' -s danger-full-access -o .reviews/latest-review.md "<prompt>" < /dev/null`. Always `high`, `run_in_background: true` + `dangerouslyDisableSandbox: true`, always `< /dev/null`. **Why:** `< /dev/null` prevents a stdin hang at 0% CPU; background avoids the Bash 10-min cap that kills foreground codex (bundles run 5–30 min). Foreground burned 70 min on a 7-min review (#364).
-2. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Report every defect; don't hunt new surfaces; new P0/P1/P2 blocks only if a REQUESTED behavior is wrong." **NEVER unilaterally dismiss** — run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
+2. **Dialogue loop:** per-finding response (`{"finding":"1","action":"FIXED|DISPUTED|ACCEPTED","summary":"..."}` in `.reviews/response.json`). Bump round, set `PENDING_RECHECK`, add `fixes_applied` (numbered, file:line). Recheck prompt: "TARGETED RECHECK. FIXED → verify certify condition. DISPUTED → ACCEPT if sound, REJECT with reasoning. ACCEPTED → verify applied. Report every defect at any severity; don't hunt new surfaces. A finding blocks only if it is P0/P1 AND against a REQUESTED behavior — and a finding showing a requested behavior is wrong IS P1, whatever label it arrived with." **NEVER unilaterally dismiss** — run the recheck; the reviewer may accept your dispute or counter with evidence you missed. **On CERTIFIED write `"commit_sha": "<git rev-parse HEAD>"` into `handoff.json`** — the gate hook (#437) treats a missing/mismatched SHA as stale, not just the status string.
 
 **Convergence — TWO PASSES PER FROZEN SCOPE, COUNTED CUMULATIVELY PER ROOT TASK.** One review, one verify (verify reads only the diff since last verdict). A fix adding code or promises beyond the reviewed diff is NEW SCOPE — log continue/stop + cost in `handoff.json` `scope_decisions` BEFORE the pass; single driver records its own, next pass ratifies; human only on a cross-model split. **The count is cumulative and never resets when scope is re-frozen** — record `root_task` (the verbatim request) and `base_sha` once, then let `round` accumulate across every re-freeze; new scopes **append** to `scope_decisions`, never replace it. Re-freezing after each fix is how two-per-scope becomes unlimited (#520: 20 rounds). This is accounting, not a cap: continuing stays the recorded decision's call. **Blame the line:** a blocker in code nobody asked for — cut it, don't repair it. Review committed SHAs, not a mutable tree. #520: 20 rounds, 46 lines.
 **Loop autonomy — no per-round check-ins.** While a pass is owed, don't hand the turn back: fix, push, launch it in the SAME turn. Ending a turn with no pending work IS a stop decision; cite **CONVERGED** (verdicts in on head SHA, zero unresolved in-allowlist), **DEADLOCK** (finding unmoved after 2 rechecks, or non-waivable gate after 2 attempts), **BOUND** (context ceiling, or gate needing a human), or **SCOPE** (two passes used — recorded decision required). Every pass carries a delta; resubmitting unchanged = reviewer-shopping.
 
-**Multi-reviewer — RECONCILE, don't collect.** Answer each blind; once all verdicts are in, show each the other's surviving position and re-ask once. The gain is the aggregation, not a second opinion. Only a split SURVIVING that reaches the user — as a decision, not a question. **Non-code domains:** add `"audience"`/`"stakes"` keys.
+**Multi-reviewer: let the reviewers reconcile with each other. You relay. You never merge their words.**
+
+1. **Review blind.** No shared draft, no summary of the other. A reviewer who saw the first one confirms it instead of looking elsewhere, and you paid for two reviews to get one.
+2. **Cross-feed verbatim.** Pass each the other's position as written. Paraphrase restates a position into something its author would not sign.
+3. **Let them argue.** Concede what's right. Hold what's wrong with a file, a line, or command output — never an opinion.
+4. **They hand back one position. You report it.** The user sees a settled answer, not two transcripts to referee.
+
+You are the lowest-ranked reviewer of your own work: most context, least independence, and you wrote it. Merging their words is grading yourself through a paraphrase you control.
+
+**On deadlock, route by where the position started.** A split that started as a design question belongs to the planner. One that started in a verdict, defect list, or recheck belongs to the reviewer, and the lower verdict applies. A split spanning both goes with the verdict. Only what survives that goes to the user, as one question. *(#561: the attacker opened with four P1s, the planner conceded all four and then found three surfaces the attacker missed. Neither produced that list alone.)*
+
+**Non-code domains:** add `"audience"`/`"stakes"` keys.
 
 **Full protocol** (rationale, full JSON example, anti-patterns like "find at least N", convergence diagrams): `CLAUDE_CODE_SDLC_WIZARD.md` → "Cross-Model Review Loop".
 
@@ -168,8 +202,8 @@ Mandatory steps:
 5. CI fails → fix, push (max 2 attempts)
 6. CI passes → `gh api .../pulls/PR/comments` for review feedback
 7. Implement valid suggestions (bugs, perf, dedup). Skip opinions. Max 3 iterations
-8. **Clearance, once CI green.** Ask reviewers *"safe to merge?"* — NOT "can you break this" (unsatisfiable; #478). Each posts `**CROSS-MODEL-CLEARANCE**` + one fenced json `{"reviewer","verdict":"YES","confidence","sha"}`. **`verdict` decides; confidence only qualifies it.** YES <95 names a residual → one focused round, never a human ask; re-asking unchanged is shopping.
-9. Explicit `gh pr merge --squash` (repo wrapper if any) — never auto-merge. Needs 2 YES ≥95 on head SHA AND: CI `validate` green, Codex `high` CERTIFIED via full dialogue; **fresh Fable subagent** (diff only) with **zero unresolved findings** in-allowlist after **≥1 dialogue round**. Merge-evidence paths (workflows, `hooks/`, `.claude/`, merge script) need a human — **unless** your repo has a merge gate mechanically checking CI, test deletions, clearance, and you run the *merged* copy, not this branch's edited one. No gate: human. Version bumps, reviewer deadlocks: always human. Tell the user after — never silent.
+8. **Clearance, once CI green.** Ask reviewers *"safe to merge?"* — NOT "can you break this" (unsatisfiable; #478). Each posts `**CROSS-MODEL-CLEARANCE**` + one fenced json `{"reviewer","verdict":"YES","confidence","sha"}`. **The verdict decides. Ignore the confidence number.** It does not separate certified-correct from certified-wrong, so never route a decision through it and don't spend output defending it. The field stays only because the merge gate still requires it (#574). *(#572: one leg certified at 100%, the other then found a P1 it had passed three times; the second certified at 96%, the first then found a P1 that only appeared by running the command. What discriminated was executing it.)*
+9. Explicit `gh pr merge --squash` (repo wrapper if any) — never auto-merge. Needs 2 YES ≥95 on head SHA (the ≥95 is the gate's mechanical requirement until PR-B, not a review signal — see #574 above) AND: CI `validate` green, Codex `high` CERTIFIED via full dialogue; **fresh Fable subagent** (diff only) with **zero unresolved findings** in-allowlist after **≥1 dialogue round**. Merge-evidence paths (workflows, `hooks/`, `.claude/`, merge script) need a human — **unless** your repo has a merge gate mechanically checking CI, test deletions, clearance, and you run the *merged* copy, not this branch's edited one. No gate: human. Version bumps, reviewer deadlocks: always human. Tell the user after — never silent.
 
 **Evidence:** PR #145 auto-merged, shipped a P1 bug. v1.92.0: two YES (97/93) dead-ended (#478).
 
@@ -194,6 +228,10 @@ Reproduce → Isolate → Root Cause → Fix → Regression Test. No skipping. `
 Before reporting a fix, name the observable that would differ if it were NOT fixed — then go look at it. Settings file edited → read the live process env, not the file. Hook changed → fire it. Threshold changed → measure it against the real files. If the only evidence is "I made the edit", the state is *submitted*, not fixed.
 
 **Out-of-repo changes get no gate** (global `settings.json`, env vars, shell rc, scheduler entries): no diff, no PR, no reviewer ever sees them. Before editing, check `.reviews/` artifacts and memory for prior findings on the subject; state the verification command in the same message as the change; if a live process won't pick up the edit (env vars need a restart), say so instead of "fixed". **Evidence:** 2026-08-08 (#525) — a settings fix was reported fixed while the bug was still live; the answer was already in `.reviews/` from PR #468.
+
+**An instruction is not a claim.** Never tell a reader to run a command you have not run. Labeling saves a claim, because the reader evaluates it. It cannot save an instruction, because the reader executes it. Delete it instead.
+
+Run the exact string you ship, and fill in every placeholder at least once. **Check that the output shows the promised behavior, not just exit 0** — `✔ already at the latest version` proves the name resolves, not that the command updates. If you can't observe the behavior, narrow the instruction to what you did see. A command you genuinely cannot run may be described, never instructed. *(#572: 24 doc lines, five P1s, every one a claim wider than its evidence — including an update command that fails outright. That doc labeled its evidence honestly and still shipped broken.)*
 
 ## Release Planning (Task Ships a Release)
 
@@ -221,6 +259,18 @@ Critique tests harder than app code: testing the right things? Proving correctne
 Mocks MUST come from real captured data — never guess shapes. Unit tests qualify ONLY for pure I→O (no DB, API, FS, cache).
 
 **TDD proves:** RED (fails — bug or missing feature), GREEN (passes — fix works), Forever (regression protection). **TDD RED applies only where a RED mutation is writable** — write the wrong version the test must catch BEFORE writing the test. If catching the wrong version requires understanding meaning (a reversal, a negation, a contradicting sentence nearby), no assertion can do it: DO NOT write the test. That exception is for prose judged by a reader — for executable behavior, any observable input/output or side-effect difference means a RED mutation IS writable. Three-way call for every change: **EVAL it** (agent-facing guidance a real scenario can observe), **plain-assert it** (mechanical contract only — byte parity, a JSON key, a version, a heading; proves structure, never meaning), or **DON'T TEST IT** (prose whose correctness is a judgement call — cross-model review is the guard). **Implement-first** is allowed ONLY when a named gate blocked the required RED/evidence act itself — a gate refusing implementation because RED is missing is the gate working, not an entry ticket. Quote the refusal verbatim in the issue/PR, get a cross-model ruling that APPROVES that same act and scope BEFORE the edit, and name — before editing — the observable that would differ if the change were wrong, then go look at it after (#525). No quoted refusal or no approving ruling — no entry.
+
+**List every observation the check promises, then break each one separately.** Mutate a copy of the live deliverable, not the base. The run fails unless every expected failure reports. Can't list them? Don't write the guard.
+
+**Make the nearest wrong version fail, not just a deletion.** Deletion is the easiest mutation to survive, because a branch that pre-existing text already satisfies never notices it. *(Five dead checks in one session. #550's runner ran 30 of 65 suites and reported green.)*
+
+**Grep prose for exact strings or structure only. Never for meaning, denial, or polarity.** Review the prose instead, or delete the marker (#493 req 6).
+
+**The first time a reversed live instruction stays green, delete the guard. Do not patch it.** *(#539: three patches to one unfixable mechanism turned round 2 into round 4. Strikethrough won — `~~the count never resets~~` keeps the string byte-identical while teaching the opposite, suite green at 137/137.)*
+
+**Offer "delete the guard" as an outcome in any guard recheck.** Reviewers only pick outcomes the prompt offers. Rounds 1–3 kept it off the menu; round 4 put it on and it was taken immediately. If you are repairing a guard for the second time this cycle, ask whether it should exist.
+
+**Accepted residual:** no string check can catch a doc that lists the required fields and then contradicts them in prose. Cross-model review is the only guard for that.
 
 ## Prove It Gate (New Additions Only)
 


### PR DESCRIPTION
Closes #558, #557, #573, #574, #564. #556 closed by [posted decision](https://github.com/BaseInfinity/claude-sdlc-harness/issues/556#issuecomment-5249930505).

**Six issues, one PR, zero new tests.** That is the point, not a shortcut — see the [batching ruling](https://github.com/BaseInfinity/claude-sdlc-harness/issues/558#issuecomment-5249401013).

The harness's per-PR toll (handoff, preflight, review, recheck, clearance, merge artifact, CI) is roughly constant regardless of change size. #572 was 30 lines of docs and cost six rounds. These six issues edit the same three files and the same protocol sections, so shipping them separately means reviewing the same surface six times against a moving target.

And the round-eater was never the prose. #557's own exhibit is **seven blocking findings, all in the test, zero in the deliverable.** A batch that ships zero guards removes that surface by construction.

## Per-item map

| Issue | What ships | Files |
|---|---|---|
| **#558** | Severity scale graded by impact-if-shipped; `blocks = (P0 or P1) AND in the scope card`; a separate architecture verdict (SOUND / CONCERN / WRONG SHAPE); feature creep is always a filed issue | `SKILL.md` (new section), wizard (revises the existing table) |
| **#557** | RED as an enumerated mutation set on the live deliverable, nearest-wrong-form not deletion; never grep prose for meaning; first reversed instruction that stays green deletes the guard; "delete the guard" must be an offered recheck outcome; review bar = acceptance criteria verbatim | `SKILL.md`, wizard |
| **#573** | An instruction is not a claim — executed-or-deleted, placeholders instantiated, output must show the promised *behavior*; certification precondition; `CLAUDE.md` release-verification list extended | `SKILL.md`, wizard, `CLAUDE.md` |
| **#574** | The confidence percentage carries no review signal. Verdict decides. Field kept only because the gate requires it | `SKILL.md` only — see note below |
| **#564** | Reviewers reconcile with each other, verbatim, in four phases. The driver relays and never merges their words. Deadlock routes by originating surface | `SKILL.md`, wizard (new subsection) |
| **#556** | Decision posted and closed. No evals. Prose is category 3: review it, never guard it | none — this PR embodies it |

`cowork/skills/sdlc/SKILL.md` stays byte-identical to `skills/sdlc/SKILL.md` (`diff -q` clean).

## The ejection rule, pre-registered before review

> A P1 on item *k* ejects item *k* into its own follow-up issue; the batch ships with the rest. One contested rule does not hold the others hostage.

Registered in the review prompt before either leg ran, so it could not be argued into existence at round 3.

## #573 applied to itself — every instructed command executed, output pasted

```
$ claude plugin details sdlc-wizard-cowork
sdlc-wizard-cowork 1.97.0
  SDLC enforcement for Claude Cowork — TDD, planning, self-review via skills and one prompt-based hook
  Source: sdlc-wizard-cowork@sdlc-wizard-marketplace

Component inventory
  Skills (2)  feedback, sdlc
  Agents (0)
  Hooks (1)  PreToolUse  (harness-only — no model context cost)
  MCP servers (0)
  LSP servers (0)

$ claude plugin update sdlc-wizard-cowork@sdlc-wizard-marketplace
Checking for updates for plugin "sdlc-wizard-cowork@sdlc-wizard-marketplace" at user scope…
✔ sdlc-wizard-cowork is already at the latest version (1.97.0).

$ claude plugin update sdlc-wizard-cowork
Checking for updates for plugin "sdlc-wizard-cowork" at user scope…
✘ Failed to update plugin "sdlc-wizard-cowork": Plugin "sdlc-wizard-cowork" not found
```

The marketplace-qualified form resolves; the bare name fails. **Neither was observed to move a version** — this install is already current — so `CLAUDE.md` states that limit rather than promising movement. That narrowing is #573's second amendment applied to this PR.

## Findings fixed before review even landed

The contradiction class that shipped as a P1 on the last PR — two places in one change disagreeing with each other — was swept for deliberately. Four places still said a P2 could block a merge:

- `SKILL.md` recheck prompt, wizard round-1 prompt, the ASCII convergence diagram, and the gate-restart paragraph.

All four now say `blocks = (P0 or P1) AND in scope`, with the bridging clause: *a finding showing a requested behavior is wrong **is** P1, whatever label it arrived with.* That is what lets P2 stop blocking without letting real defects through.

## Premise corrections, disclosed rather than worked around

- **#558 said the severity scale was "defined in none."** Not quite: `SKILL.md` had no definition, but the wizard already had a table at :4232 — with `P2 = fix before merge`, which the new rule reverses. So the wizard work is a **revision**, not an addition.
- **#574 lands in `SKILL.md` only.** The wizard never documented the clearance payload, so there was nothing to cut there. Stated as a finding of fact rather than padded with an edit.

## Known unknowns — recorded, not chased

1. Whether `claude plugin update <name>@<marketplace>` actually *moves* a version. Needs a genuinely stale install; declined mid-trial to avoid confounding the v1.97.0 baseline.
2. No exhaustive per-suite classification of all 88 test suites for #556. The decision names representative examples and is not in the acceptance criteria as an audit.

## Deliberately not done

- **Zero new tests, zero new guards.**
- **No static guard for #573** — ruled dead-check class on the issue. It would pass on pasted, fabricated or stale output and cannot tell an instruction from an illustration.
- **No pre-existing prose restyled.** Only lines this PR adds.
- **No `package.json` bump.** v1.98.0 is the milestone name; the tag comes later.
- **Driver-side Confidence Check (HIGH/MEDIUM/LOW) and the E2E rubric's `confidence` criterion left alone** — different mechanism, and the evaluator greps them.

## Verification

All doc-facing suites green on this tree:

| Suite | Result |
|---|---|
| `test-doc-consistency.sh` | 137 passed, 0 failed |
| `test-cowork-drift.sh` | 30 passed, 0 failed |
| `test-docs-usability.sh` | 29 passed, 0 failed |
| `test-skill-graduations.sh` | 5 passed, 0 failed |
| `test-update-skill-step-7-7` / `7-8` / `cli-version` | 8 / 8 / 8 passed |
| `test-compliance`, `test-plugin`, `test-audit-session-load` | pass |
| `test-memory-audit-protocol`, `test-prove-it`, `test-hooks` | pass |
| `test-self-update`, `test-cli`, `test-model-config-batch` | pass |
| `test-autocompact-methodology`, `test-postmortem-lessons` | pass |

No RED/GREEN cycle: this PR adds no assertions. Per the scoped-TDD rule (#561), TDD RED applies only where a RED mutation is writable, and prose whose correctness is a judgement call is category 3 — cross-model review is the guard. That is the same rule #556 just closed on.
